### PR TITLE
Port missing stuff from @fresha/noname-core

### DIFF
--- a/packages/api-tools-core/README.md
+++ b/packages/api-tools-core/README.md
@@ -63,6 +63,16 @@ Below is a list of types. For their descriptions, please consult `src/types.ts`.
 
 Below is a list of guard names. For more information, please read `src/typeGuards.ts`.
 
+- `isJSONObject`
+- `isJSONValueArray`
 - `isJSONRef`
 - `isJSONAPIDataDocument`
 - `isJSONAPIErrorDocument`
+
+## Miscellaneous functions
+
+- `transformKeysDeep`
+- `camelCase`
+- `camelCaseDeep`
+- `kebabCase`
+- `kebabCaseDeep`

--- a/packages/api-tools-core/package.json
+++ b/packages/api-tools-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/api-tools-core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Core project functionality",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/api-tools-core/src/index.ts
+++ b/packages/api-tools-core/src/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './typeGuards';
 export { ITreeParent, TreeNode } from './TreeNode';
+export * from './utils';

--- a/packages/api-tools-core/src/typeGuards.test.ts
+++ b/packages/api-tools-core/src/typeGuards.test.ts
@@ -1,6 +1,25 @@
-import { isJSONAPIDataDocument, isJSONAPIErrorDocument, isJSONRef } from './typeGuards';
+import {
+  isJSONAPIDataDocument,
+  isJSONAPIErrorDocument,
+  isJSONObject,
+  isJSONRef,
+  isJSONValueArray,
+} from './typeGuards';
 
 import type { JSONAPIDocument } from './types';
+
+test('isJSONObject', () => {
+  expect(isJSONObject({})).toBeTruthy();
+  expect(isJSONObject(null)).toBeFalsy();
+  expect(isJSONObject([])).toBeFalsy();
+});
+
+test('isJSONValueArray', () => {
+  expect(isJSONValueArray({})).toBeFalsy();
+  expect(isJSONValueArray(null)).toBeFalsy();
+  expect(isJSONValueArray([])).toBeTruthy();
+  expect(isJSONValueArray([1, 's', {}])).toBeTruthy();
+});
 
 test('isJSONRef', () => {
   expect(isJSONRef({})).toBeFalsy();

--- a/packages/api-tools-core/src/typeGuards.ts
+++ b/packages/api-tools-core/src/typeGuards.ts
@@ -4,16 +4,20 @@ import type {
   JSONAPIErrorDocument,
   JSONObject,
   JSONRef,
+  JSONValue,
 } from './types';
 
-export const isJSONRef = (arg: unknown): arg is JSONRef => {
-  return arg != null && typeof arg === 'object' && typeof (arg as JSONObject).$ref === 'string';
-};
+export const isJSONObject = (value: JSONValue): value is JSONObject =>
+  !Array.isArray(value) && value !== null && typeof value === 'object';
 
-export const isJSONAPIDataDocument = (doc: JSONAPIDocument): doc is JSONAPIDataDocument => {
-  return 'data' in doc;
-};
+export const isJSONValueArray = (value: JSONValue | JSONValue[] | null): value is JSONValue[] =>
+  value !== null && Array.isArray(value);
 
-export const isJSONAPIErrorDocument = (doc: JSONAPIDocument): doc is JSONAPIErrorDocument => {
-  return 'errors' in doc;
-};
+export const isJSONRef = (arg: unknown): arg is JSONRef =>
+  arg != null && typeof arg === 'object' && typeof (arg as JSONObject).$ref === 'string';
+
+export const isJSONAPIDataDocument = (doc: JSONAPIDocument): doc is JSONAPIDataDocument =>
+  'data' in doc;
+
+export const isJSONAPIErrorDocument = (doc: JSONAPIDocument): doc is JSONAPIErrorDocument =>
+  'errors' in doc;

--- a/packages/api-tools-core/src/utils.test.ts
+++ b/packages/api-tools-core/src/utils.test.ts
@@ -1,0 +1,61 @@
+import { kebabCase, kebabCaseDeep, camelCase } from './utils';
+
+describe('kebabCase', () => {
+  it('should convert strings to kebab case', () => {
+    expect(kebabCase('')).toBe('');
+    expect(kebabCase('testIdent')).toBe('test-ident');
+    expect(kebabCase('TestIdent')).toBe('test-ident');
+    expect(kebabCase('testIdent123')).toBe('test-ident123');
+    expect(kebabCase('test123Ident')).toBe('test123-ident');
+    expect(kebabCase('test_123_indent')).toBe('test-123-indent');
+    expect(kebabCase('_123_indent__yes__')).toBe('123-indent-yes');
+    expect(kebabCase('-almost--kebab-case--')).toBe('almost-kebab-case');
+  });
+});
+
+describe('camelCase', () => {
+  it('should convert strings to camel case', () => {
+    expect(camelCase('test-ident')).toBe('testIdent');
+    expect(camelCase('test-123-ident')).toBe('test123Ident');
+    expect(camelCase('test_123__iDent')).toBe('test123IDent');
+    expect(camelCase('-almostCamel_case')).toBe('almostCamelCase');
+  });
+});
+
+describe('kebabCaseDeep', () => {
+  it('should handle complex objects properly', () => {
+    expect(
+      kebabCaseDeep({
+        keyOne: [
+          {
+            subKeyOne: '1',
+            subKeyTwo: [2, 4],
+          },
+        ],
+        keyTwo: {
+          subKeyThree: [
+            {
+              subSubKeyOne: null,
+            },
+          ],
+          subKeyFour: ['valOne', 'valueTwo'],
+        },
+      }),
+    ).toEqual({
+      'key-one': [
+        {
+          'sub-key-one': '1',
+          'sub-key-two': [2, 4],
+        },
+      ],
+      'key-two': {
+        'sub-key-three': [
+          {
+            'sub-sub-key-one': null,
+          },
+        ],
+        'sub-key-four': ['valOne', 'valueTwo'],
+      },
+    });
+  });
+});

--- a/packages/api-tools-core/src/utils.ts
+++ b/packages/api-tools-core/src/utils.ts
@@ -1,0 +1,40 @@
+import type { JSONValue, JSONObject } from './types';
+
+export type KeyTransformFunc = (key: string) => string;
+export type TransformFunc = (obj: JSONValue) => JSONValue;
+
+export const identity: TransformFunc = obj => obj;
+
+export const transformKeysDeep = (obj: JSONValue, keyFn: KeyTransformFunc): JSONValue => {
+  if (Array.isArray(obj)) {
+    return obj.map(o => transformKeysDeep(o, keyFn));
+  }
+  if (obj instanceof Object) {
+    return Object.entries(obj).reduce((accum: JSONObject, [key, value]) => {
+      const newKey = keyFn(key);
+      return { ...accum, [newKey]: transformKeysDeep(value, keyFn) };
+    }, {});
+  }
+  return obj;
+};
+
+const RE_WORD_START = /[A-Z][^A-Z]/g;
+
+export const kebabCase: KeyTransformFunc = str => {
+  const parts = str.replace(RE_WORD_START, r => `-${r.toLowerCase()}`).match(/[a-z0-9]+/g);
+  return parts != null ? parts.filter(elem => elem.length).join('-') : str;
+};
+
+export const kebabCaseDeep: TransformFunc = obj => transformKeysDeep(obj, kebabCase);
+
+const RE_WORD_SEPARATOR = /[-_]/g;
+
+export const camelCase: KeyTransformFunc = str => {
+  return str
+    .split(RE_WORD_SEPARATOR)
+    .filter(Boolean)
+    .map((s, index) => (index > 0 ? s.slice(0, 1).toUpperCase() + s.slice(1) : s))
+    .join('');
+};
+
+export const camelCaseDeep: TransformFunc = obj => transformKeysDeep(obj, camelCase);


### PR DESCRIPTION
## Motivation and Context

This PR ports missing types, guards and functions from `@fresha/noname-core`, which is a preparation step for moving other noname packages.

## Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

- added type guards `isJSONObject`, `isJSONValueArray`
- added string modification functions `camelCase`, `kebabCase`
- added JSON modification functions `kebabCaseDeep`, `camelCaseDeep`, `transformKeysDeep`
