### PR TITLE
Extend models with strict getter methods

### DIFF
--- a/packages/openapi-model/src/3.0.3/model/BasicNode.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/BasicNode.test.ts
@@ -8,6 +8,19 @@ beforeEach(() => {
   openapi = new OpenAPI('BasicNode.test', '0.0.1');
 });
 
+test('getExtension + getExtensionOrThrow', () => {
+  class Item extends BasicNode<OpenAPI> {}
+
+  const item = new Item(openapi);
+  item.setExtension('a', 1);
+  item.setExtension('b', 'log');
+
+  expect(item.getExtension('a')).not.toBeUndefined();
+  expect(item.getExtension('')).toBeUndefined();
+  expect(item.getExtensionOrThrow('b')).not.toBeUndefined();
+  expect(() => item.getExtensionOrThrow('')).toThrow();
+});
+
 describe('parent-child relationships', () => {
   class Branch extends BasicNode<BranchParent> {}
   class Leaf extends BasicNode<Branch> {}

--- a/packages/openapi-model/src/3.0.3/model/BasicNode.ts
+++ b/packages/openapi-model/src/3.0.3/model/BasicNode.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import type {
   ExtensionFields,
   OpenAPIModel,
@@ -25,6 +27,16 @@ export class BasicNode<TParent extends TreeParent>
 
   // eslint-disable-next-line class-methods-use-this
   dispose(): void {}
+
+  getExtension(key: string): JSONValue | undefined {
+    return this.extensions.get(key);
+  }
+
+  getExtensionOrThrow(key: string): JSONValue {
+    const result = this.getExtension(key);
+    assert(result !== undefined);
+    return result;
+  }
 
   setExtension(key: string, value: JSONValue): void {
     this.extensions.set(key, value);

--- a/packages/openapi-model/src/3.0.3/model/Callback.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Callback.test.ts
@@ -1,0 +1,34 @@
+import { OpenAPIFactory } from './OpenAPI';
+
+let callback = OpenAPIFactory.create().components.setCallback('onData');
+
+beforeEach(() => {
+  callback = OpenAPIFactory.create().components.setCallback('onData');
+});
+
+test('getPathItem + getPathItemOrThrow', () => {
+  callback.setPathItem('people');
+  callback.setPathItem('pets');
+
+  expect(callback.getPathItem('people')).not.toBeUndefined();
+  expect(callback.getPathItem('wizards')).toBeUndefined();
+  expect(callback.getPathItemOrThrow('pets')).not.toBeUndefined();
+  expect(() => callback.getPathItemOrThrow('monsters')).toThrow();
+});
+
+test('mutation methods', () => {
+  expect(callback.paths.size).toBe(0);
+
+  callback.setPathItem('warlock');
+  callback.setPathItem('amazons');
+
+  expect(Array.from(callback.paths.keys())).toStrictEqual(['warlock', 'amazons']);
+
+  callback.deletePathItem('warlock');
+
+  expect(Array.from(callback.paths.keys())).toStrictEqual(['amazons']);
+
+  callback.clearPathItems();
+
+  expect(callback.paths.size).toBe(0);
+});

--- a/packages/openapi-model/src/3.0.3/model/Callback.ts
+++ b/packages/openapi-model/src/3.0.3/model/Callback.ts
@@ -2,15 +2,41 @@ import { BasicNode } from './BasicNode';
 
 import type { CallbackModel, CallbackModelParent, PathItemModel } from './types';
 import type { ParametrisedURLString } from '@fresha/api-tools-core';
+import assert from 'assert';
+import { PathItem } from './PathItem';
 
 /**
  * @see http://spec.openapis.org/oas/v3.0.3#callback-object
  */
 export class Callback extends BasicNode<CallbackModelParent> implements CallbackModel {
-  readonly paths: Map<ParametrisedURLString, PathItemModel>;
+  readonly paths: Map<string, PathItemModel>;
 
   constructor(parent: CallbackModelParent) {
     super(parent);
     this.paths = new Map<ParametrisedURLString, PathItemModel>();
+  }
+
+  getPathItem(key: ParametrisedURLString): PathItemModel | undefined {
+    return this.paths.get(key);
+  }
+
+  getPathItemOrThrow(key: string): PathItemModel {
+    const result = this.getPathItem(key);
+    assert(result);
+    return result;
+  }
+
+  setPathItem(key: string): PathItemModel {
+    const result = new PathItem(this);
+    this.paths.set(key, result);
+    return result;
+  }
+
+  deletePathItem(key: string): void {
+    this.paths.delete(key);
+  }
+
+  clearPathItems(): void {
+    this.paths.clear();
   }
 }

--- a/packages/openapi-model/src/3.0.3/model/Callback.ts
+++ b/packages/openapi-model/src/3.0.3/model/Callback.ts
@@ -1,9 +1,10 @@
+import assert from 'assert';
+
 import { BasicNode } from './BasicNode';
+import { PathItem } from './PathItem';
 
 import type { CallbackModel, CallbackModelParent, PathItemModel } from './types';
 import type { ParametrisedURLString } from '@fresha/api-tools-core';
-import assert from 'assert';
-import { PathItem } from './PathItem';
 
 /**
  * @see http://spec.openapis.org/oas/v3.0.3#callback-object

--- a/packages/openapi-model/src/3.0.3/model/Components.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Components.test.ts
@@ -22,6 +22,13 @@ describe('schemas', () => {
     components.setSchema('Empty');
   });
 
+  test('getSchema + getSchemaOrThrow', () => {
+    expect(components.getSchema('Integer')).not.toBeUndefined();
+    expect(components.getSchema('_')).toBeUndefined();
+    expect(components.getSchemaOrThrow('Empty')).not.toBeUndefined();
+    expect(() => components.getSchemaOrThrow('non-existent')).toThrow();
+  });
+
   test('setSchemaModel logic', () => {
     const parent = components.setSchema('Parent', 'object');
     const child = parent.setProperty('child', 'integer');
@@ -61,6 +68,13 @@ describe('responses', () => {
   beforeEach(() => {
     components.setResponse('Success', 'Success response');
     components.setResponse('Error500', 'Error 5xx');
+  });
+
+  test('getResponse + getResponseOrThrow', () => {
+    expect(components.getResponse('Success')).not.toBeUndefined();
+    expect(components.getResponse('i-dont-exist')).toBeUndefined();
+    expect(components.getResponseOrThrow('Error500')).not.toBeUndefined();
+    expect(() => components.getResponseOrThrow('nothing-here')).toThrow();
   });
 
   test('setResponseModel logic', () => {
@@ -112,7 +126,14 @@ describe('parameters', () => {
     components.setParameter('SessionID', 'cookie', 'session');
   });
 
-  test('setResponseModel logic', () => {
+  test('getParameter + getParameterOrThrow', () => {
+    expect(components.getParameter('ID')).not.toBeUndefined();
+    expect(components.getParameter('>')).toBeUndefined();
+    expect(components.getParameterOrThrow('Offset')).not.toBeUndefined();
+    expect(() => components.getParameterOrThrow('<')).toThrow();
+  });
+
+  test('setParameterModel logic', () => {
     const sharedParam = components.setParameter('Parent', 'path', 'id');
 
     const operationParam = openapi.setPathItem('/').setOperation('get').addParameter('ns', 'path');
@@ -178,6 +199,13 @@ describe('examples', () => {
     components.setExample('Error');
   });
 
+  test('getExample + getExampleOrThrow', () => {
+    expect(components.getExample('Success')).not.toBeUndefined();
+    expect(components.getExample('?')).toBeUndefined();
+    expect(components.getExampleOrThrow('Error')).not.toBeUndefined();
+    expect(() => components.getExampleOrThrow('?')).toThrow();
+  });
+
   test('setExampleModel logic', () => {
     const sharedExample = components.setExample('Parent');
 
@@ -217,6 +245,13 @@ describe('requestBodies', () => {
   beforeEach(() => {
     components.setRequestBody('Empty');
     components.setRequestBody('List');
+  });
+
+  test('getRequestBody + getRequestBodyOrThrow', () => {
+    expect(components.getRequestBody('List')).not.toBeUndefined();
+    expect(components.getRequestBody('_')).toBeUndefined();
+    expect(components.getRequestBodyOrThrow('Empty')).not.toBeUndefined();
+    expect(() => components.getRequestBodyOrThrow('?')).toThrow();
   });
 
   test('setRequestBodyModel logic', () => {
@@ -259,6 +294,13 @@ describe('headers', () => {
   beforeEach(() => {
     components.setHeader('X-Language');
     components.setHeader('X-Fresha');
+  });
+
+  test('getHeader + getHeaderOrThrow', () => {
+    expect(components.getHeader('X-Fresha')).not.toBeUndefined();
+    expect(components.getHeader('_')).toBeUndefined();
+    expect(components.getHeaderOrThrow('X-Language')).not.toBeUndefined();
+    expect(() => components.getHeaderOrThrow('?')).toThrow();
   });
 
   test('setHeaderModel logic', () => {
@@ -306,6 +348,13 @@ describe('securitySchemes', () => {
     components.setSecuritySchema('google', 'oauth2');
   });
 
+  test('getSecuritySchema + getSecuritySchemaOrThrow', () => {
+    expect(components.getSecuritySchema('local')).not.toBeUndefined();
+    expect(components.getSecuritySchema('_')).toBeUndefined();
+    expect(components.getSecuritySchemaOrThrow('google')).not.toBeUndefined();
+    expect(() => components.getSecuritySchemaOrThrow('?')).toThrow();
+  });
+
   test('setSecuritySchema', () => {
     components.setSecuritySchema('httpToken', 'http');
     components.setSecuritySchema('oid', 'openIdConnect');
@@ -348,6 +397,13 @@ describe('links', () => {
   beforeEach(() => {
     components.setLink('Language');
     components.setLink('Fresha');
+  });
+
+  test('getLink + getLinkOrThrow', () => {
+    expect(components.getLink('Language')).not.toBeUndefined();
+    expect(components.getLink('_')).toBeUndefined();
+    expect(components.getLinkOrThrow('Fresha')).not.toBeUndefined();
+    expect(() => components.getLinkOrThrow('?')).toThrow();
   });
 
   test('setLinkModel logic', () => {
@@ -393,6 +449,13 @@ describe('callbacks', () => {
   beforeEach(() => {
     components.setCallback('Language');
     components.setCallback('Fresha');
+  });
+
+  test('getCallback + getCallbackOrThrow', () => {
+    expect(components.getCallback('Language')).not.toBeUndefined();
+    expect(components.getCallback('_')).toBeUndefined();
+    expect(components.getCallbackOrThrow('Fresha')).not.toBeUndefined();
+    expect(() => components.getCallbackOrThrow('?')).toThrow();
   });
 
   test('setCallbackModel logic', () => {

--- a/packages/openapi-model/src/3.0.3/model/Components.ts
+++ b/packages/openapi-model/src/3.0.3/model/Components.ts
@@ -73,6 +73,16 @@ export class Components extends BasicNode<ComponentsModelParent> implements Comp
     );
   }
 
+  getSchema(name: string): SchemaModel | undefined {
+    return this.schemas.get(name);
+  }
+
+  getSchemaOrThrow(name: string): SchemaModel {
+    const result = this.getSchema(name);
+    assert(result);
+    return result;
+  }
+
   setSchemaModel(name: string, model: SchemaModel): void {
     assert(!this.schemas.has(name));
     assert.equal(model.parent, this);
@@ -95,6 +105,16 @@ export class Components extends BasicNode<ComponentsModelParent> implements Comp
     this.schemas.clear();
   }
 
+  getResponse(name: string): ResponseModel | undefined {
+    return this.responses.get(name);
+  }
+
+  getResponseOrThrow(name: string): ResponseModel {
+    const result = this.getResponse(name);
+    assert(result);
+    return result;
+  }
+
   setResponseModel(name: string, model: ResponseModel): void {
     assert(!this.responses.has(name));
     assert.equal(model.parent, this);
@@ -114,6 +134,16 @@ export class Components extends BasicNode<ComponentsModelParent> implements Comp
 
   clearResponses(): void {
     this.responses.clear();
+  }
+
+  getParameter(name: string): ParameterModel | undefined {
+    return this.parameters.get(name);
+  }
+
+  getParameterOrThrow(name: string): ParameterModel {
+    const result = this.getParameter(name);
+    assert(result);
+    return result;
   }
 
   setParameterModel(name: string, model: ParameterModel): void {
@@ -153,6 +183,16 @@ export class Components extends BasicNode<ComponentsModelParent> implements Comp
     this.parameters.clear();
   }
 
+  getExample(name: string): ExampleModel | undefined {
+    return this.examples.get(name);
+  }
+
+  getExampleOrThrow(name: string): ExampleModel {
+    const result = this.getExample(name);
+    assert(result);
+    return result;
+  }
+
   setExampleModel(name: string, model: ExampleModel): void {
     assert(!this.examples.has(name));
     assert.equal(model.parent, this);
@@ -172,6 +212,16 @@ export class Components extends BasicNode<ComponentsModelParent> implements Comp
 
   clearExamples(): void {
     this.examples.clear();
+  }
+
+  getRequestBody(name: string): RequestBodyModel | undefined {
+    return this.requestBodies.get(name);
+  }
+
+  getRequestBodyOrThrow(name: string): RequestBodyModel {
+    const result = this.getRequestBody(name);
+    assert(result);
+    return result;
   }
 
   setRequestBodyModel(name: string, model: RequestBodyModel): void {
@@ -195,6 +245,16 @@ export class Components extends BasicNode<ComponentsModelParent> implements Comp
     this.requestBodies.clear();
   }
 
+  getHeader(name: string): HeaderModel | undefined {
+    return this.headers.get(name);
+  }
+
+  getHeaderOrThrow(name: string): HeaderModel {
+    const result = this.getHeader(name);
+    assert(result);
+    return result;
+  }
+
   setHeaderModel(name: string, model: HeaderModel): void {
     assert(!this.headers.has(name));
     assert.equal(model.parent, this);
@@ -214,6 +274,16 @@ export class Components extends BasicNode<ComponentsModelParent> implements Comp
 
   clearHeaders(): void {
     this.headers.clear();
+  }
+
+  getSecuritySchema(name: string): SecuritySchemaModel | undefined {
+    return this.securitySchemes.get(name);
+  }
+
+  getSecuritySchemaOrThrow(name: string): SecuritySchemaModel {
+    const result = this.getSecuritySchema(name);
+    assert(result);
+    return result;
   }
 
   setSecuritySchemaModel(name: string, model: SecuritySchemaModel): void {
@@ -253,6 +323,16 @@ export class Components extends BasicNode<ComponentsModelParent> implements Comp
     this.securitySchemes.clear();
   }
 
+  getLink(name: string): LinkModel | undefined {
+    return this.links.get(name);
+  }
+
+  getLinkOrThrow(name: string): LinkModel {
+    const result = this.getLink(name);
+    assert(result);
+    return result;
+  }
+
   setLinkModel(name: string, model: LinkModel): void {
     assert(!this.links.has(name));
     assert.equal(model.parent, this);
@@ -272,6 +352,16 @@ export class Components extends BasicNode<ComponentsModelParent> implements Comp
 
   clearLinks(): void {
     this.links.clear();
+  }
+
+  getCallback(name: string): CallbackModel | undefined {
+    return this.callbacks.get(name);
+  }
+
+  getCallbackOrThrow(name: string): CallbackModel {
+    const result = this.getCallback(name);
+    assert(result);
+    return result;
   }
 
   setCallbackModel(name: string, model: CallbackModel): void {

--- a/packages/openapi-model/src/3.0.3/model/Encoding.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Encoding.test.ts
@@ -2,7 +2,7 @@ import { OpenAPIFactory } from './OpenAPI';
 
 import type { EncodingModel } from './types';
 
-let encoding: EncodingModel | null = null;
+let encoding: EncodingModel = {} as EncodingModel;
 
 beforeEach(() => {
   const openapi = OpenAPIFactory.create();
@@ -13,36 +13,46 @@ beforeEach(() => {
 
 test('default properties', () => {
   expect(encoding).toHaveProperty('contentType', 'application/json');
-  expect(encoding?.headers).toHaveProperty('size', 0);
+  expect(encoding.headers).toHaveProperty('size', 0);
   expect(encoding).toHaveProperty('style', 'form');
   expect(encoding).toHaveProperty('explode', false);
   expect(encoding).toHaveProperty('allowReserved', false);
 });
 
 describe('header collection', () => {
+  test('getHeader + getHeaderOrThrow', () => {
+    encoding.setHeader('Accept');
+    encoding.setHeader('Content-Length');
+
+    expect(encoding.getHeader('Accept')).not.toBeUndefined();
+    expect(encoding.getHeader('-')).toBeUndefined();
+    expect(encoding.getHeaderOrThrow('Content-Length')).not.toBeUndefined();
+    expect(() => encoding.getHeaderOrThrow('?')).toThrow();
+  });
+
   test('setHeader', () => {
-    encoding?.setHeader('Accept');
-    expect(encoding?.headers.get('Accept')).not.toBeNull();
+    encoding.setHeader('Accept');
+    expect(encoding.headers.get('Accept')).not.toBeNull();
   });
 
   test('deleteHeader', () => {
-    encoding?.setHeader('Accept');
-    encoding?.setHeader('Content-Length');
+    encoding.setHeader('Accept');
+    encoding.setHeader('Content-Length');
 
-    expect(encoding?.headers.size).toBe(2);
+    expect(encoding.headers.size).toBe(2);
 
-    encoding?.deleteHeader('Accept');
+    encoding.deleteHeader('Accept');
 
-    expect(encoding?.headers.size).toBe(1);
-    expect(encoding?.headers.get('Accept')).toBeFalsy();
+    expect(encoding.headers.size).toBe(1);
+    expect(encoding.headers.get('Accept')).toBeFalsy();
   });
 
   test('clearHeaders', () => {
-    encoding?.setHeader('Accept');
-    encoding?.setHeader('Content-Length');
+    encoding.setHeader('Accept');
+    encoding.setHeader('Content-Length');
 
-    encoding?.clearHeaders();
+    encoding.clearHeaders();
 
-    expect(encoding?.headers.size).toBe(0);
+    expect(encoding.headers.size).toBe(0);
   });
 });

--- a/packages/openapi-model/src/3.0.3/model/Encoding.ts
+++ b/packages/openapi-model/src/3.0.3/model/Encoding.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import { BasicNode } from './BasicNode';
 import { Header } from './Header';
 
@@ -26,6 +28,16 @@ export class Encoding extends BasicNode<EncodingModelParent> implements Encoding
     this.style = 'form';
     this.explode = false;
     this.allowReserved = false;
+  }
+
+  getHeader(name: string): HeaderModel | undefined {
+    return this.headers.get(name);
+  }
+
+  getHeaderOrThrow(name: string): HeaderModel {
+    const result = this.getHeader(name);
+    assert(result);
+    return result;
   }
 
   setHeader(name: string): HeaderModel {

--- a/packages/openapi-model/src/3.0.3/model/Header.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Header.test.ts
@@ -1,0 +1,83 @@
+import { OpenAPIFactory } from './OpenAPI';
+
+let header = OpenAPIFactory.create().components.setHeader('X-Test');
+
+beforeEach(() => {
+  header = OpenAPIFactory.create().components.setHeader('X-Test');
+});
+
+describe('example collection', () => {
+  test('getExample + getExampleOrThrow', () => {
+    header.setExample('1');
+    header.setExample('2');
+
+    expect(header.getExample('1')).not.toBeUndefined();
+    expect(header.getExample('-')).toBeUndefined();
+    expect(header.getExampleOrThrow('2')).not.toBeUndefined();
+    expect(() => header.getExampleOrThrow('-')).toThrow();
+  });
+
+  test('setExample', () => {
+    const example = header.setExample('1');
+
+    expect(header.examples.size).toBe(1);
+    expect(header.getExample('1')).toBe(example);
+  });
+
+  test('deleteExample', () => {
+    header.setExample('1');
+    header.setExample('2');
+
+    header.deleteExample('2');
+
+    expect(Array.from(header.examples.keys())).toStrictEqual(['1']);
+  });
+
+  test('clearExamples', () => {
+    header.setExample('1');
+    header.setExample('2');
+    header.setExample('3');
+
+    header.clearExamples();
+
+    expect(header.examples.size).toBe(0);
+  });
+});
+
+describe('content collection', () => {
+  test('getContent + getContentOrThrow', () => {
+    header.setContent('application/json');
+    header.setContent('application/xml');
+
+    expect(header.getContent('application/json')).not.toBeUndefined();
+    expect(header.getContent('-')).toBeUndefined();
+    expect(header.getContentOrThrow('application/xml')).not.toBeUndefined();
+    expect(() => header.getContentOrThrow('-')).toThrow();
+  });
+
+  test('setContent', () => {
+    const mediaType = header.setContent('application/json');
+
+    expect(header.content.size).toBe(1);
+    expect(header.getContent('1')).toBe(mediaType);
+  });
+
+  test('deleteContent', () => {
+    header.setContent('application/json');
+    header.setContent('application/xml');
+
+    header.deleteContent('application/xml');
+
+    expect(Array.from(header.content.keys())).toStrictEqual(['application/json']);
+  });
+
+  test('clearContent', () => {
+    header.setContent('application/json');
+    header.setContent('application/xml');
+    header.setContent('application/vnd.api+json');
+
+    header.clearContents();
+
+    expect(header.content.size).toBe(0);
+  });
+});

--- a/packages/openapi-model/src/3.0.3/model/Header.ts
+++ b/packages/openapi-model/src/3.0.3/model/Header.ts
@@ -1,4 +1,8 @@
+import assert from 'assert';
+
 import { BasicNode } from './BasicNode';
+import { Example } from './Example';
+import { MediaType } from './MediaType';
 
 import type {
   ExampleModel,
@@ -35,5 +39,52 @@ export class Header extends BasicNode<HeaderModelParent> implements HeaderModel 
     this.example = null;
     this.examples = new Map<string, ExampleModel>();
     this.content = new Map<MIMETypeString, MediaTypeModel>();
+  }
+
+  getExample(name: string): ExampleModel | undefined {
+    return this.examples.get(name);
+  }
+
+  getExampleOrThrow(name: string): ExampleModel {
+    const result = this.getExample(name);
+    assert(result);
+    return result;
+  }
+
+  setExample(name: string): ExampleModel {
+    const result = new Example(this);
+    this.examples.set(name, result);
+    return result;
+  }
+
+  deleteExample(name: string): void {
+    this.examples.delete(name);
+  }
+
+  clearExamples(): void {
+    this.examples.clear();
+  }
+
+  getContent(mimeType: MIMETypeString): MediaTypeModel | undefined {
+    return this.content.get(mimeType);
+  }
+
+  getContentOrThrow(mimeType: MIMETypeString): MediaTypeModel {
+    const result = this.getContent(mimeType);
+    assert(result);
+    return result;
+  }
+
+  setContent(mimeType: MIMETypeString): void {
+    const result = new MediaType(this);
+    this.content.set(mimeType, result);
+  }
+
+  deleteContent(mimeType: MIMETypeString): void {
+    this.content.delete(mimeType);
+  }
+
+  clearContents(): void {
+    this.content.clear();
   }
 }

--- a/packages/openapi-model/src/3.0.3/model/Link.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Link.test.ts
@@ -1,0 +1,28 @@
+import { OpenAPIFactory } from './OpenAPI';
+
+let link = OpenAPIFactory.create().components.setLink('test');
+
+beforeEach(() => {
+  link = OpenAPIFactory.create().components.setLink('test');
+});
+
+test('parameters collection', () => {
+  expect(link.parameters.size).toBe(0);
+
+  link.setParameter('x', null);
+  link.setParameter('y', 'monday');
+
+  expect(link.parameters.size).toBe(2);
+  expect(link.getParameter('x')).toBe(null);
+  expect(link.getParameter('z')).toBeUndefined();
+  expect(link.getParameterOrThrow('y')).toBe('monday');
+  expect(() => link.getParameterOrThrow('t')).toThrow();
+
+  link.deleteParameter('x');
+
+  expect(Array.from(link.parameters.keys())).toStrictEqual(['y']);
+
+  link.clearParameters();
+
+  expect(link.parameters.size).toBe(0);
+});

--- a/packages/openapi-model/src/3.0.3/model/Link.ts
+++ b/packages/openapi-model/src/3.0.3/model/Link.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import { BasicNode } from './BasicNode';
 
 import type { Server } from './Server';
@@ -23,5 +25,27 @@ export class Link extends BasicNode<LinkModelParent> implements LinkModel {
     this.requestBody = null;
     this.description = null;
     this.server = null;
+  }
+
+  getParameter(key: string): JSONValue | undefined {
+    return this.parameters.get(key);
+  }
+
+  getParameterOrThrow(key: string): JSONValue {
+    const result = this.getParameter(key);
+    assert(result !== undefined);
+    return result;
+  }
+
+  setParameter(key: string, value: JSONValue): void {
+    this.parameters.set(key, value);
+  }
+
+  deleteParameter(key: string): void {
+    this.parameters.delete(key);
+  }
+
+  clearParameters(): void {
+    this.parameters.clear();
   }
 }

--- a/packages/openapi-model/src/3.0.3/model/MediaType.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/MediaType.test.ts
@@ -2,7 +2,7 @@ import { OpenAPIFactory } from './OpenAPI';
 
 import type { MediaTypeModel } from './types';
 
-let mediaType: MediaTypeModel | null = null;
+let mediaType: MediaTypeModel = {} as MediaTypeModel;
 
 beforeEach(() => {
   const openapi = OpenAPIFactory.create();
@@ -11,56 +11,66 @@ beforeEach(() => {
 });
 
 test('default properties', () => {
-  expect(mediaType?.schema).toBeNull();
-  expect(mediaType?.example).toBeNull();
-  expect(mediaType?.examples).toHaveProperty('size', 0);
-  expect(mediaType?.encoding).toHaveProperty('size', 0);
+  expect(mediaType.schema).toBeNull();
+  expect(mediaType.example).toBeNull();
+  expect(mediaType.examples).toHaveProperty('size', 0);
+  expect(mediaType.encoding).toHaveProperty('size', 0);
 });
 
 test('schema property', () => {
-  mediaType?.setSchema('date-time');
+  mediaType.setSchema('date-time');
 
-  expect(mediaType?.schema).toHaveProperty('type', 'string');
-  expect(mediaType?.schema).toHaveProperty('format', 'date-time');
+  expect(mediaType.schema).toHaveProperty('type', 'string');
+  expect(mediaType.schema).toHaveProperty('format', 'date-time');
 
-  mediaType?.deleteSchema();
+  mediaType.deleteSchema();
 
-  expect(mediaType?.schema).toBeNull();
+  expect(mediaType.schema).toBeNull();
 });
 
 test('examples collection', () => {
-  mediaType?.setExample('1');
-  mediaType?.setExample('2');
-  mediaType?.setExample('3');
+  mediaType.setExample('1');
+  mediaType.setExample('2');
+  mediaType.setExample('3');
 
-  expect(mediaType?.examples).toHaveProperty('size', 3);
+  expect(mediaType.examples).toHaveProperty('size', 3);
 
-  mediaType?.deleteExample('2');
+  expect(mediaType.getExample('1')).not.toBeUndefined();
+  expect(mediaType.getExample('_')).toBeUndefined();
+  expect(mediaType.getExampleOrThrow('2')).not.toBeUndefined();
+  expect(() => mediaType.getExampleOrThrow('?')).toThrow();
 
-  expect(Array.from(mediaType?.examples.keys() ?? [])).toStrictEqual(['1', '3']);
+  mediaType.deleteExample('2');
 
-  mediaType?.clearExamples();
+  expect(Array.from(mediaType.examples.keys() ?? [])).toStrictEqual(['1', '3']);
 
-  expect(mediaType?.examples).toHaveProperty('size', 0);
+  mediaType.clearExamples();
+
+  expect(mediaType.examples).toHaveProperty('size', 0);
 });
 
 test('either example or examples can be set', () => {
-  mediaType!.example = {};
-  expect(() => mediaType?.setExample('1')).toThrow();
+  mediaType.example = {};
+  expect(() => mediaType.setExample('1')).toThrow();
 });
 
 test('encoding collection', () => {
-  mediaType?.setEncoding('1');
-  mediaType?.setEncoding('2');
-  mediaType?.setEncoding('3');
+  mediaType.setEncoding('1');
+  mediaType.setEncoding('2');
+  mediaType.setEncoding('3');
 
-  expect(mediaType?.encoding).toHaveProperty('size', 3);
+  expect(mediaType.encoding).toHaveProperty('size', 3);
 
-  mediaType?.deleteEncoding('2');
+  expect(mediaType.getEncoding('1')).not.toBeUndefined();
+  expect(mediaType.getEncoding('_')).toBeUndefined();
+  expect(mediaType.getEncodingOrThrow('2')).not.toBeUndefined();
+  expect(() => mediaType.getEncodingOrThrow('?')).toThrow();
 
-  expect(Array.from(mediaType?.encoding.keys() ?? [])).toStrictEqual(['1', '3']);
+  mediaType.deleteEncoding('2');
 
-  mediaType?.clearEncodings();
+  expect(Array.from(mediaType.encoding.keys() ?? [])).toStrictEqual(['1', '3']);
 
-  expect(mediaType?.encoding).toHaveProperty('size', 0);
+  mediaType.clearEncodings();
+
+  expect(mediaType.encoding).toHaveProperty('size', 0);
 });

--- a/packages/openapi-model/src/3.0.3/model/MediaType.ts
+++ b/packages/openapi-model/src/3.0.3/model/MediaType.ts
@@ -43,6 +43,16 @@ export class MediaType extends BasicNode<MediaTypeModelParent> implements MediaT
     this.schema = null;
   }
 
+  getExample(key: string): ExampleModel | undefined {
+    return this.examples.get(key);
+  }
+
+  getExampleOrThrow(key: string): ExampleModel {
+    const result = this.getExample(key);
+    assert(result);
+    return result;
+  }
+
   setExample(key: string): ExampleModel {
     assert.equal(this.example, null);
     const result = new Example(this);
@@ -56,6 +66,16 @@ export class MediaType extends BasicNode<MediaTypeModelParent> implements MediaT
 
   clearExamples(): void {
     this.examples.clear();
+  }
+
+  getEncoding(key: string): EncodingModel | undefined {
+    return this.encoding.get(key);
+  }
+
+  getEncodingOrThrow(key: string): EncodingModel {
+    const result = this.getEncoding(key);
+    assert(result);
+    return result;
   }
 
   setEncoding(key: string): EncodingModel {

--- a/packages/openapi-model/src/3.0.3/model/OAuthFlow/OAuthFlowBase.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/OAuthFlow/OAuthFlowBase.test.ts
@@ -1,0 +1,43 @@
+import { OpenAPIFactory } from '../OpenAPI';
+
+import { OAuthFlowBase } from './OAuthFlowBase';
+
+import type { OAuth2SecuritySchemaModel } from '../types';
+
+class TestFlow extends OAuthFlowBase {}
+
+let flow = {} as OAuthFlowBase;
+
+beforeEach(() => {
+  flow = new TestFlow(
+    (
+      OpenAPIFactory.create().components.setSecuritySchema(
+        'test',
+        'oauth2',
+      ) as OAuth2SecuritySchemaModel
+    ).flows,
+    'authorizationCode',
+  );
+});
+
+test('scopes collection', () => {
+  expect(flow.scopes.size).toBe(0);
+
+  flow.setScope('x', '*');
+  flow.setScope('y', 'email');
+
+  expect(Array.from(flow.scopes.keys())).toStrictEqual(['x', 'y']);
+
+  expect(flow.getScope('y')).toBe('email');
+  expect(flow.getScope('z')).toBeUndefined();
+  expect(flow.getScopeOrThrow('x')).toBe('*');
+  expect(() => flow.getScopeOrThrow('t')).toThrow();
+
+  flow.deleteScope('y');
+
+  expect(flow.scopes.size).toBe(1);
+
+  flow.clearScopes();
+
+  expect(flow.scopes.size).toBe(0);
+});

--- a/packages/openapi-model/src/3.0.3/model/OAuthFlow/OAuthFlowBase.ts
+++ b/packages/openapi-model/src/3.0.3/model/OAuthFlow/OAuthFlowBase.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import { BasicNode } from '../BasicNode';
 
 import type { OAuthFlowModelParent, OAuthFlowType } from '../types';
@@ -16,5 +18,27 @@ export abstract class OAuthFlowBase extends BasicNode<OAuthFlowModelParent> {
     this.type = type;
     this.refreshUrl = null;
     this.scopes = new Map<string, string>();
+  }
+
+  getScope(key: string): string | undefined {
+    return this.scopes.get(key);
+  }
+
+  getScopeOrThrow(key: string): string {
+    const result = this.getScope(key);
+    assert(result !== undefined);
+    return result;
+  }
+
+  setScope(key: string, value: string): void {
+    this.scopes.set(key, value);
+  }
+
+  deleteScope(key: string): void {
+    this.scopes.delete(key);
+  }
+
+  clearScopes(): void {
+    this.scopes.clear();
   }
 }

--- a/packages/openapi-model/src/3.0.3/model/OpenAPI.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPI.test.ts
@@ -1,10 +1,53 @@
 import { OpenAPI } from './OpenAPI';
 
-test('ownership', () => {
-  const openapi = new OpenAPI('example', '0.1.0');
-  expect(openapi.root).toBe(openapi);
+let openapi: OpenAPI = {} as OpenAPI;
 
+beforeEach(() => {
+  openapi = new OpenAPI('example', '0.1.0');
+});
+
+test('ownership', () => {
+  expect(openapi.root).toBe(openapi);
   expect(openapi.info.parent).toBe(openapi);
   expect(openapi.info.contact.parent).toBe(openapi.info);
   expect(openapi.info.license.parent).toBe(openapi.info);
+});
+
+describe('server collection', () => {
+  test('getServer + getServerOrThrow', () => {
+    const server1 = openapi.addServer('https://api1.example.com');
+    const server2 = openapi.addServer('https://api2.example.com');
+
+    expect(openapi.getServer('https://api1.example.com')).toBe(server1);
+    expect(openapi.getServer('https://api3.example.com')).toBeUndefined();
+
+    expect(openapi.getServerOrThrow('https://api2.example.com')).toBe(server2);
+    expect(() => openapi.getServerOrThrow('https://api3.example.com')).toThrow();
+  });
+});
+
+describe('path items collection', () => {
+  test('getPathItem + getPathItemOrThrow', () => {
+    const pathItem1 = openapi.setPathItem('/item1');
+    const pathItem2 = openapi.setPathItem('/item2');
+
+    expect(openapi.getPathItem('/item1')).toBe(pathItem1);
+    expect(openapi.getPathItem('/')).toBeUndefined();
+
+    expect(openapi.getPathItemOrThrow('/item2')).toBe(pathItem2);
+    expect(() => openapi.getPathItemOrThrow('/item3')).toThrow();
+  });
+});
+
+describe('tags collection', () => {
+  test('getTag + getTagOrThrow', () => {
+    const tag1 = openapi.addTag('t1');
+    const tag2 = openapi.addTag('t2');
+
+    expect(openapi.getTag('t1')).toBe(tag1);
+    expect(openapi.getTag('t3')).toBeUndefined();
+
+    expect(openapi.getTagOrThrow('t2')).toBe(tag2);
+    expect(() => openapi.getTagOrThrow('t3')).toThrow();
+  });
 });

--- a/packages/openapi-model/src/3.0.3/model/OpenAPI.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPI.test.ts
@@ -13,6 +13,16 @@ test('ownership', () => {
   expect(openapi.info.license.parent).toBe(openapi.info);
 });
 
+test('getExtension + getExtensionOrThrow', () => {
+  openapi.setExtension('a', 1);
+  openapi.setExtension('b', 'log');
+
+  expect(openapi.getExtension('a')).not.toBeUndefined();
+  expect(openapi.getExtension('')).toBeUndefined();
+  expect(openapi.getExtensionOrThrow('b')).not.toBeUndefined();
+  expect(() => openapi.getExtensionOrThrow('')).toThrow();
+});
+
 describe('server collection', () => {
   test('getServer + getServerOrThrow', () => {
     const server1 = openapi.addServer('https://api1.example.com');

--- a/packages/openapi-model/src/3.0.3/model/OpenAPI.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPI.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import { Components } from './Components';
 import { ExternalDocumentation } from './ExternalDocumentation';
 import { Info } from './Info';
@@ -73,6 +75,16 @@ export class OpenAPI implements OpenAPIModel, SpecificationExtensionsModel {
     this.extensions.clear();
   }
 
+  getServer(url: ParametrisedURLString): ServerModel | undefined {
+    return this.servers.find(item => item.url === url);
+  }
+
+  getServerOrThrow(url: ParametrisedURLString): ServerModel {
+    const result = this.getServer(url);
+    assert(result);
+    return result;
+  }
+
   addServer(
     url: ParametrisedURLString,
     variableDefaults?: Record<string, string>,
@@ -96,6 +108,16 @@ export class OpenAPI implements OpenAPIModel, SpecificationExtensionsModel {
 
   clearServers(): void {
     this.servers.splice(0, this.servers.length);
+  }
+
+  getPathItem(url: ParametrisedURLString): PathItemModel | undefined {
+    return this.paths.get(url);
+  }
+
+  getPathItemOrThrow(url: ParametrisedURLString): PathItemModel {
+    const result = this.paths.get(url);
+    assert(result);
+    return result;
   }
 
   setPathItem(url: ParametrisedURLString): PathItemModel {
@@ -127,6 +149,16 @@ export class OpenAPI implements OpenAPIModel, SpecificationExtensionsModel {
 
   clearSecurityRequirements(): void {
     this.security.splice(1, this.security.length);
+  }
+
+  getTag(name: string): TagModel | undefined {
+    return this.tags.find(item => item.name === name);
+  }
+
+  getTagOrThrow(name: string): TagModel {
+    const result = this.getTag(name);
+    assert(result);
+    return result;
   }
 
   addTag(name: string): TagModel {

--- a/packages/openapi-model/src/3.0.3/model/OpenAPI.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPI.ts
@@ -63,6 +63,16 @@ export class OpenAPI implements OpenAPIModel, SpecificationExtensionsModel {
     return this;
   }
 
+  getExtension(key: string): JSONValue | undefined {
+    return this.extensions.get(key);
+  }
+
+  getExtensionOrThrow(key: string): JSONValue {
+    const result = this.getExtension(key);
+    assert(result !== undefined);
+    return result;
+  }
+
   setExtension(key: string, value: JSONValue): void {
     this.extensions.set(key, value);
   }

--- a/packages/openapi-model/src/3.0.3/model/Operation.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Operation.test.ts
@@ -60,6 +60,13 @@ test('parameters collection', () => {
 
   expect(operation.parameters).toStrictEqual([p1, p2, p3, p4]);
 
+  expect(operation.getParameter('p1', 'path')).not.toBeUndefined();
+  expect(operation.getParameter('p1', 'query')).toBeUndefined();
+  expect(operation.getParameter('p5', 'path')).toBeUndefined();
+  expect(operation.getParameterOrThrow('p3', 'header')).not.toBeUndefined();
+  expect(() => operation.getParameterOrThrow('p1', 'query')).toThrow();
+  expect(() => operation.getParameterOrThrow('p5', 'cookie')).toThrow();
+
   expect(() => operation.addParameter('p1', 'path')).toThrow();
   expect(() => operation.addParameter('p1', 'cookie')).toThrow();
 
@@ -85,6 +92,11 @@ test('delegated response methods', () => {
   expect(operation.responses.codes.get(200)).toBe(res200);
   expect(operation.responses.codes.get(404)).toBe(res404);
 
+  expect(operation.getResponse(200)).not.toBeUndefined();
+  expect(operation.getResponse(418)).toBeUndefined();
+  expect(operation.getResponseOrThrow(404)).not.toBeUndefined();
+  expect(() => operation.getResponseOrThrow(501)).toThrow();
+
   operation.deleteResponse(404);
   expect(operation.responses.codes.get(404)).toBeUndefined();
 
@@ -99,6 +111,11 @@ test('callbacks collection', () => {
   operation.setCallback('cb2');
 
   expect(operation.callbacks.size).toBe(2);
+
+  expect(operation.getCallback('cb1')).not.toBeUndefined();
+  expect(operation.getCallback('-')).toBeUndefined();
+  expect(operation.getCallbackOrThrow('cb2')).not.toBeUndefined();
+  expect(() => operation.getCallbackOrThrow('?')).toThrow();
 
   operation.deleteCallback('cb1');
 
@@ -137,6 +154,11 @@ test('servers collection', () => {
   expect(() => operation.addServer('http://second.example.com')).toThrow();
 
   expect(operation.servers.length).toBe(3);
+
+  expect(operation.getServer('http://first.example.com')).not.toBeUndefined();
+  expect(operation.getServer('-')).toBeUndefined();
+  expect(operation.getServerOrThrow('http://second.example.com')).not.toBeUndefined();
+  expect(() => operation.getServerOrThrow('?')).toThrow();
 
   operation.deleteServer('http://third.example.com');
   expect(operation.servers.length).toBe(2);

--- a/packages/openapi-model/src/3.0.3/model/Operation.ts
+++ b/packages/openapi-model/src/3.0.3/model/Operation.ts
@@ -20,7 +20,7 @@ import type {
   SecurityRequirementModel,
   ServerModel,
 } from './types';
-import type { CommonMarkString, Nullable } from '@fresha/api-tools-core';
+import type { CommonMarkString, Nullable, ParametrisedURLString } from '@fresha/api-tools-core';
 
 /**
  * @see http://spec.openapis.org/oas/v3.0.3#operation-object
@@ -76,6 +76,16 @@ export class Operation extends BasicNode<OperationModelParent> implements Operat
     this.tags.splice(0, this.tags.length);
   }
 
+  getParameter(name: string, source: ParameterLocation): ParameterModel | undefined {
+    return this.parameters.find(param => param.name === name && param.in === source);
+  }
+
+  getParameterOrThrow(name: string, source: ParameterLocation): ParameterModel {
+    const result = this.getParameter(name, source);
+    assert(result);
+    return result;
+  }
+
   addParameter(name: string, location: 'path'): PathParameter;
   addParameter(name: string, location: 'query'): QueryParameter;
   addParameter(name: string, location: 'header'): HeaderParameter;
@@ -129,6 +139,14 @@ export class Operation extends BasicNode<OperationModelParent> implements Operat
     this.responses.deleteDefaultResponse();
   }
 
+  getResponse(code: HTTPStatusCode): ResponseModel | undefined {
+    return this.responses.getResponse(code);
+  }
+
+  getResponseOrThrow(code: HTTPStatusCode): ResponseModel {
+    return this.responses.getResponseOrThrow(code);
+  }
+
   setResponse(code: HTTPStatusCode, description: CommonMarkString): ResponseModel {
     return this.responses.setResponse(code, description);
   }
@@ -139,6 +157,16 @@ export class Operation extends BasicNode<OperationModelParent> implements Operat
 
   clearResponses(): void {
     this.responses.clearResponses();
+  }
+
+  getCallback(name: string): CallbackModel | undefined {
+    return this.callbacks.get(name);
+  }
+
+  getCallbackOrThrow(name: string): CallbackModel {
+    const result = this.getCallback(name);
+    assert(result);
+    return result;
   }
 
   setCallback(key: string): CallbackModel {
@@ -167,6 +195,16 @@ export class Operation extends BasicNode<OperationModelParent> implements Operat
 
   clearSecurityRequirements(): void {
     this.security.splice(0, this.security.length);
+  }
+
+  getServer(url: ParametrisedURLString): ServerModel | undefined {
+    return this.servers.find(item => item.url === url);
+  }
+
+  getServerOrThrow(url: ParametrisedURLString): ServerModel {
+    const result = this.getServer(url);
+    assert(result);
+    return result;
   }
 
   addServer(url: string): ServerModel {

--- a/packages/openapi-model/src/3.0.3/model/Parameter/ParameterBase.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Parameter/ParameterBase.test.ts
@@ -1,0 +1,32 @@
+import { OpenAPIFactory } from '../OpenAPI';
+
+import { ParameterBase } from './ParameterBase';
+
+class Param extends ParameterBase {}
+
+let param = {} as ParameterBase;
+
+beforeEach(() => {
+  const openapi = OpenAPIFactory.create();
+  param = new Param(openapi.components, 'path', 'x');
+});
+
+test('getExample + getExampleOrThrow', () => {
+  param.setExample('json');
+  param.setExample('xml');
+
+  expect(param.getExample('json')).not.toBeUndefined();
+  expect(param.getExample('wrong')).toBeUndefined();
+  expect(param.getExampleOrThrow('xml')).not.toBeUndefined();
+  expect(() => param.getExampleOrThrow('wrong')).toThrow();
+});
+
+test('getContent + getContentOrThrow', () => {
+  param.setContent('application/json');
+  param.setContent('application/xml');
+
+  expect(param.getContent('application/json')).not.toBeUndefined();
+  expect(param.getContent('wrong')).toBeUndefined();
+  expect(param.getContentOrThrow('application/xml')).not.toBeUndefined();
+  expect(() => param.getContentOrThrow('wrong')).toThrow();
+});

--- a/packages/openapi-model/src/3.0.3/model/Parameter/ParameterBase.ts
+++ b/packages/openapi-model/src/3.0.3/model/Parameter/ParameterBase.ts
@@ -42,6 +42,16 @@ export abstract class ParameterBase extends BasicNode<ParameterModelParent> {
     this.required = false;
   }
 
+  getExample(name: string): ExampleModel | undefined {
+    return this.examples.get(name);
+  }
+
+  getExampleOrThrow(name: string): ExampleModel {
+    const result = this.getExample(name);
+    assert(result);
+    return result;
+  }
+
   setExampleModel(name: string, model: ExampleModel): void {
     assert(!this.examples.has(name));
     assert.equal(model.parent, this);
@@ -61,6 +71,16 @@ export abstract class ParameterBase extends BasicNode<ParameterModelParent> {
 
   clearExamples(): void {
     this.examples.clear();
+  }
+
+  getContent(mimeType: MIMETypeString): MediaTypeModel | undefined {
+    return this.content.get(mimeType);
+  }
+
+  getContentOrThrow(mimeType: MIMETypeString): MediaTypeModel {
+    const result = this.getContent(mimeType);
+    assert(result);
+    return result;
   }
 
   setContentModel(mimeType: MIMETypeString, model: MediaTypeModel): void {

--- a/packages/openapi-model/src/3.0.3/model/Paths.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Paths.test.ts
@@ -1,0 +1,17 @@
+import { OpenAPIFactory } from './OpenAPI';
+
+let { paths } = OpenAPIFactory.create();
+
+beforeEach(() => {
+  paths = OpenAPIFactory.create().paths;
+});
+
+test('getItem + getItemOrThrow', () => {
+  paths.root.setPathItem('/people');
+  paths.root.setPathItem('/pets');
+
+  expect(paths.getItem('/people')).not.toBeUndefined();
+  expect(paths.getItem('/wizards')).toBeUndefined();
+  expect(paths.getItemOrThrow('/pets')).not.toBeUndefined();
+  expect(() => paths.getItemOrThrow('/monsters')).toThrow();
+});

--- a/packages/openapi-model/src/3.0.3/model/Paths.ts
+++ b/packages/openapi-model/src/3.0.3/model/Paths.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import { BasicNode } from './BasicNode';
 
 import type { PathItemModel, PathsModel, PathsModelParent } from './types';
@@ -12,6 +14,16 @@ export class Paths extends BasicNode<PathsModelParent> implements PathsModel {
   constructor(parent: PathsModelParent) {
     super(parent);
     this.items = new Map<ParametrisedURLString, PathItemModel>();
+  }
+
+  getItem(url: ParametrisedURLString): PathItemModel | undefined {
+    return this.items.get(url);
+  }
+
+  getItemOrThrow(url: ParametrisedURLString): PathItemModel {
+    const result = this.getItem(url);
+    assert(result);
+    return result;
   }
 
   clear(): void {

--- a/packages/openapi-model/src/3.0.3/model/RequestBody.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/RequestBody.test.ts
@@ -1,0 +1,39 @@
+import { OpenAPIFactory } from './OpenAPI';
+
+import type { RequestBodyModel } from './types';
+
+let requestBody: RequestBodyModel = {} as RequestBodyModel;
+
+beforeEach(() => {
+  requestBody = OpenAPIFactory.create().components.setRequestBody('JSONRequest');
+});
+
+describe('content collections', () => {
+  test('getContent + getContentOrThrow', () => {
+    requestBody.setContent('application/json');
+    requestBody.setContent('application/xml');
+    requestBody.setContent('image/png');
+
+    expect(requestBody.getContent('image/png')).not.toBeUndefined();
+    expect(requestBody.getContent('app/x')).toBeUndefined();
+    expect(requestBody.getContentOrThrow('application/json')).not.toBeUndefined();
+    expect(() => requestBody.getContentOrThrow('image/x')).toThrow();
+  });
+
+  test('mutation methods', () => {
+    requestBody.setContent('application/json');
+    requestBody.setContent('application/xml');
+    requestBody.setContent('image/png');
+
+    expect(requestBody.content.size).toBe(3);
+
+    requestBody.deleteContent('image/png');
+
+    expect(requestBody.content.size).toBe(2);
+    expect(requestBody.getContent('image/png')).toBeUndefined();
+
+    requestBody.clearContent();
+
+    expect(requestBody.content.size).toBe(0);
+  });
+});

--- a/packages/openapi-model/src/3.0.3/model/RequestBody.ts
+++ b/packages/openapi-model/src/3.0.3/model/RequestBody.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import { BasicNode } from './BasicNode';
 import { MediaType } from './MediaType';
 
@@ -17,6 +19,16 @@ export class RequestBody extends BasicNode<RequestBodyModelParent> implements Re
     this.description = null;
     this.content = new Map<string, MediaTypeModel>();
     this.required = false;
+  }
+
+  getContent(mimeType: MIMETypeString): MediaTypeModel | undefined {
+    return this.content.get(mimeType);
+  }
+
+  getContentOrThrow(mimeType: MIMETypeString): MediaTypeModel {
+    const result = this.getContent(mimeType);
+    assert(result);
+    return result;
   }
 
   setContent(mimeType: MIMETypeString): MediaType {

--- a/packages/openapi-model/src/3.0.3/model/Response.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Response.test.ts
@@ -1,0 +1,45 @@
+import { OpenAPIFactory } from './OpenAPI';
+
+import type { ResponseModel } from './types';
+
+let response: ResponseModel = {} as ResponseModel;
+
+beforeEach(() => {
+  response = OpenAPIFactory.create().components.setResponse('JSONResponse', 'test');
+});
+
+describe('headers collection', () => {
+  test('getHeader + getHeaderOrThrow', () => {
+    response.setHeader('X-Language');
+    response.setHeader('X-Fresha');
+
+    expect(response.getHeader('X-Fresha')).not.toBeUndefined();
+    expect(response.getHeader('_')).toBeUndefined();
+    expect(response.getHeaderOrThrow('X-Language')).not.toBeUndefined();
+    expect(() => response.getHeaderOrThrow('?')).toThrow();
+  });
+});
+
+describe('content collection', () => {
+  test('getContent + getContentOrThrow', () => {
+    response.setContent('application/json');
+    response.setContent('application/xml');
+
+    expect(response.getContent('application/json')).not.toBeUndefined();
+    expect(response.getContent('-')).toBeUndefined();
+    expect(response.getContentOrThrow('application/xml')).not.toBeUndefined();
+    expect(() => response.getContentOrThrow('-')).toThrow();
+  });
+});
+
+describe('links collection', () => {
+  test('getLink + getLinkOrThrow', () => {
+    response.setLink('Language');
+    response.setLink('Fresha');
+
+    expect(response.getLink('Language')).not.toBeUndefined();
+    expect(response.getLink('_')).toBeUndefined();
+    expect(response.getLinkOrThrow('Fresha')).not.toBeUndefined();
+    expect(() => response.getLinkOrThrow('?')).toThrow();
+  });
+});

--- a/packages/openapi-model/src/3.0.3/model/Response.ts
+++ b/packages/openapi-model/src/3.0.3/model/Response.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import { BasicNode } from './BasicNode';
 import { Header } from './Header';
 import { Link } from './Link';
@@ -29,6 +31,16 @@ export class Response extends BasicNode<ResponseModelParent> implements Response
     this.links = new Map<string, LinkModel>();
   }
 
+  getHeader(name: string): HeaderModel | undefined {
+    return this.headers.get(name);
+  }
+
+  getHeaderOrThrow(name: string): HeaderModel {
+    const result = this.getHeader(name);
+    assert(result);
+    return result;
+  }
+
   setHeader(name: string): HeaderModel {
     const result = new Header(this);
     this.headers.set(name, result);
@@ -41,6 +53,16 @@ export class Response extends BasicNode<ResponseModelParent> implements Response
 
   clearHeaders(): void {
     this.headers.clear();
+  }
+
+  getContent(mimeType: MIMETypeString): MediaTypeModel | undefined {
+    return this.content.get(mimeType);
+  }
+
+  getContentOrThrow(mimeType: MIMETypeString): MediaTypeModel {
+    const result = this.getContent(mimeType);
+    assert(result);
+    return result;
   }
 
   setContent(mimeType: MIMETypeString): MediaTypeModel {
@@ -58,6 +80,16 @@ export class Response extends BasicNode<ResponseModelParent> implements Response
 
   clearContent(): void {
     this.content.clear();
+  }
+
+  getLink(key: string): LinkModel | undefined {
+    return this.links.get(key);
+  }
+
+  getLinkOrThrow(key: string): LinkModel {
+    const result = this.getLink(key);
+    assert(result);
+    return result;
   }
 
   setLink(key: string): LinkModel {

--- a/packages/openapi-model/src/3.0.3/model/Responses.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Responses.test.ts
@@ -1,0 +1,21 @@
+import { OpenAPIFactory } from './OpenAPI';
+
+import type { ResponsesModel } from './types';
+
+let responses: ResponsesModel = {} as ResponsesModel;
+
+beforeEach(() => {
+  responses = OpenAPIFactory.create().setPathItem('/item').setOperation('get').responses;
+});
+
+describe('responses collection', () => {
+  test('getResponse + getResponseOrThrow', () => {
+    responses.setResponse(200, 'success');
+    responses.setResponse(201, 'created');
+
+    expect(responses.getResponse(200)).not.toBeUndefined();
+    expect(responses.getResponse(500)).toBeUndefined();
+    expect(responses.getResponseOrThrow(201)).not.toBeUndefined();
+    expect(() => responses.getResponseOrThrow(404)).toThrow();
+  });
+});

--- a/packages/openapi-model/src/3.0.3/model/Responses.ts
+++ b/packages/openapi-model/src/3.0.3/model/Responses.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import { BasicNode } from './BasicNode';
 import { Response } from './Response';
 
@@ -27,10 +29,18 @@ export class Responses extends BasicNode<ResponsesModelParent> implements Respon
     this.default = null;
   }
 
+  getResponse(code: HTTPStatusCode): ResponseModel | undefined {
+    return this.codes.get(code);
+  }
+
+  getResponseOrThrow(code: HTTPStatusCode): ResponseModel {
+    const result = this.getResponse(code);
+    assert(result);
+    return result;
+  }
+
   setResponse(code: HTTPStatusCode, description: CommonMarkString): ResponseModel {
-    if (this.codes.has(code)) {
-      throw new Error(`Duplicate response for code ${code}`);
-    }
+    assert(!this.codes.has(code), `Duplicate response for code ${code}`);
     const response = new Response(this, description);
     this.codes.set(code, response);
     return response;

--- a/packages/openapi-model/src/3.0.3/model/Schema.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Schema.test.ts
@@ -66,6 +66,18 @@ describe('SchemaFactory', () => {
 });
 
 describe('Schema', () => {
+  test('getProperty + getPropertyOrThrow', () => {
+    const openapi = new OpenAPI('example', '0.1.0');
+
+    const schema = SchemaFactory.create(openapi.components, 'object');
+    schema.setProperties({ a: 'string', b: 'date' });
+
+    expect(schema.getProperty('a')).not.toBeUndefined();
+    expect(schema.getProperty('')).toBeUndefined();
+    expect(schema.getPropertyOrThrow('b')).not.toBeUndefined();
+    expect(() => schema.getPropertyOrThrow('_')).toThrow();
+  });
+
   test('setProperty', () => {
     const openapi = new OpenAPI('example', '0.1.0');
 

--- a/packages/openapi-model/src/3.0.3/model/Schema.ts
+++ b/packages/openapi-model/src/3.0.3/model/Schema.ts
@@ -184,6 +184,16 @@ export class Schema extends BasicNode<SchemaModelParent> implements SchemaModel 
     this.deprecated = false;
   }
 
+  getProperty(name: string): SchemaModel | undefined {
+    return this.properties.get(name);
+  }
+
+  getPropertyOrThrow(name: string): SchemaModel {
+    const result = this.getProperty(name);
+    assert(result);
+    return result;
+  }
+
   setProperty(name: string, params: SchemaCreateOptions): SchemaModel {
     const propertySchema = Schema.internalCreate(this, params);
     this.properties.set(name, propertySchema);

--- a/packages/openapi-model/src/3.0.3/model/SecurityRequirement.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/SecurityRequirement.test.ts
@@ -1,0 +1,12 @@
+import { OpenAPIFactory } from './OpenAPI';
+
+test('getScopes + getScopesOrThrow', () => {
+  const requirement = OpenAPIFactory.create().addSecurityRequirement();
+  requirement.addScopes('s1', 'a');
+  requirement.addScopes('s2', 'b');
+
+  expect(requirement.getScopes('s1')).not.toBeUndefined();
+  expect(requirement.getScopes('s3')).toBeUndefined();
+  expect(requirement.getScopesOrThrow('s2')).not.toBeUndefined();
+  expect(() => requirement.getScopesOrThrow('s3')).toThrow();
+});

--- a/packages/openapi-model/src/3.0.3/model/SecurityRequirement.ts
+++ b/packages/openapi-model/src/3.0.3/model/SecurityRequirement.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import { BasicNode } from './BasicNode';
 
 import type { SecurityRequirementModel, SecurityRequirementModelParent } from './types';
@@ -14,6 +16,16 @@ export class SecurityRequirement
   constructor(parent: SecurityRequirementModelParent) {
     super(parent);
     this.scopes = new Map<string, string[]>();
+  }
+
+  getScopes(schemeName: string): string[] | undefined {
+    return this.scopes.get(schemeName);
+  }
+
+  getScopesOrThrow(schemeName: string): string[] {
+    const result = this.getScopes(schemeName);
+    assert(result);
+    return result;
   }
 
   addScopes(schemeName: string, ...scopes: string[]): void {

--- a/packages/openapi-model/src/3.0.3/model/Server.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Server.test.ts
@@ -24,6 +24,14 @@ describe('constructor', () => {
   });
 });
 
+test('getVariable + getVariableOrThrow', () => {
+  const server = new Server(openapi, 'https://www.example.com/{a}/{b}');
+  expect(server.getVariable('a')).not.toBeUndefined();
+  expect(server.getVariable('_')).toBeUndefined();
+  expect(server.getVariableOrThrow('b')).not.toBeUndefined();
+  expect(() => server.getVariableOrThrow('_')).toThrow();
+});
+
 test('changing server URL also updates variable map', () => {
   const server = new Server(openapi, 'https://www.{hostName}.com/{pathName}');
   server.variables.get('pathName')!.default = '/a/b/c';

--- a/packages/openapi-model/src/3.0.3/model/Server.ts
+++ b/packages/openapi-model/src/3.0.3/model/Server.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import { BasicNode } from './BasicNode';
 import { ServerVariable } from './ServerVariable';
 
@@ -42,6 +44,16 @@ export class Server extends BasicNode<ServerModelParent> implements ServerModel 
 
   get variables(): ReadonlyMap<string, ServerVariableModel> {
     return this.mVariables;
+  }
+
+  getVariable(name: string): ServerVariableModel | undefined {
+    return this.variables.get(name);
+  }
+
+  getVariableOrThrow(name: string): ServerVariableModel {
+    const result = this.getVariable(name);
+    assert(result);
+    return result;
   }
 
   setVariableDefault(name: string, value: string): void {

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -444,14 +444,20 @@ export interface ResponseModel extends TreeNode<ResponseModelParent>, Specificat
   readonly content: ReadonlyMap<MIMETypeString, MediaTypeModel>; // key = MIME media type
   readonly links: ReadonlyMap<string, LinkModel>; // key = short name of the link
 
+  getHeader(name: string): HeaderModel | undefined;
+  getHeaderOrThrow(name: string): HeaderModel;
   setHeader(name: string): HeaderModel;
   deleteHeader(name: string): void;
   clearHeaders(): void;
 
+  getContent(mimeType: MIMETypeString): MediaTypeModel | undefined;
+  getContentOrThrow(mimeType: MIMETypeString): MediaTypeModel;
   setContent(mimeType: MIMETypeString): MediaTypeModel;
   deleteContent(mimeType: MIMETypeString): void;
   clearContent(): void;
 
+  getLink(key: string): LinkModel | undefined;
+  getLinkOrThrow(key: string): LinkModel;
   setLink(key: string): LinkModel;
   deleteLink(key: string): void;
   clearLinks(): void;

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -43,6 +43,8 @@ export interface TreeNode<TParent> extends Disposable {
 export interface SpecificationExtensionsModel {
   readonly extensions: ExtensionFields;
 
+  getExtension(key: string): JSONValue | undefined;
+  getExtensionOrThrow(key: string): JSONValue;
   setExtension(key: string, value: JSONValue): void;
   deleteExtension(key: string): void;
   clearExtensions(): void;

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -221,6 +221,8 @@ export interface ServerModel extends TreeNode<ServerModelParent>, SpecificationE
   description: Nullable<CommonMarkString>;
   readonly variables: ReadonlyMap<string, ServerVariableModel>;
 
+  getVariable(name: string): ServerVariableModel | undefined;
+  getVariableOrThrow(name: string): ServerVariableModel;
   setVariableDefault(name: string, value: string): void;
 }
 

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -122,6 +122,8 @@ export interface SchemaModel extends TreeNode<SchemaModelParent>, SpecificationE
   example: Nullable<JSONValue>;
   deprecated: boolean;
 
+  getProperty(name: string): SchemaModel | undefined;
+  getPropertyOrThrow(name: string): SchemaModel;
   setProperty(name: string, options: SchemaCreateOptions): SchemaModel;
   setProperties(props: Record<string, SchemaCreateOptions>): SchemaModel;
   deleteProperty(name: string): void;

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -479,6 +479,8 @@ export interface ResponsesModel
   setDefaultResponse(description: CommonMarkString): ResponseModel;
   deleteDefaultResponse(): void;
 
+  getResponse(code: HTTPStatusCode): ResponseModel | undefined;
+  getResponseOrThrow(code: HTTPStatusCode): ResponseModel;
   setResponse(code: HTTPStatusCode, description: CommonMarkString): ResponseModel;
   deleteResponse(code: HTTPStatusCode): void;
   clearResponses(): void;

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -259,11 +259,15 @@ export interface ParameterBaseModel
   readonly examples: ReadonlyMap<string, ExampleModel>;
   readonly content: ReadonlyMap<MIMETypeString, MediaTypeModel>;
 
+  getExample(name: string): ExampleModel | undefined;
+  getExampleOrThrow(name: string): ExampleModel;
   setExampleModel(name: string, model: ExampleModel): void;
   setExample(name: string): ExampleModel;
   deleteExample(name: string): void;
   clearExamples(): void;
 
+  getContent(mimeType: MIMETypeString): MediaTypeModel | undefined;
+  getContentOrThrow(mimeType: MIMETypeString): MediaTypeModel;
   setContentModel(mimeType: MIMETypeString, model: MediaTypeModel): void;
   setContent(mimeType: MIMETypeString): MediaTypeModel;
   deleteContent(mimeType: MIMETypeString): void;

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -738,7 +738,13 @@ export type CallbackModelParent = ComponentsModel | OperationModel;
  * @see https://spec.openapis.org/oas/v3.0.3#callback-object
  */
 export interface CallbackModel extends TreeNode<CallbackModelParent>, SpecificationExtensionsModel {
-  readonly paths: ReadonlyMap<ParametrisedURLString, PathItemModel>;
+  readonly paths: ReadonlyMap<string, PathItemModel>;
+
+  getPathItem(key: string): PathItemModel | undefined;
+  getPathItemOrThrow(key: string): PathItemModel;
+  setPathItem(key: string): PathItemModel;
+  deletePathItem(key: string): void;
+  clearPathItems(): void;
 }
 
 export type ComponentsModelParent = OpenAPIModel;

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -786,6 +786,8 @@ export interface SecurityRequirementModel
     SpecificationExtensionsModel {
   readonly scopes: ReadonlyMap<string, ReadonlyArray<string>>;
 
+  getScopes(schemeName: string): string[] | undefined;
+  getScopesOrThrow(schemeName: string): string[];
   addScopes(schemeName: string, ...scope: string[]): void;
   deleteScopes(schemeName: string, ...scope: string[]): void;
   clearScopes(): void;

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -634,6 +634,12 @@ export type OAuthFlowModelParent = OAuthFlowsModel;
 interface OAuthFlowBaseModel extends TreeNode<OAuthFlowModelParent>, SpecificationExtensionsModel {
   refreshUrl: Nullable<URLString>;
   readonly scopes: ReadonlyMap<string, string>;
+
+  getScope(key: string): string | undefined;
+  getScopeOrThrow(key: string): string;
+  setScope(key: string, value: string): void;
+  deleteScope(key: string): void;
+  clearScopes(): void;
 }
 
 /**

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -512,6 +512,8 @@ export interface OperationModel
   deleteTagAt(index: number): void;
   clearTags(): void;
 
+  getParameter(name: string, source: ParameterLocation): ParameterModel | undefined;
+  getParameterOrThrow(name: string, source: ParameterLocation): ParameterModel;
   addParameter(name: string, source: 'path'): PathParameterModel;
   addParameter(name: string, source: 'query'): QueryParameterModel;
   addParameter(name: string, source: 'header'): HeaderParameterModel;
@@ -522,10 +524,14 @@ export interface OperationModel
   setDefaultResponse(description: CommonMarkString): ResponseModel;
   deleteDefaultResponse(): void;
 
+  getResponse(code: HTTPStatusCode): ResponseModel | undefined;
+  getResponseOrThrow(code: HTTPStatusCode): ResponseModel;
   setResponse(code: HTTPStatusCode, description: CommonMarkString): ResponseModel;
   deleteResponse(code: HTTPStatusCode): void;
   clearResponses(): void;
 
+  getCallback(name: string): CallbackModel | undefined;
+  getCallbackOrThrow(name: string): CallbackModel;
   setCallback(key: string): CallbackModel;
   deleteCallback(key: string): void;
   clearCallbacks(): void;
@@ -534,6 +540,8 @@ export interface OperationModel
   deleteSecurityRequirementAt(index: number): void;
   clearSecurityRequirements(): void;
 
+  getServer(url: ParametrisedURLString): ServerModel | undefined;
+  getServerOrThrow(url: ParametrisedURLString): ServerModel;
   addServer(url: string): ServerModel;
   deleteServer(url: string): void;
   deleteServerAt(index: number): void;

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -350,6 +350,18 @@ export interface HeaderModel extends TreeNode<HeaderModelParent>, SpecificationE
   example: JSONValue;
   readonly examples: Map<string, ExampleModel>;
   readonly content: Map<MIMETypeString, MediaTypeModel>;
+
+  getExample(name: string): ExampleModel | undefined;
+  getExampleOrThrow(name: string): ExampleModel;
+  setExample(name: string): ExampleModel;
+  deleteExample(name: string): void;
+  clearExamples(): void;
+
+  getContent(mimeType: MIMETypeString): MediaTypeModel | undefined;
+  getContentOrThrow(mimeType: MIMETypeString): MediaTypeModel;
+  setContent(mimeType: MIMETypeString): void;
+  deleteContent(mimeType: MIMETypeString): void;
+  clearContents(): void;
 }
 
 export type EncodingModelParent = MediaTypeModel;
@@ -371,7 +383,7 @@ export interface EncodingModel extends TreeNode<EncodingModelParent>, Specificat
   clearHeaders(): void;
 }
 
-export type MediaTypeModelParent = ParameterModel | RequestBodyModel | ResponseModel;
+export type MediaTypeModelParent = ParameterModel | RequestBodyModel | ResponseModel | HeaderModel;
 
 /**
  * @see https://spec.openapis.org/oas/v3.0.3#media-type-object

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -730,6 +730,12 @@ export interface LinkModel extends TreeNode<LinkModelParent>, SpecificationExten
   requestBody: JSONValue;
   description: Nullable<CommonMarkString>;
   server: Nullable<ServerModel>;
+
+  getParameter(key: string): JSONValue | undefined;
+  getParameterOrThrow(key: string): JSONValue;
+  setParameter(key: string, value: JSONValue): void;
+  deleteParameter(key: string): void;
+  clearParameters(): void;
 }
 
 export type CallbackModelParent = ComponentsModel | OperationModel;

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -712,46 +712,64 @@ export interface ComponentsModel
 
   isEmpty(): boolean;
 
+  getSchema(name: string): SchemaModel | undefined;
+  getSchemaOrThrow(name: string): SchemaModel;
   setSchemaModel(name: string, model: SchemaModel): void;
   setSchema(name: string, type?: SchemaType): SchemaModel;
   deleteSchema(name: string): void;
   clearSchemas(): void;
 
+  getResponse(name: string): ResponseModel | undefined;
+  getResponseOrThrow(name: string): ResponseModel;
   setResponseModel(name: string, model: ResponseModel): void;
   setResponse(name: string, description: CommonMarkString): ResponseModel;
   deleteResponse(name: string): void;
   clearResponses(): void;
 
+  getParameter(name: string): ParameterModel | undefined;
+  getParameterOrThrow(name: string): ParameterModel;
   setParameterModel(name: string, model: ParameterModel): void;
   setParameter(name: string, kind: ParameterModel['in'], paramName: string): ParameterModel;
   deleteParameter(name: string): void;
   clearParameters(): void;
 
+  getExample(name: string): ExampleModel | undefined;
+  getExampleOrThrow(name: string): ExampleModel;
   setExampleModel(name: string, model: ExampleModel): void;
   setExample(name: string): ExampleModel;
   deleteExample(name: string): void;
   clearExamples(): void;
 
+  getRequestBody(name: string): RequestBodyModel | undefined;
+  getRequestBodyOrThrow(name: string): RequestBodyModel;
   setRequestBodyModel(name: string, model: RequestBodyModel): void;
   setRequestBody(name: string): RequestBodyModel;
   deleteRequestBody(name: string): void;
   clearRequestBodies(): void;
 
+  getHeader(name: string): HeaderModel | undefined;
+  getHeaderOrThrow(name: string): HeaderModel;
   setHeaderModel(name: string, model: HeaderModel): void;
   setHeader(name: string): HeaderModel;
   deleteHeader(name: string): void;
   clearHeaders(): void;
 
+  getSecuritySchema(name: string): SecuritySchemaModel | undefined;
+  getSecuritySchemaOrThrow(name: string): SecuritySchemaModel;
   setSecuritySchemaModel(name: string, model: SecuritySchemaModel): void;
   setSecuritySchema(name: string, kind: SecuritySchemaModel['type']): SecuritySchemaModel;
   deleteSecuritySchema(name: string): void;
   clearSecuritySchemes(): void;
 
+  getLink(name: string): LinkModel | undefined;
+  getLinkOrThrow(name: string): LinkModel;
   setLinkModel(name: string, model: LinkModel): void;
   setLink(name: string): LinkModel;
   deleteLink(name: string): void;
   clearLinks(): void;
 
+  getCallback(name: string): CallbackModel | undefined;
+  getCallbackOrThrow(name: string): CallbackModel;
   setCallbackModel(name: string, model: CallbackModel): void;
   setCallback(name: string): CallbackModel;
   deleteCallback(name: string): void;

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -591,7 +591,10 @@ export type PathsModelParent = OpenAPIModel;
 export interface PathsModel
   extends TreeNode<PathsModelParent>,
     Map<ParametrisedURLString, PathItemModel>,
-    SpecificationExtensionsModel {}
+    SpecificationExtensionsModel {
+  getItem(url: ParametrisedURLString): PathItemModel | undefined;
+  getItemOrThrow(url: ParametrisedURLString): PathItemModel;
+}
 
 export type SecuritySchemaModelParent = ComponentsModel;
 

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -401,10 +401,14 @@ export interface MediaTypeModel
   setSchema(type: SchemaCreateType): SchemaModel;
   deleteSchema(): void;
 
+  getExample(key: string): ExampleModel | undefined;
+  getExampleOrThrow(key: string): ExampleModel;
   setExample(key: string): ExampleModel;
   deleteExample(key: string): void;
   clearExamples(): void;
 
+  getEncoding(key: string): EncodingModel | undefined;
+  getEncodingOrThrow(key: string): EncodingModel;
   setEncoding(key: string): EncodingModel;
   deleteEncoding(key: string): void;
   clearEncodings(): void;

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -811,6 +811,8 @@ export interface OpenAPIModel extends Disposable, SpecificationExtensionsModel {
   readonly tags: ReadonlyArray<TagModel>;
   readonly externalDocs: Nullable<ExternalDocumentationModel>;
 
+  getServer(url: ParametrisedURLString): ServerModel | undefined;
+  getServerOrThrow(url: ParametrisedURLString): ServerModel;
   addServer(
     url: ParametrisedURLString,
     variableDefaults?: Record<string, string>,
@@ -819,6 +821,8 @@ export interface OpenAPIModel extends Disposable, SpecificationExtensionsModel {
   removeServerAt(index: number): void;
   clearServers(): void;
 
+  getPathItem(url: ParametrisedURLString): PathItemModel | undefined;
+  getPathItemOrThrow(url: ParametrisedURLString): PathItemModel;
   setPathItem(url: ParametrisedURLString): PathItemModel;
   deletePathItem(url: ParametrisedURLString): void;
   clearPathItems(): void;
@@ -827,6 +831,8 @@ export interface OpenAPIModel extends Disposable, SpecificationExtensionsModel {
   deleteSecurityRequirementAt(index: number): void;
   clearSecurityRequirements(): void;
 
+  getTag(name: string): TagModel | undefined;
+  getTagOrThrow(name: string): TagModel;
   addTag(name: string): TagModel;
   deleteTag(name: string): void;
   deleteTagAt(index: number): void;

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -378,6 +378,8 @@ export interface EncodingModel extends TreeNode<EncodingModelParent>, Specificat
   explode: boolean;
   allowReserved: boolean;
 
+  getHeader(name: string): HeaderModel | undefined;
+  getHeaderOrThrow(name: string): HeaderModel;
   setHeader(name: string): HeaderModel;
   deleteHeader(name: string): void;
   clearHeaders(): void;

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -426,6 +426,8 @@ export interface RequestBodyModel
   readonly content: ReadonlyMap<MIMETypeString, MediaTypeModel>;
   required: boolean;
 
+  getContent(mimeType: MIMETypeString): MediaTypeModel | undefined;
+  getContentOrThrow(mimeType: MIMETypeString): MediaTypeModel;
   setContent(mimeType: MIMETypeString): MediaTypeModel;
   deleteContent(mimeType: MIMETypeString): void;
   clearContent(): void;


### PR DESCRIPTION
## Motivation and Context

This PR addresses https://github.com/fresha/api-tools/issues/33. It adds `getXXX` and `getXXXOrThrow` as specified in the issue.

## Type of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

None.