### PR TITLE
Move string conversion functions to @fresha/api-tools-core

### DIFF
--- a/packages/api-tools-core/src/utils.test.ts
+++ b/packages/api-tools-core/src/utils.test.ts
@@ -1,4 +1,4 @@
-import { kebabCase, kebabCaseDeep, camelCase } from './utils';
+import { kebabCase, kebabCaseDeep, camelCase, titleCase, snakeCase } from './utils';
 
 describe('kebabCase', () => {
   it('should convert strings to kebab case', () => {
@@ -58,4 +58,16 @@ describe('kebabCaseDeep', () => {
       },
     });
   });
+});
+
+test('titleCase', () => {
+  expect(titleCase('forget-me-not')).toBe('ForgetMeNot');
+  expect(titleCase('forgetMeNot')).toBe('ForgetMeNot');
+});
+
+test('snakeCase', () => {
+  expect(snakeCase('forget-me-not')).toBe('forget_me_not');
+  expect(snakeCase('Forget-me-not')).toBe('forget_me_not');
+  expect(snakeCase('forgetMeNot')).toBe('forget_me_not');
+  expect(snakeCase('--Forget--MeNot')).toBe('forget_me_not');
 });

--- a/packages/api-tools-core/src/utils.ts
+++ b/packages/api-tools-core/src/utils.ts
@@ -38,3 +38,20 @@ export const camelCase: KeyTransformFunc = str => {
 };
 
 export const camelCaseDeep: TransformFunc = obj => transformKeysDeep(obj, camelCase);
+
+export const titleCase = (str: string): string => {
+  const camelized = camelCase(str);
+  return `${camelized[0].toUpperCase()}${camelized.slice(1)}`;
+};
+
+export const snakeCase = (str: string): string => {
+  return str
+    .replace(/^[-_]+/, '')
+    .replace(/^[A-Z]/, (match: string): string => match.toLowerCase())
+    .replace(/-+/g, '_')
+    .replace(/[-_]+[A-Z]/g, (match: string): string => String(match.at(-1)))
+    .replace(
+      /[a-z0-9][A-Z]/g,
+      (match: string): string => `${String(match.at(0))}_${String(match.at(-1)).toLowerCase()}`,
+    );
+};

--- a/packages/openapi-codegen-client-fetch/package.json
+++ b/packages/openapi-codegen-client-fetch/package.json
@@ -24,7 +24,12 @@
     "LICENSE",
     "README.md"
   ],
-  "keywords": ["OpenAPI", "code generator", "Fetch API", "TypeScript"],
+  "keywords": [
+    "OpenAPI",
+    "code generator",
+    "Fetch API",
+    "TypeScript"
+  ],
   "author": "Fresha Engineering",
   "contributors": [
     {
@@ -42,8 +47,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@fresha/openapi-model": "0.3.0",
+    "@fresha/api-tools-core": "^0.2.1",
     "@fresha/openapi-codegen-utils": "0.1.0",
+    "@fresha/openapi-model": "0.3.0",
     "ts-morph": "^16.0.0"
   },
   "devDependencies": {

--- a/packages/openapi-codegen-client-fetch/src/Generator.ts
+++ b/packages/openapi-codegen-client-fetch/src/Generator.ts
@@ -1,10 +1,10 @@
 import assert from 'assert';
 import path from 'path';
 
+import { titleCase } from '@fresha/api-tools-core';
 import {
   addTypeLiteralProperty,
   Logger,
-  titleCase,
   getOperationIdOrThrow,
   addTypeLiteralAlias,
   addImportDeclaration,

--- a/packages/openapi-codegen-client-fresha/src/parts/ActionSignature.ts
+++ b/packages/openapi-codegen-client-fresha/src/parts/ActionSignature.ts
@@ -1,12 +1,12 @@
 import assert from 'assert';
 
+import { titleCase } from '@fresha/api-tools-core';
 import {
   addImportDeclaration,
   addTypeAlias,
   addTypeLiteralCall,
   addTypeLiteralProperty,
   Logger,
-  titleCase,
 } from '@fresha/openapi-codegen-utils';
 import { OperationModel, SchemaModel } from '@fresha/openapi-model/build/3.0.3';
 import { CodeBlockWriter, SyntaxKind, TypeLiteralNode } from 'ts-morph';

--- a/packages/openapi-codegen-client-fresha/src/parts/ActionsSignatures.ts
+++ b/packages/openapi-codegen-client-fresha/src/parts/ActionsSignatures.ts
@@ -1,13 +1,12 @@
 import assert from 'assert';
 
-import { camelCase } from '@fresha/api-tools-core';
+import { camelCase, titleCase } from '@fresha/api-tools-core';
 import {
   addConstant,
   addTypeLiteralAlias,
   getOperationEntryKeyOrThrow,
   getOperationId,
   Logger,
-  titleCase,
 } from '@fresha/openapi-codegen-utils';
 
 import { ActionSignature } from './ActionSignature';

--- a/packages/openapi-codegen-server-nestjs/src/Action.ts
+++ b/packages/openapi-codegen-server-nestjs/src/Action.ts
@@ -1,9 +1,8 @@
 import assert from 'assert';
 
+import { Nullable, camelCase, titleCase } from '@fresha/api-tools-core';
 import {
   Logger,
-  camelCase,
-  titleCase,
   addImportDeclarations,
   addImportDeclaration,
   addDecorator,
@@ -13,7 +12,6 @@ import { ClassDeclaration, Scope } from 'ts-morph';
 import { ActionParam } from './ActionParam';
 
 import type { Controller } from './Controller';
-import type { Nullable } from '@fresha/api-tools-core';
 import type { OperationModel, SchemaModel } from '@fresha/openapi-model/build/3.0.3';
 
 const jsonApiMediaType = 'application/vnd.api+json';

--- a/packages/openapi-codegen-server-nestjs/src/Controller.ts
+++ b/packages/openapi-codegen-server-nestjs/src/Controller.ts
@@ -1,12 +1,12 @@
 import path from 'path';
 
+import { titleCase } from '@fresha/api-tools-core';
 import {
   addDecorator,
   commonStringPrefix,
   kebabCase,
   Logger,
   significantNameParts,
-  titleCase,
   addImportDeclaration,
 } from '@fresha/openapi-codegen-utils';
 

--- a/packages/openapi-codegen-server-nestjs/src/DTO.ts
+++ b/packages/openapi-codegen-server-nestjs/src/DTO.ts
@@ -1,15 +1,10 @@
 import assert from 'assert';
 import path from 'path';
 
-import {
-  addDecorator,
-  addImportDeclaration,
-  Logger,
-  titleCase,
-} from '@fresha/openapi-codegen-utils';
+import { Nullable, titleCase } from '@fresha/api-tools-core';
+import { addDecorator, addImportDeclaration, Logger } from '@fresha/openapi-codegen-utils';
 
 import type { Generator } from './Generator';
-import type { Nullable } from '@fresha/api-tools-core';
 import type { SchemaModel, SchemaPropertyObject } from '@fresha/openapi-model/build/3.0.3';
 import type { ClassDeclaration, CodeBlockWriter, SourceFile } from 'ts-morph';
 

--- a/packages/openapi-codegen-utils/src/string.test.ts
+++ b/packages/openapi-codegen-utils/src/string.test.ts
@@ -1,9 +1,4 @@
-import { titleCase, commonStringPrefix } from './string';
-
-test('titleCase', () => {
-  expect(titleCase('forget-me-not')).toBe('ForgetMeNot');
-  expect(titleCase('forgetMeNot')).toBe('ForgetMeNot');
-});
+import { commonStringPrefix } from './string';
 
 test('empty array', () => {
   expect(() => commonStringPrefix([])).toThrow();

--- a/packages/openapi-codegen-utils/src/string.ts
+++ b/packages/openapi-codegen-utils/src/string.ts
@@ -6,11 +6,6 @@ export { kebabCase } from '@fresha/api-tools-core';
 
 export { camelCase };
 
-export const titleCase = (str: string): string => {
-  const camelized = camelCase(str);
-  return `${camelized[0].toUpperCase()}${camelized.slice(1)}`;
-};
-
 const maybeAddLeadingSlash = (str: string): string => {
   return str.startsWith('/') ? str : `/${str}`;
 };


### PR DESCRIPTION
## Motivation and Context

This PR moves `titleCase` and `snakeCase` from `@fresha/openapi-codegen-utils` to `@fresha/api-tools-core`. These functions will be used in several places other than code generators.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring

## Details

None.
