### PR TITLE
Add PathItem.pathUrl and Operation.httpMethod

### DIFF
--- a/packages/openapi-model/src/3.0.3/model/Callback.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Callback.test.ts
@@ -6,6 +6,27 @@ beforeEach(() => {
   callback = OpenAPIFactory.create().components.setCallback('onData');
 });
 
+test('getPathUrl() + getPathUrlOrThrow()', () => {
+  const item1 = callback.setPathItem('hello');
+
+  const callback2 = callback.root.components.setCallback('onResult');
+  const item2 = callback2.setPathItem('hello');
+
+  expect(callback.getItemUrl(item1)).toBe('hello');
+  expect(callback.getItemUrl(item2)).toBeUndefined();
+
+  expect(() => callback2.getItemUrlOrThrow(item1)).toThrow();
+  expect(callback2.getItemUrlOrThrow(item2)).toBe('hello');
+});
+
+test('getPathUrl() + mutation', () => {
+  const item1 = callback.setPathItem('hello');
+
+  expect(callback.getItemUrl(item1)).toBe('hello');
+  callback.deletePathItem('hello');
+  expect(callback.getItemUrl(item1)).toBeUndefined();
+});
+
 test('getPathItem + getPathItemOrThrow', () => {
   callback.setPathItem('people');
   callback.setPathItem('pets');

--- a/packages/openapi-model/src/3.0.3/model/Callback.ts
+++ b/packages/openapi-model/src/3.0.3/model/Callback.ts
@@ -1,5 +1,7 @@
 import assert from 'assert';
 
+import { BidiMap } from '../../BidiMap';
+
 import { BasicNode } from './BasicNode';
 import { PathItem } from './PathItem';
 
@@ -10,11 +12,21 @@ import type { ParametrisedURLString } from '@fresha/api-tools-core';
  * @see http://spec.openapis.org/oas/v3.0.3#callback-object
  */
 export class Callback extends BasicNode<CallbackModelParent> implements CallbackModel {
-  readonly paths: Map<string, PathItemModel>;
+  readonly paths: BidiMap<ParametrisedURLString, PathItemModel>;
 
   constructor(parent: CallbackModelParent) {
     super(parent);
-    this.paths = new Map<ParametrisedURLString, PathItemModel>();
+    this.paths = new BidiMap<ParametrisedURLString, PathItemModel>();
+  }
+
+  getItemUrl(pathItem: PathItemModel): string | undefined {
+    return this.paths.getKey(pathItem);
+  }
+
+  getItemUrlOrThrow(pathItem: PathItemModel): string {
+    const result = this.getItemUrl(pathItem);
+    assert(result, `Cannot find URL associated with path item`);
+    return result;
   }
 
   getPathItem(key: ParametrisedURLString): PathItemModel | undefined {
@@ -23,7 +35,7 @@ export class Callback extends BasicNode<CallbackModelParent> implements Callback
 
   getPathItemOrThrow(key: string): PathItemModel {
     const result = this.getPathItem(key);
-    assert(result);
+    assert(result, `Cannot find path item associated with '${key}' URL`);
     return result;
   }
 

--- a/packages/openapi-model/src/3.0.3/model/Components.ts
+++ b/packages/openapi-model/src/3.0.3/model/Components.ts
@@ -297,7 +297,7 @@ export class Components extends BasicNode<ComponentsModelParent> implements Comp
     let result: SecuritySchemaModel;
     switch (kind) {
       case 'apiKey':
-        result = new APIKeySecurityScheme(this, 'x', 'header');
+        result = new APIKeySecurityScheme(this, name, 'header');
         break;
       case 'http':
         result = new HTTPSecurityScheme(this, Schema.create(this));

--- a/packages/openapi-model/src/3.0.3/model/OpenAPI.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPI.ts
@@ -131,11 +131,11 @@ export class OpenAPI implements OpenAPIModel, SpecificationExtensionsModel {
   }
 
   setPathItem(url: ParametrisedURLString): PathItemModel {
-    if (this.paths.items.has(url)) {
+    if (this.paths.has(url)) {
       throw new Error(`Duplicate path item ${url}`);
     }
     const pathItem = new PathItem(this.paths);
-    this.paths.items.set(url, pathItem);
+    this.paths.set(url, pathItem);
     return pathItem;
   }
 
@@ -158,7 +158,7 @@ export class OpenAPI implements OpenAPIModel, SpecificationExtensionsModel {
   }
 
   clearSecurityRequirements(): void {
-    this.security.splice(1, this.security.length);
+    this.security.splice(0, this.security.length);
   }
 
   getTag(name: string): TagModel | undefined {

--- a/packages/openapi-model/src/3.0.3/model/Operation.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Operation.test.ts
@@ -22,6 +22,15 @@ test('default properties', () => {
   expect(operation.servers).toHaveLength(0);
 });
 
+test('httpMethod property', () => {
+  const pathItem = openapi.setPathItem('/hello');
+  const op1 = pathItem.setOperation('post');
+  const op2 = pathItem.setOperation('delete');
+
+  expect(op1.httpMethod).toBe('post');
+  expect(op2.httpMethod).toBe('delete');
+});
+
 test('tags collection', () => {
   const operation = openapi.setPathItem('/').setOperation('head');
 
@@ -41,6 +50,10 @@ test('tags collection', () => {
   operation.deleteTag('tag4');
   expect(operation.tags).toStrictEqual(['tag1', 'tag3']);
 
+  operation.deleteTag('tag3');
+  expect(operation.tags).toStrictEqual(['tag1']);
+
+  operation.addTag('tag3');
   operation.deleteTagAt(0);
   expect(operation.tags).toStrictEqual(['tag3']);
 

--- a/packages/openapi-model/src/3.0.3/model/Operation.ts
+++ b/packages/openapi-model/src/3.0.3/model/Operation.ts
@@ -16,6 +16,7 @@ import type {
   OperationModelParent,
   ParameterLocation,
   ParameterModel,
+  PathItemOperationKey,
   RequestBodyModel,
   ResponseModel,
   SecurityRequirementModel,
@@ -54,6 +55,10 @@ export class Operation extends BasicNode<OperationModelParent> implements Operat
     this.deprecated = false;
     this.security = [];
     this.servers = [];
+  }
+
+  get httpMethod(): PathItemOperationKey {
+    return this.parent.getOperationKeyOrThrow(this);
   }
 
   addTag(name: string): void {

--- a/packages/openapi-model/src/3.0.3/model/PathItem.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/PathItem.test.ts
@@ -1,0 +1,45 @@
+import { OpenAPIFactory } from './OpenAPI';
+
+let openapi = OpenAPIFactory.create();
+
+beforeEach(() => {
+  openapi = OpenAPIFactory.create();
+});
+
+test('.pathUrl', () => {
+  const item = openapi.setPathItem('/hello/{uid}');
+  expect(item.pathUrl).toBe('/hello/{uid}');
+});
+
+describe('operations()', () => {
+  test('sparse', () => {
+    const pathItem = openapi.setPathItem('/health');
+    pathItem.setOperation('get');
+    pathItem.setOperation('delete');
+
+    expect(Array.from(pathItem.operations(), ([key]) => key)).toStrictEqual(['get', 'delete']);
+  });
+
+  test('sorting', () => {
+    const pathItem = openapi.setPathItem('/health');
+    pathItem.setOperation('trace');
+    pathItem.setOperation('options');
+    pathItem.setOperation('head');
+    pathItem.setOperation('delete');
+    pathItem.setOperation('patch');
+    pathItem.setOperation('get');
+    pathItem.setOperation('put');
+    pathItem.setOperation('post');
+
+    expect(Array.from(pathItem.operations(), ([key]) => key)).toStrictEqual([
+      'get',
+      'post',
+      'put',
+      'patch',
+      'delete',
+      'options',
+      'head',
+      'trace',
+    ]);
+  });
+});

--- a/packages/openapi-model/src/3.0.3/model/Paths.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Paths.test.ts
@@ -15,3 +15,26 @@ test('getItem + getItemOrThrow', () => {
   expect(paths.getItemOrThrow('/pets')).not.toBeUndefined();
   expect(() => paths.getItemOrThrow('/monsters')).toThrow();
 });
+
+test('getItemUrl() + getItemUrlOrThrow()', () => {
+  const openapi1 = paths.root;
+  const item1 = openapi1.setPathItem('/hello');
+  const item2 = openapi1.setPathItem('/world/{id}');
+
+  const openapi2 = OpenAPIFactory.create();
+  const item3 = openapi2.setPathItem('/hello');
+
+  expect(openapi1.paths.getItemUrl(item1)).toBe('/hello');
+  expect(openapi1.paths.getItemUrl(item2)).toBe('/world/{id}');
+  expect(openapi1.paths.getItemUrl(item3)).toBeUndefined();
+
+  expect(openapi2.paths.getItemUrl(item1)).toBeUndefined();
+  expect(() => openapi2.paths.getItemUrlOrThrow(item2)).toThrow();
+  expect(openapi2.paths.getItemUrlOrThrow(item3)).toBe('/hello');
+});
+
+test('getItemUrl() + mutations', () => {
+  const item = paths.root.setPathItem('/hello');
+  paths.root.deletePathItem('/hello');
+  expect(paths.getItemUrl(item)).toBeUndefined();
+});

--- a/packages/openapi-model/src/3.0.3/model/Paths.ts
+++ b/packages/openapi-model/src/3.0.3/model/Paths.ts
@@ -1,5 +1,7 @@
 import assert from 'assert';
 
+import { BidiMap } from '../../BidiMap';
+
 import { BasicNode } from './BasicNode';
 
 import type { PathItemModel, PathsModel, PathsModelParent } from './types';
@@ -9,11 +11,11 @@ import type { ParametrisedURLString } from '@fresha/api-tools-core';
  * @see https://spec.openapis.org/oas/v3.0.3#paths-object
  */
 export class Paths extends BasicNode<PathsModelParent> implements PathsModel {
-  readonly items: Map<ParametrisedURLString, PathItemModel>;
+  readonly items: BidiMap<ParametrisedURLString, PathItemModel>;
 
   constructor(parent: PathsModelParent) {
     super(parent);
-    this.items = new Map<ParametrisedURLString, PathItemModel>();
+    this.items = new BidiMap<ParametrisedURLString, PathItemModel>();
   }
 
   getItem(url: ParametrisedURLString): PathItemModel | undefined {
@@ -22,7 +24,17 @@ export class Paths extends BasicNode<PathsModelParent> implements PathsModel {
 
   getItemOrThrow(url: ParametrisedURLString): PathItemModel {
     const result = this.getItem(url);
-    assert(result);
+    assert(result, `Cannot find path item for '${url}' URL`);
+    return result;
+  }
+
+  getItemUrl(pathItem: PathItemModel): string | undefined {
+    return this.items.getKey(pathItem);
+  }
+
+  getItemUrlOrThrow(pathItem: PathItemModel): string {
+    const result = this.getItemUrl(pathItem);
+    assert(result, `Cannot find URL assigned to path item`);
     return result;
   }
 
@@ -50,6 +62,7 @@ export class Paths extends BasicNode<PathsModelParent> implements PathsModel {
   }
 
   set(key: string, value: PathItemModel): this {
+    assert(value.parent === this, `Path item at ${key} does not belong to the paths object`);
     this.items.set(key, value);
     return this;
   }

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -552,6 +552,11 @@ export interface OperationModel
   readonly security: ReadonlyArray<SecurityRequirementModel>;
   readonly servers: ReadonlyArray<ServerModel>;
 
+  /**
+   * HTTP method this operation is associated with, within its path item.
+   */
+  readonly httpMethod: PathItemOperationKey;
+
   addTag(name: string): void;
   deleteTag(name: string): void;
   deleteTagAt(index: number): void;
@@ -617,6 +622,35 @@ export interface PathItemModel extends TreeNode<PathItemModelParent>, Specificat
   readonly servers: ServerModel[];
   readonly parameters: ParameterModel[];
 
+  /**
+   * URL associated with this path item in item's parent collection.
+   */
+  readonly pathUrl: ParametrisedURLString;
+
+  /**
+   * Returns operation associated with given HTTP method. Returns undefined
+   * if there is no such an operation.
+   */
+  getOperation(key: PathItemOperationKey): OperationModel | undefined;
+
+  /**
+   * Returns operation associated with given HTTP method. Throws an exception
+   * if there is no such an operation.
+   */
+  getOperationOrThrow(key: PathItemOperationKey): OperationModel;
+
+  /**
+   * Returns HTTP method, associated with given operation. If the operation does
+   * not belong to this path item, returns undefined.
+   */
+  getOperationKey(operation: OperationModel): PathItemOperationKey | undefined;
+
+  /**
+   * Returns HTTP method, associated with given operation. If the operation does
+   * not belong to this path item, throws an error.
+   */
+  getOperationKeyOrThrow(operation: OperationModel): PathItemOperationKey;
+
   operations(): IterableIterator<[PathItemOperationKey, OperationModel]>;
 
   setOperation(method: PathItemOperationKey): OperationModel;
@@ -642,6 +676,18 @@ export interface PathsModel
     SpecificationExtensionsModel {
   getItem(url: ParametrisedURLString): PathItemModel | undefined;
   getItemOrThrow(url: ParametrisedURLString): PathItemModel;
+
+  /**
+   * Returns an URL associated with given path item. If the item is not
+   * in this paths collection, return undefined.
+   */
+  getItemUrl(pathItem: PathItemModel): ParametrisedURLString | undefined;
+
+  /**
+   * Returns an URL associated with given path item. If the item is not
+   * in this paths collection, throws an exception.
+   */
+  getItemUrlOrThrow(pathItem: PathItemModel): ParametrisedURLString;
 }
 
 export type SecuritySchemaModelParent = ComponentsModel;
@@ -798,13 +844,25 @@ export type CallbackModelParent = ComponentsModel | OperationModel;
  * @see https://spec.openapis.org/oas/v3.0.3#callback-object
  */
 export interface CallbackModel extends TreeNode<CallbackModelParent>, SpecificationExtensionsModel {
-  readonly paths: ReadonlyMap<string, PathItemModel>;
+  readonly paths: ReadonlyMap<ParametrisedURLString, PathItemModel>;
 
-  getPathItem(key: string): PathItemModel | undefined;
-  getPathItemOrThrow(key: string): PathItemModel;
-  setPathItem(key: string): PathItemModel;
-  deletePathItem(key: string): void;
+  getPathItem(key: ParametrisedURLString): PathItemModel | undefined;
+  getPathItemOrThrow(key: ParametrisedURLString): PathItemModel;
+  setPathItem(key: ParametrisedURLString): PathItemModel;
+  deletePathItem(key: ParametrisedURLString): void;
   clearPathItems(): void;
+
+  /**
+   * Returns an URL associated with given path item. If the item is not
+   * in this paths collection, return undefined.
+   */
+  getItemUrl(pathItem: PathItemModel): ParametrisedURLString | undefined;
+
+  /**
+   * Returns an URL associated with given path item. If the item is not
+   * in this paths collection, throws an exception.
+   */
+  getItemUrlOrThrow(pathItem: PathItemModel): ParametrisedURLString;
 }
 
 export type ComponentsModelParent = OpenAPIModel;

--- a/packages/openapi-model/src/BidiMap.test.ts
+++ b/packages/openapi-model/src/BidiMap.test.ts
@@ -1,0 +1,67 @@
+import { BidiMap } from './BidiMap';
+
+test('querying', () => {
+  const value1 = {};
+  const value2 = {};
+
+  const map = new BidiMap();
+  map.set('key1', value1);
+  map.set('key2', value2);
+
+  expect(map.get('key1')).toBe(value1);
+  expect(map.getKey(value2)).toBe('key2');
+
+  expect(map.has('key2'));
+  expect(map.hasValue(value1));
+});
+
+test('mutation', () => {
+  const value1 = {};
+  const value2 = {};
+
+  const map = new BidiMap();
+  map.set('key1', value1);
+  map.set('key2', value2);
+
+  expect(map.delete('key3')).toBeFalsy();
+  expect(map.deleteValue({})).toBeFalsy();
+
+  expect(map.delete('key1')).toBeTruthy();
+  expect(map.size).toBe(1);
+  expect(map.hasValue(value1)).toBeFalsy();
+
+  expect(map.deleteValue(value2)).toBeTruthy();
+  expect(map.size).toBe(0);
+  expect(map.has('key2')).toBeFalsy();
+
+  map.set('key3', {});
+  map.clear();
+  expect(map.size).toBe(0);
+});
+
+test('iteration', () => {
+  const value2 = {};
+
+  const map = new BidiMap();
+  map.set(1, 2);
+  map.set('2', value2);
+
+  const callback = jest.fn();
+  const thisArg = {};
+
+  map.forEach(callback, thisArg);
+
+  const callbackCalls = callback.mock.calls as unknown[][];
+  expect(callbackCalls.length).toBe(2);
+
+  expect(callbackCalls[0].length).toBe(3);
+  expect(callbackCalls[0][0]).toStrictEqual(2);
+  expect(callbackCalls[0][1]).toStrictEqual(1);
+  expect(callbackCalls[0][2]).toBeInstanceOf(Map);
+
+  expect(callbackCalls[1][0]).toStrictEqual(value2);
+  expect(callbackCalls[1][1]).toStrictEqual('2');
+  expect(callbackCalls[1][2]).toBeInstanceOf(Map);
+
+  expect(Array.from(map.values())).toStrictEqual([2, value2]);
+});

--- a/packages/openapi-model/src/BidiMap.ts
+++ b/packages/openapi-model/src/BidiMap.ts
@@ -1,0 +1,87 @@
+/**
+ * Bi-directional map. It is a map which also provides mapping from values to keys.
+ */
+export class BidiMap<K, V> implements Map<K, V> {
+  private items: Map<K, V>;
+  private inverted: Map<V, K>;
+
+  constructor() {
+    this.items = new Map<K, V>();
+    this.inverted = new Map<V, K>();
+  }
+
+  clear(): void {
+    this.items.clear();
+    this.inverted.clear();
+  }
+
+  delete(key: K): boolean {
+    const value = this.items.get(key);
+    if (value !== undefined) {
+      this.items.delete(key);
+      this.inverted.delete(value);
+      return true;
+    }
+    return false;
+  }
+
+  deleteValue(value: V): boolean {
+    const key = this.inverted.get(value);
+    if (key) {
+      this.items.delete(key);
+      this.inverted.delete(value);
+      return true;
+    }
+    return false;
+  }
+
+  forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: unknown): void {
+    this.items.forEach(callbackfn, thisArg);
+  }
+
+  get(key: K): V | undefined {
+    return this.items.get(key);
+  }
+
+  getKey(value: V): K | undefined {
+    return this.inverted.get(value);
+  }
+
+  has(key: K): boolean {
+    return this.items.has(key);
+  }
+
+  hasValue(value: V): boolean {
+    return this.inverted.has(value);
+  }
+
+  set(key: K, value: V): this {
+    this.items.set(key, value);
+    this.inverted.set(value, key);
+    return this;
+  }
+
+  get size(): number {
+    return this.items.size;
+  }
+
+  entries(): IterableIterator<[K, V]> {
+    return this.items.entries();
+  }
+
+  keys(): IterableIterator<K> {
+    return this.items.keys();
+  }
+
+  values(): IterableIterator<V> {
+    return this.items.values();
+  }
+
+  [Symbol.iterator](): IterableIterator<[K, V]> {
+    return this.items.entries();
+  }
+
+  get [Symbol.toStringTag](): string {
+    return this.items[Symbol.toStringTag];
+  }
+}


### PR DESCRIPTION
## Motivation and Context

This PR addresses https://github.com/fresha/api-tools/issues/56 and https://github.com/fresha/api-tools/issues/44.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

- added `httpMethod` property to `OperationModel`.
- added `pathUrl` property to `PathItemModel`
- added `getOperationKey()` / `getOperationKeyOrThrow()` methods to `PathItemModel`
- added `getItemUrl()` / `getItemUrlOrThrow()` methods to `PathsModel` and `CallbackModel`
- added more unit tests
