### PR TITLE
Better TS definitions for JSONAPIDataDocument

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6279,7 +6279,7 @@
     },
     "packages/api-tools-core": {
       "name": "@fresha/api-tools-core",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "devDependencies": {
         "@fresha/eslint-config": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6279,7 +6279,7 @@
     },
     "packages/api-tools-core": {
       "name": "@fresha/api-tools-core",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "devDependencies": {
         "@fresha/eslint-config": "0.1.0",
@@ -6366,6 +6366,12 @@
         "typescript": "^4.7.2"
       }
     },
+    "packages/asyncapi-model/node_modules/@fresha/api-tools-core": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+      "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA==",
+      "dev": true
+    },
     "packages/asyncapi-validator": {
       "name": "@fresha/asyncapi-validator",
       "version": "0.1.0",
@@ -6425,6 +6431,11 @@
         "typescript": "^4.7.2"
       }
     },
+    "packages/ex-morph/node_modules/@fresha/api-tools-core": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+      "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
+    },
     "packages/har-extract": {
       "name": "@fresha/har-extract",
       "version": "0.1.2",
@@ -6442,6 +6453,11 @@
         "@fresha/typescript-config": "0.1.0",
         "typescript": "^4.7.2"
       }
+    },
+    "packages/har-extract/node_modules/@fresha/api-tools-core": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+      "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
     },
     "packages/json-api-codegen": {
       "name": "@fresha/json-api-codegen",
@@ -6469,6 +6485,11 @@
         "typescript": "^4.7.2"
       }
     },
+    "packages/json-api-model/node_modules/@fresha/api-tools-core": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+      "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
+    },
     "packages/json-schema-codegen": {
       "name": "@fresha/json-schema-codegen",
       "version": "0.1.0",
@@ -6493,6 +6514,11 @@
         "@fresha/typescript-config": "0.1.0",
         "typescript": "^4.7.2"
       }
+    },
+    "packages/json-schema-model/node_modules/@fresha/api-tools-core": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+      "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
     },
     "packages/openapi-codegen-cli": {
       "name": "@fresha/openapi-codegen-cli",
@@ -6534,6 +6560,11 @@
         "typescript": "^4.7.2"
       }
     },
+    "packages/openapi-codegen-client-fetch/node_modules/@fresha/api-tools-core": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+      "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
+    },
     "packages/openapi-codegen-client-fresha": {
       "name": "@fresha/openapi-codegen-client-fresha",
       "version": "0.2.0",
@@ -6551,6 +6582,11 @@
         "@fresha/typescript-config": "0.1.0",
         "typescript": "^4.7.2"
       }
+    },
+    "packages/openapi-codegen-client-fresha/node_modules/@fresha/api-tools-core": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+      "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
     },
     "packages/openapi-codegen-server-elixir": {
       "name": "@fresha/openapi-codegen-server-elixir",
@@ -6571,6 +6607,11 @@
         "@fresha/typescript-config": "0.1.0",
         "typescript": "^4.7.2"
       }
+    },
+    "packages/openapi-codegen-server-elixir/node_modules/@fresha/api-tools-core": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+      "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
     },
     "packages/openapi-codegen-server-mock": {
       "name": "@fresha/openapi-codegen-server-mock",
@@ -6620,6 +6661,11 @@
         "reflect-metadata": "^0.1.13"
       }
     },
+    "packages/openapi-codegen-server-nestjs/node_modules/@fresha/api-tools-core": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+      "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
+    },
     "packages/openapi-codegen-utils": {
       "name": "@fresha/openapi-codegen-utils",
       "version": "0.1.0",
@@ -6636,6 +6682,11 @@
         "@fresha/typescript-config": "0.1.0",
         "typescript": "^4.7.2"
       }
+    },
+    "packages/openapi-codegen-utils/node_modules/@fresha/api-tools-core": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+      "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
     },
     "packages/openapi-diff": {
       "name": "@fresha/openapi-diff",
@@ -6675,6 +6726,11 @@
         "deep-object-diff": "^1.1.7",
         "typescript": "^4.7.2"
       }
+    },
+    "packages/openapi-model/node_modules/@fresha/api-tools-core": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+      "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
     },
     "packages/openapi-validator": {
       "name": "@fresha/openapi-validator",
@@ -7353,6 +7409,14 @@
         "@fresha/jest-config": "0.1.0",
         "@fresha/typescript-config": "0.1.0",
         "typescript": "^4.7.2"
+      },
+      "dependencies": {
+        "@fresha/api-tools-core": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+          "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA==",
+          "dev": true
+        }
       }
     },
     "@fresha/asyncapi-validator": {
@@ -7452,6 +7516,13 @@
         "@fresha/typescript-config": "0.1.0",
         "memfs": "^3.4.9",
         "typescript": "^4.7.2"
+      },
+      "dependencies": {
+        "@fresha/api-tools-core": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+          "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
+        }
       }
     },
     "@fresha/har-extract": {
@@ -7463,6 +7534,13 @@
         "@fresha/typescript-config": "0.1.0",
         "typescript": "^4.7.2",
         "yargs": "^17.5.1"
+      },
+      "dependencies": {
+        "@fresha/api-tools-core": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+          "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
+        }
       }
     },
     "@fresha/jest-config": {
@@ -7499,6 +7577,13 @@
         "@fresha/openapi-model": "0.4.0",
         "@fresha/typescript-config": "0.1.0",
         "typescript": "^4.7.2"
+      },
+      "dependencies": {
+        "@fresha/api-tools-core": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+          "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
+        }
       }
     },
     "@fresha/json-schema-codegen": {
@@ -7518,6 +7603,13 @@
         "@fresha/jest-config": "0.1.0",
         "@fresha/typescript-config": "0.1.0",
         "typescript": "^4.7.2"
+      },
+      "dependencies": {
+        "@fresha/api-tools-core": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+          "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
+        }
       }
     },
     "@fresha/openapi-codegen-cli": {
@@ -7547,6 +7639,13 @@
         "@fresha/typescript-config": "0.1.0",
         "ts-morph": "^16.0.0",
         "typescript": "^4.7.2"
+      },
+      "dependencies": {
+        "@fresha/api-tools-core": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+          "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
+        }
       }
     },
     "@fresha/openapi-codegen-client-fresha": {
@@ -7561,6 +7660,13 @@
         "ts-morph": "^16.0.0",
         "typescript": "^4.7.2",
         "winston": "^3.8.2"
+      },
+      "dependencies": {
+        "@fresha/api-tools-core": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+          "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
+        }
       }
     },
     "@fresha/openapi-codegen-server-elixir": {
@@ -7577,6 +7683,13 @@
         "@fresha/typescript-config": "0.1.0",
         "memfs": "^3.4.7",
         "typescript": "^4.7.2"
+      },
+      "dependencies": {
+        "@fresha/api-tools-core": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+          "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
+        }
       }
     },
     "@fresha/openapi-codegen-server-mock": {
@@ -7617,6 +7730,13 @@
         "typescript": "^4.7.2",
         "winston": "^3.8.2",
         "yaml": "^2.1.1"
+      },
+      "dependencies": {
+        "@fresha/api-tools-core": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+          "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
+        }
       }
     },
     "@fresha/openapi-codegen-utils": {
@@ -7630,6 +7750,13 @@
         "ts-morph": "^16.0.0",
         "typescript": "^4.7.2",
         "winston": "^3.8.2"
+      },
+      "dependencies": {
+        "@fresha/api-tools-core": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+          "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
+        }
       }
     },
     "@fresha/openapi-diff": {
@@ -7661,6 +7788,13 @@
         "deep-object-diff": "^1.1.7",
         "typescript": "^4.7.2",
         "yaml": "^2.1.1"
+      },
+      "dependencies": {
+        "@fresha/api-tools-core": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
+          "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
+        }
       }
     },
     "@fresha/openapi-validator": {

--- a/packages/api-tools-core/package.json
+++ b/packages/api-tools-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/api-tools-core",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Core project functionality",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/api-tools-core/package.json
+++ b/packages/api-tools-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/api-tools-core",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Core project functionality",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/api-tools-core/src/typeGuards.test.ts
+++ b/packages/api-tools-core/src/typeGuards.test.ts
@@ -6,7 +6,7 @@ import {
   isJSONValueArray,
 } from './typeGuards';
 
-import type { JSONAPIDocument } from './types';
+import type { JSONAPIDocument, JSONAPIServerResource } from './types';
 
 test('isJSONObject', () => {
   expect(isJSONObject({})).toBeTruthy();
@@ -28,7 +28,7 @@ test('isJSONRef', () => {
 });
 
 test('JSON:API document types', () => {
-  const doc1: JSONAPIDocument = {
+  const doc1: JSONAPIDocument<JSONAPIServerResource[]> = {
     jsonapi: { version: '1.0' },
     data: [],
   };

--- a/packages/api-tools-core/src/typeGuards.ts
+++ b/packages/api-tools-core/src/typeGuards.ts
@@ -2,6 +2,7 @@ import type {
   JSONAPIDataDocument,
   JSONAPIDocument,
   JSONAPIErrorDocument,
+  JSONAPIPrimaryDocumentData,
   JSONObject,
   JSONRef,
   JSONValue,
@@ -16,8 +17,10 @@ export const isJSONValueArray = (value: JSONValue | JSONValue[] | null): value i
 export const isJSONRef = (arg: unknown): arg is JSONRef =>
   arg != null && typeof arg === 'object' && typeof (arg as JSONObject).$ref === 'string';
 
-export const isJSONAPIDataDocument = (doc: JSONAPIDocument): doc is JSONAPIDataDocument =>
-  'data' in doc;
+export const isJSONAPIDataDocument = <TPrimaryData extends JSONAPIPrimaryDocumentData>(
+  doc: JSONAPIDocument<TPrimaryData>,
+): doc is JSONAPIDataDocument<TPrimaryData> => 'data' in doc;
 
-export const isJSONAPIErrorDocument = (doc: JSONAPIDocument): doc is JSONAPIErrorDocument =>
-  'errors' in doc;
+export const isJSONAPIErrorDocument = <TPrimaryData extends JSONAPIPrimaryDocumentData>(
+  doc: JSONAPIDocument<TPrimaryData>,
+): doc is JSONAPIErrorDocument => 'errors' in doc;

--- a/packages/api-tools-core/src/types.ts
+++ b/packages/api-tools-core/src/types.ts
@@ -140,7 +140,11 @@ export type JSONAPIMeta = JSONObject;
 export type JSONAPILink = string | { href: string; meta?: JSONAPIMeta };
 
 /**
- * Represents a resource ID.
+ * Represents a resource ID. `JSONAPIResourceID` must either be a string or a string literal.
+ *
+ * @example
+ * JSONAPIResourceID // generic resource ID object
+ * JSONAPIResourceID<'employees'> // resource ID for specific resource
  *
  * @typeParam TResourceType resource type string. To identify specific resource,
  *  pass a string literal.
@@ -407,12 +411,15 @@ interface JSONAPIDocumentBase {
  * @see https://jsonapi.org/format/#document-top-level
  */
 export interface JSONAPIDataDocument<
-  TPrimaryData extends JSONAPIServerResource | JSONAPIResourceID | null =
+  TPrimaryData extends
     | JSONAPIServerResource
-    | JSONAPIResourceID,
+    | JSONAPIServerResource[]
+    | JSONAPIResourceID
+    | JSONAPIResourceID[]
+    | null = JSONAPIServerResource,
   TIncludedData extends JSONAPIServerResource = JSONAPIServerResource,
 > extends JSONAPIDocumentBase {
-  data: TPrimaryData[] | TPrimaryData | null;
+  data: TPrimaryData;
   included?: TIncludedData[];
 }
 

--- a/packages/api-tools-core/src/types.ts
+++ b/packages/api-tools-core/src/types.ts
@@ -391,6 +391,13 @@ interface JSONAPIDocumentBase {
   meta?: JSONAPIMeta;
 }
 
+export type JSONAPIPrimaryDocumentData =
+  | JSONAPIServerResource
+  | JSONAPIServerResource[]
+  | JSONAPIResourceID
+  | JSONAPIResourceID[]
+  | null;
+
 /**
  * Document that contains data.
  *
@@ -411,12 +418,7 @@ interface JSONAPIDocumentBase {
  * @see https://jsonapi.org/format/#document-top-level
  */
 export interface JSONAPIDataDocument<
-  TPrimaryData extends
-    | JSONAPIServerResource
-    | JSONAPIServerResource[]
-    | JSONAPIResourceID
-    | JSONAPIResourceID[]
-    | null = JSONAPIServerResource,
+  TPrimaryData extends JSONAPIPrimaryDocumentData = JSONAPIServerResource,
   TIncludedData extends JSONAPIServerResource = JSONAPIServerResource,
 > extends JSONAPIDocumentBase {
   data: TPrimaryData;
@@ -459,9 +461,7 @@ export interface JSONAPIErrorDocument extends JSONAPIDocumentBase {
  * @see https://jsonapi.org/format/#document-top-level
  */
 export type JSONAPIDocument<
-  TPrimaryData extends JSONAPIServerResource | JSONAPIResourceID =
-    | JSONAPIServerResource
-    | JSONAPIResourceID,
+  TPrimaryData extends JSONAPIPrimaryDocumentData = JSONAPIServerResource,
   TIncludedData extends JSONAPIServerResource = JSONAPIServerResource,
 > = JSONAPIDataDocument<TPrimaryData, TIncludedData> | JSONAPIErrorDocument;
 


### PR DESCRIPTION
## Motivation and Context

This PR improves TS types for `JSONAPIDataDocument`. Now, type of document's primary data is the same as defined.

```ts
type Doc = JSONAPIDataDocument<JSONAPIResource[]>;
type PrimaryData = Doc['data']; // resolves to JSONAPIResource[];
```

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
