### PR TITLE
Add code-morph-test-utils package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
       - run: npm run -w @fresha/asyncapi-lint --if-present build && exit 0
       - run: npm run -w @fresha/asyncapi-model --if-present build && exit 0
       - run: npm run -w @fresha/asyncapi-validator --if-present build && exit 0
+      - run: npm run -w @fresha/code-morph-test-utils --if-present build && exit 0
       - run: npm run -w @fresha/code-morph-ex --if-present build && exit 0
       - run: npm run -w @fresha/designer-app --if-present build && exit 0
       - run: npm run -w @fresha/browser-extension --if-present build && exit 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -744,6 +744,10 @@
       "resolved": "packages/code-morph-ex",
       "link": true
     },
+    "node_modules/@fresha/code-morph-test-utils": {
+      "resolved": "packages/code-morph-test-utils",
+      "link": true
+    },
     "node_modules/@fresha/designer-app": {
       "resolved": "packages/designer-app",
       "link": true
@@ -6418,6 +6422,7 @@
       }
     },
     "packages/code-morph-ex": {
+      "name": "@fresha/code-morph-ex",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -6435,6 +6440,21 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
       "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
+    },
+    "packages/code-morph-test-utils": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@fresha/jest-config": "0.1.0",
+        "jest-matcher-utils": "^29.1.2",
+        "prettier": "^2.7.1"
+      },
+      "devDependencies": {
+        "@fresha/eslint-config": "0.1.0",
+        "@fresha/typescript-config": "0.1.0",
+        "@types/jest": "^29.1.2",
+        "typescript": "^4.7.2"
+      }
     },
     "packages/designer-app": {
       "name": "@fresha/designer-app",
@@ -7558,6 +7578,18 @@
           "resolved": "https://registry.npmjs.org/@fresha/api-tools-core/-/api-tools-core-0.3.0.tgz",
           "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
         }
+      }
+    },
+    "@fresha/code-morph-test-utils": {
+      "version": "file:packages/code-morph-test-utils",
+      "requires": {
+        "@fresha/eslint-config": "0.1.0",
+        "@fresha/jest-config": "0.1.0",
+        "@fresha/typescript-config": "0.1.0",
+        "@types/jest": "^29.1.2",
+        "jest-matcher-utils": "^29.1.2",
+        "prettier": "^2.7.1",
+        "typescript": "^4.7.2"
       }
     },
     "@fresha/designer-app": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6430,8 +6430,8 @@
         "memfs": "^3.4.9"
       },
       "devDependencies": {
+        "@fresha/code-morph-test-utils": "0.1.0",
         "@fresha/eslint-config": "0.1.0",
-        "@fresha/jest-config": "0.1.0",
         "@fresha/typescript-config": "0.1.0",
         "typescript": "^4.7.2"
       }
@@ -6442,6 +6442,7 @@
       "integrity": "sha512-cmSMIG5XH9UUCqpffOrpCuJCpvniueHrYiQpa9kvGaAjFAjoU56dpk9kyumB+G+CrSSz71Ju1YfFHmNQMDQkwA=="
     },
     "packages/code-morph-test-utils": {
+      "name": "@fresha/code-morph-test-utils",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -6688,8 +6689,8 @@
         "memfs": "^3.4.7"
       },
       "devDependencies": {
+        "@fresha/code-morph-test-utils": "0.1.0",
         "@fresha/eslint-config": "0.1.0",
-        "@fresha/jest-config": "0.1.0",
         "@fresha/typescript-config": "0.1.0",
         "typescript": "^4.7.2"
       }
@@ -7566,8 +7567,8 @@
       "version": "file:packages/code-morph-ex",
       "requires": {
         "@fresha/api-tools-core": "0.3.0",
+        "@fresha/code-morph-test-utils": "0.1.0",
         "@fresha/eslint-config": "0.1.0",
-        "@fresha/jest-config": "0.1.0",
         "@fresha/typescript-config": "0.1.0",
         "memfs": "^3.4.9",
         "typescript": "^4.7.2"
@@ -7785,8 +7786,8 @@
         "@faker-js/faker": "^7.6.0",
         "@fresha/api-tools-core": "0.3.0",
         "@fresha/code-morph-ex": "^0.1.0",
+        "@fresha/code-morph-test-utils": "0.1.0",
         "@fresha/eslint-config": "0.1.0",
-        "@fresha/jest-config": "0.1.0",
         "@fresha/json-api-model": "^0.1.0",
         "@fresha/openapi-codegen-utils": "^0.1.0",
         "@fresha/openapi-model": "0.4.0",

--- a/packages/code-morph-ex/jest.config.js
+++ b/packages/code-morph-ex/jest.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@fresha/jest-config');
+module.exports = require('@fresha/code-morph-test-utils/build/jestConfig');

--- a/packages/code-morph-ex/package.json
+++ b/packages/code-morph-ex/package.json
@@ -46,8 +46,8 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "@fresha/code-morph-test-utils": "0.1.0",
     "@fresha/eslint-config": "0.1.0",
-    "@fresha/jest-config": "0.1.0",
     "@fresha/typescript-config": "0.1.0",
     "typescript": "^4.7.2"
   },

--- a/packages/code-morph-ex/src/SourceFile.test.ts
+++ b/packages/code-morph-ex/src/SourceFile.test.ts
@@ -1,5 +1,6 @@
 import { Project } from './Project';
-import { poorMansElixirFormat } from './testHelpers';
+
+import '@fresha/code-morph-test-utils/build/matchers';
 
 test('code writing', () => {
   const sourceFile = new Project({
@@ -50,33 +51,31 @@ test('code writing', () => {
     });
   });
 
-  expect(sourceFile.getText()).toBe(
-    poorMansElixirFormat(`
-      defmodule ShopkeeperWeb.BasketController do
-        @moduledoc false
+  expect(sourceFile).toHaveFormattedElixirText(`
+    defmodule ShopkeeperWeb.BasketController do
+      @moduledoc false
 
-        use ShopkeeperWeb, :controller
-        alias Shopkeeper.Actions.Storefront
-        alias ShopkeeperWeb.Helpers.StorefrontSession
+      use ShopkeeperWeb, :controller
+      alias Shopkeeper.Actions.Storefront
+      alias ShopkeeperWeb.Helpers.StorefrontSession
 
-        def index(conn, params) do
-          with {:ok, shop_slug} <- parse_params(params),
-               {:ok, shop} <- Shopkeeper.Shops.impl().get_by_slug(shop_slug) do
-            categories = Shopkeeper.Catalog.impl().list_storefront_categories(shop)
-            render(conn, %{categories: categories})
-          else
-            {:error, :invalid_parameters, params} ->
-              {:error, :invalid_parameters, params}
+      def index(conn, params) do
+        with {:ok, shop_slug} <- parse_params(params),
+             {:ok, shop} <- Shopkeeper.Shops.impl().get_by_slug(shop_slug) do
+          categories = Shopkeeper.Catalog.impl().list_storefront_categories(shop)
+          render(conn, %{categories: categories})
+        else
+          {:error, :invalid_parameters, params} ->
+            {:error, :invalid_parameters, params}
 
-            {:error, :not_found} ->
-              {:error, :not_found}
-          end
-        end
-
-        defp parse_index_params(params) do
-          flat_parse(params, shop_slug: [:string, :required])
+          {:error, :not_found} ->
+            {:error, :not_found}
         end
       end
-    `),
-  );
+
+      defp parse_index_params(params) do
+        flat_parse(params, shop_slug: [:string, :required])
+      end
+    end
+  `);
 });

--- a/packages/code-morph-ex/src/index.ts
+++ b/packages/code-morph-ex/src/index.ts
@@ -1,4 +1,3 @@
 export { Project } from './Project';
 export { SourceFile } from './SourceFile';
-export * from './testHelpers';
 export * from './utils';

--- a/packages/code-morph-ex/src/testHelpers.ts
+++ b/packages/code-morph-ex/src/testHelpers.ts
@@ -1,8 +1,0 @@
-export const poorMansElixirFormat = (s: string): string => {
-  const lines = s.replace(/(^\\n+)|(\s+$)/g, '').split('\n');
-  if (!lines[0]) {
-    lines.shift();
-  }
-  const indent = lines[0].search(/\S/);
-  return lines.map(line => line.slice(indent)).join('\n');
-};

--- a/packages/code-morph-test-utils/.eslintrc
+++ b/packages/code-morph-test-utils/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "extends": ["@fresha"],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "project": ["./tsconfig.eslint.json"]
+  }
+}

--- a/packages/code-morph-test-utils/jest.config.js
+++ b/packages/code-morph-test-utils/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@fresha/jest-config');

--- a/packages/code-morph-test-utils/package.json
+++ b/packages/code-morph-test-utils/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@fresha/code-morph-test-utils",
+  "version": "0.1.0",
+  "description": "Testing utilites for code morphers",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "build:watch": "tsc --watch",
+    "check": "run-s lint test",
+    "check:fix": "run-s lint:fix test",
+    "clean": "rimraf ./build",
+    "eslint": "eslint ./src",
+    "eslint:fix": "eslint ./src --fix",
+    "lint": "run-s eslint typecheck",
+    "lint:fix": "run-s eslint:fix typecheck",
+    "prebuild": "npm run clean",
+    "prebuild:watch": "npm run clean",
+    "test": "jest --passWithNoTests",
+    "typecheck": "tsc --noEmit"
+  },
+  "keywords": [
+    "code morphing",
+    "testing",
+    "Jest"
+  ],
+  "author": "Fresha Engineering",
+  "contributors": [
+    {
+      "name": "Andriy Mykulyak",
+      "email": "andriy@fresha.com",
+      "url": "https://github.com/mykulyak"
+    }
+  ],
+  "maintainers": [
+    {
+      "name": "Andriy Mykulyak",
+      "email": "andriy@fresha.com",
+      "url": "https://github.com/mykulyak"
+    }
+  ],
+  "license": "MIT",
+  "devDependencies": {
+    "@fresha/eslint-config": "0.1.0",
+    "@fresha/typescript-config": "0.1.0",
+    "@types/jest": "^29.1.2",
+    "typescript": "^4.7.2"
+  },
+  "dependencies": {
+    "@fresha/jest-config": "0.1.0",
+    "jest-matcher-utils": "^29.1.2",
+    "prettier": "^2.7.1"
+  }
+}

--- a/packages/code-morph-test-utils/src/elixir.ts
+++ b/packages/code-morph-test-utils/src/elixir.ts
@@ -1,0 +1,8 @@
+export const poorMansElixirFormat = (s: string): string => {
+  const lines = s.replace(/(^\\n+)|(\s+$)/g, '').split('\n');
+  if (!lines[0]) {
+    lines.shift();
+  }
+  const indent = lines[0].search(/\S/);
+  return lines.map(line => line.slice(indent)).join('\n');
+};

--- a/packages/code-morph-test-utils/src/index.ts
+++ b/packages/code-morph-test-utils/src/index.ts
@@ -1,0 +1,1 @@
+export * from './elixir';

--- a/packages/code-morph-test-utils/src/jestConfig.ts
+++ b/packages/code-morph-test-utils/src/jestConfig.ts
@@ -1,0 +1,8 @@
+import path from 'path';
+
+import baseConfig from '@fresha/jest-config/build/index';
+
+export default {
+  ...baseConfig,
+  setupFilesAfterEnv: [path.join(__dirname, 'setupEnv.js')],
+};

--- a/packages/code-morph-test-utils/src/matchers.ts
+++ b/packages/code-morph-test-utils/src/matchers.ts
@@ -1,0 +1,84 @@
+import {
+  MatcherHintOptions,
+  matcherHint,
+  printDiffOrStringify,
+  printExpected,
+  printReceived,
+  stringify,
+} from 'jest-matcher-utils';
+import * as prettier from 'prettier';
+
+import { poorMansElixirFormat } from './elixir';
+
+const EXPECTED_LABEL = 'Expected';
+const RECEIVED_LABEL = 'Received';
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace, @typescript-eslint/no-unused-vars
+  namespace jest {
+    interface Matchers<R> {
+      toHaveFormattedElixirTest(test: string): R;
+      toHaveFormattedTypeScriptText(text: string): R;
+    }
+  }
+}
+
+type SourceFile = {
+  getText(): string;
+};
+
+const compareText = (
+  received: string,
+  expected: string,
+  matcherName: string,
+): jest.CustomMatcherResult => {
+  const matcherOptions: MatcherHintOptions = {
+    comment: 'deep equality',
+  };
+  const pass = received === expected;
+
+  const message = pass
+    ? () =>
+        // eslint-disable-next-line prefer-template
+        matcherHint(matcherName, undefined, undefined, matcherOptions) +
+        '\n\n' +
+        `Expected: not ${printExpected(expected)}\n` +
+        (stringify(expected) !== stringify(received)
+          ? `Received:     ${printReceived(received)}`
+          : '')
+    : () =>
+        // eslint-disable-next-line prefer-template
+        matcherHint(matcherName, undefined, undefined, matcherOptions) +
+        '\n\n' +
+        printDiffOrStringify(expected, received, EXPECTED_LABEL, RECEIVED_LABEL, true);
+
+  return { message, pass };
+};
+
+export const createMatchers = () => ({
+  toHaveFormattedElixirText: (
+    sourceFile: SourceFile,
+    expectedText: string,
+  ): jest.CustomMatcherResult => {
+    return compareText(
+      poorMansElixirFormat(sourceFile.getText()),
+      poorMansElixirFormat(expectedText),
+      'toHaveFormattedElixirText',
+    );
+  },
+
+  toHaveFormattedTypeScriptText: (
+    sourceFile: SourceFile,
+    expectedText: string,
+  ): jest.CustomMatcherResult => {
+    const options: prettier.Options = {
+      parser: 'typescript',
+      singleQuote: true,
+      trailingComma: 'all',
+    };
+    const received = prettier.format(sourceFile.getText(), options);
+    const expected = prettier.format(expectedText, options);
+
+    return compareText(received, expected, 'toHaveFormattedTypeScriptText');
+  },
+});

--- a/packages/code-morph-test-utils/src/matchers.ts
+++ b/packages/code-morph-test-utils/src/matchers.ts
@@ -17,7 +17,7 @@ declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace, @typescript-eslint/no-unused-vars
   namespace jest {
     interface Matchers<R> {
-      toHaveFormattedElixirTest(test: string): R;
+      toHaveFormattedElixirText(test: string): R;
       toHaveFormattedTypeScriptText(text: string): R;
     }
   }

--- a/packages/code-morph-test-utils/src/setupEnv.ts
+++ b/packages/code-morph-test-utils/src/setupEnv.ts
@@ -1,0 +1,3 @@
+import { createMatchers } from './matchers';
+
+expect.extend(createMatchers());

--- a/packages/code-morph-test-utils/tsconfig.eslint.json
+++ b/packages/code-morph-test-utils/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": []
+}

--- a/packages/code-morph-test-utils/tsconfig.json
+++ b/packages/code-morph-test-utils/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@fresha/typescript-config",
+  "compilerOptions": {
+    "outDir": "./build",
+    "rootDir": "./src"
+  },
+  "include": [
+    "./src/**/*.ts"
+  ],
+  "exclude": [
+    "**/*.test.ts"
+  ]
+}

--- a/packages/openapi-codegen-server-elixir/jest.config.js
+++ b/packages/openapi-codegen-server-elixir/jest.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@fresha/jest-config');
+module.exports = require('@fresha/code-morph-test-utils/build/jestConfig');

--- a/packages/openapi-codegen-server-elixir/package.json
+++ b/packages/openapi-codegen-server-elixir/package.json
@@ -55,8 +55,8 @@
     "memfs": "^3.4.7"
   },
   "devDependencies": {
+    "@fresha/code-morph-test-utils": "0.1.0",
     "@fresha/eslint-config": "0.1.0",
-    "@fresha/jest-config": "0.1.0",
     "@fresha/typescript-config": "0.1.0",
     "typescript": "^4.7.2"
   }

--- a/packages/openapi-codegen-server-elixir/src/parts/Controller.test.ts
+++ b/packages/openapi-codegen-server-elixir/src/parts/Controller.test.ts
@@ -1,4 +1,3 @@
-import { poorMansElixirFormat } from '@fresha/code-morph-ex';
 import {
   addResourceRelationship,
   MEDIA_TYPE_JSON_API,
@@ -9,6 +8,8 @@ import { SchemaFactory } from '@fresha/openapi-model/build/3.0.3';
 import { makeContext } from '../testHelpers';
 
 import { Controller } from './Controller';
+
+import '@fresha/code-morph-test-utils/build/matchers';
 
 test('parameter-less action, minimal implementation', () => {
   const context = makeContext('awesome_web');
@@ -21,8 +22,7 @@ test('parameter-less action, minimal implementation', () => {
   controller.collectData(pathItem);
   controller.generateCode();
 
-  expect(controller.sourceFile.getText()).toBe(
-    poorMansElixirFormat(`
+  expect(controller.sourceFile).toHaveFormattedElixirText(`
     defmodule AwesoneWeb.EmployeesController do
       @moduledoc false
 
@@ -38,8 +38,7 @@ test('parameter-less action, minimal implementation', () => {
         render(conn)
       end
     end
-  `),
-  );
+  `);
 });
 
 test('ID parameter leads to generating parse_XXXX_param function, as well as error handling', () => {
@@ -55,8 +54,7 @@ test('ID parameter leads to generating parse_XXXX_param function, as well as err
   controller.collectData(pathItem);
   controller.generateCode();
 
-  expect(controller.sourceFile.getText()).toBe(
-    poorMansElixirFormat(`
+  expect(controller.sourceFile).toHaveFormattedElixirText(`
     defmodule EmployeeController do
       @moduledoc false
 
@@ -90,8 +88,7 @@ test('ID parameter leads to generating parse_XXXX_param function, as well as err
         )
       end
     end
-  `),
-  );
+  `);
 });
 
 test('request body leads to generating parse_XXXX_conn function, as well as error handling', () => {
@@ -128,53 +125,51 @@ test('request body leads to generating parse_XXXX_conn function, as well as erro
   // :decimal
   // :email
   // trim options for :string
-  expect(controller.sourceFile.getText()).toBe(
-    poorMansElixirFormat(`
-      defmodule AwesomeWeb.ProfileController do
-        @moduledoc false
+  expect(controller.sourceFile).toHaveFormattedElixirText(`
+    defmodule AwesomeWeb.ProfileController do
+      @moduledoc false
 
-        use AwesomeWeb, :controller
+      use AwesomeWeb, :controller
 
-        action_fallback(AwesomeWeb.FallbackController)
+      action_fallback(AwesomeWeb.FallbackController)
 
-        # add aliases here
+      # add aliases here
 
-        def update(conn, _params) do
-          with {:ok, parsed_opts} <- parse_update_conn(conn) do
-            # TODO this is the part you need to implement by yourself
-            # TODO evaluate extra arguments, then pass them to render()
-            render(conn)
-          else
-            {:error, :invalid_parameters, params} ->
-              {:error, :invalid_parameters, params}
+      def update(conn, _params) do
+        with {:ok, parsed_opts} <- parse_update_conn(conn) do
+          # TODO this is the part you need to implement by yourself
+          # TODO evaluate extra arguments, then pass them to render()
+          render(conn)
+        else
+          {:error, :invalid_parameters, params} ->
+            {:error, :invalid_parameters, params}
 
-            {:error, :invalid_pointers, pointers} ->
-              {:error, :invalid_parameters, pointers}
+          {:error, :invalid_pointers, pointers} ->
+            {:error, :invalid_parameters, pointers}
 
-            {:error, :not_found} ->
-              {:error, :not_found}
-          end
-        end
-
-        defp parse_update_conn(conn) do
-          parse(
-            conn.assigns[:doc],
-            id: [:id, :required],
-            attributes: %{
-              name: [:string, :required],
-              age: [{:integer, min: 18, max: 200}, :required],
-              weight: :float,
-              birth_date: :date,
-              score: :float,
-              gender: [:string, :required, {:contain, ~w{male female other}}],
-            },
-            relationships: %{
-              location: [:resource_id, :required],
-              employee: :resource_id,
-            },
-          )
+          {:error, :not_found} ->
+            {:error, :not_found}
         end
       end
-    `),
-  );
+
+      defp parse_update_conn(conn) do
+        parse(
+          conn.assigns[:doc],
+          id: [:id, :required],
+          attributes: %{
+            name: [:string, :required],
+            age: [{:integer, min: 18, max: 200}, :required],
+            weight: :float,
+            birth_date: :date,
+            score: :float,
+            gender: [:string, :required, {:contain, ~w{male female other}}],
+          },
+          relationships: %{
+            location: [:resource_id, :required],
+            employee: :resource_id,
+          },
+        )
+      end
+    end
+  `);
 });

--- a/packages/openapi-codegen-server-elixir/src/parts/Resource.test.ts
+++ b/packages/openapi-codegen-server-elixir/src/parts/Resource.test.ts
@@ -1,5 +1,4 @@
 import { titleCase } from '@fresha/api-tools-core';
-import { poorMansElixirFormat } from '@fresha/code-morph-ex';
 import {
   addResourceAttributes,
   addResourceRelationship,
@@ -11,6 +10,8 @@ import { makeTestingContext } from '../testHelpers';
 import { Resource } from './Resource';
 
 import type { SchemaModel } from '@fresha/openapi-model/build/3.0.3';
+
+import '@fresha/code-morph-test-utils/build/matchers';
 
 const makeResource = (
   resourceType: string,
@@ -43,23 +44,21 @@ test('for schema-less resources, only link/1 is generated', () => {
   resource.collectData();
   resource.generateCode();
 
-  expect(resource.sourceFile.getText()).toBe(
-    poorMansElixirFormat(`
-      defmodule ApiToolsWeb.SchemaLessResource do
-        @moduledoc false
+  expect(resource.sourceFile).toHaveFormattedElixirText(`
+    defmodule ApiToolsWeb.SchemaLessResource do
+      @moduledoc false
 
-        @resource_type "schema-less"
-        use Jabbax.Document
+      @resource_type "schema-less"
+      use Jabbax.Document
 
-        def link(config) do
-          %ResourceId{
-            type: @resource_type,
-            id: config.id,
-          }
-        end
+      def link(config) do
+        %ResourceId{
+          type: @resource_type,
+          id: config.id,
+        }
       end
-    `),
-  );
+    end
+  `);
 });
 
 test('empty resource', () => {
@@ -68,32 +67,30 @@ test('empty resource', () => {
   resource.collectData();
   resource.generateCode();
 
-  expect(resource.sourceFile.getText()).toBe(
-    poorMansElixirFormat(`
-      defmodule ApiToolsWeb.MicroNanoResource do
-        @moduledoc false
+  expect(resource.sourceFile).toHaveFormattedElixirText(`
+    defmodule ApiToolsWeb.MicroNanoResource do
+      @moduledoc false
 
-        @resource_type "micro-nano"
-        use Jabbax.Document
+      @resource_type "micro-nano"
+      use Jabbax.Document
 
-        def build(config) do
-          %Resource{
-            type: @resource_type,
-            id: config.id,
-            attributes: %{
-            },
-          }
-        end
-
-        def link(config) do
-          %ResourceId{
-            type: @resource_type,
-            id: config.id,
-          }
-        end
+      def build(config) do
+        %Resource{
+          type: @resource_type,
+          id: config.id,
+          attributes: %{
+          },
+        }
       end
-    `),
-  );
+
+      def link(config) do
+        %ResourceId{
+          type: @resource_type,
+          id: config.id,
+        }
+      end
+    end
+  `);
 });
 
 test('happy path', () => {
@@ -122,51 +119,49 @@ test('happy path', () => {
   resource.collectData();
   resource.generateCode();
 
-  expect(resource.sourceFile.getText()).toBe(
-    poorMansElixirFormat(`
-      defmodule ApiToolsWeb.UsersResource do
-        @moduledoc false
+  expect(resource.sourceFile).toHaveFormattedElixirText(`
+    defmodule ApiToolsWeb.UsersResource do
+      @moduledoc false
 
-        @resource_type "users"
-        use Jabbax.Document
-        alias ApiToolsWeb.OrganizationsResource
-        alias ApiToolsWeb.UserAvatarsResource
+      @resource_type "users"
+      use Jabbax.Document
+      alias ApiToolsWeb.OrganizationsResource
+      alias ApiToolsWeb.UserAvatarsResource
 
-        def build(config) do
-          %Resource{
-            type: @resource_type,
-            id: config.id,
-            attributes: %{
-              name: config.name,
-              age: config.age,
-              email: config.email,
-            },
-            relationships:
-              %{}
-              |> link_relationship(:organization, config.organization)
-              |> link_relationship(:avatar, config.avatar)
-          }
-        end
-
-        def link(config) do
-          %ResourceId{
-            type: @resource_type,
-            id: config.id,
-          }
-        end
-
-        defp link_relationship(relationships, type, nil) do
-          Map.put(relationships, type, %Jabbax.Document.Relationship{data: nil})
-        end
-
-        defp link_relationship(relationships, :organization, organization) do
-          Map.put(relationships, :organization, OrganizationsResource.link(organization))
-        end
-
-        defp link_relationship(relationships, :avatar, avatar) do
-          Map.put(relationships, :avatar, UserAvatarsResource.link(avatar))
-        end
+      def build(config) do
+        %Resource{
+          type: @resource_type,
+          id: config.id,
+          attributes: %{
+            name: config.name,
+            age: config.age,
+            email: config.email,
+          },
+          relationships:
+            %{}
+            |> link_relationship(:organization, config.organization)
+            |> link_relationship(:avatar, config.avatar)
+        }
       end
-    `),
-  );
+
+      def link(config) do
+        %ResourceId{
+          type: @resource_type,
+          id: config.id,
+        }
+      end
+
+      defp link_relationship(relationships, type, nil) do
+        Map.put(relationships, type, %Jabbax.Document.Relationship{data: nil})
+      end
+
+      defp link_relationship(relationships, :organization, organization) do
+        Map.put(relationships, :organization, OrganizationsResource.link(organization))
+      end
+
+      defp link_relationship(relationships, :avatar, avatar) do
+        Map.put(relationships, :avatar, UserAvatarsResource.link(avatar))
+      end
+    end
+  `);
 });

--- a/packages/openapi-codegen-server-elixir/src/parts/Router.test.ts
+++ b/packages/openapi-codegen-server-elixir/src/parts/Router.test.ts
@@ -1,4 +1,4 @@
-import { poorMansElixirFormat } from '@fresha/code-morph-ex';
+import { poorMansElixirFormat } from '@fresha/code-morph-test-utils';
 
 import { makeContext } from '../testHelpers';
 


### PR DESCRIPTION
## Motivation and Context

This PR aim is improved DX in testing code morphers. It adds the `@fresha/code-morph-test-utils` package, where all shared testing code will reside. The package will contain Jest matchers, set up code, and similar stuff.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring

## Details

`@fresha/code-morph-test-utils` contains 2 Jest matchers. Also, OpenAPI code generator for Elixir uses this package.