### PR TITLE
ComponentsModel.setSchema now sets schema title

### DIFF
--- a/packages/openapi-codegen-utils/src/jsonapi.test.ts
+++ b/packages/openapi-codegen-utils/src/jsonapi.test.ts
@@ -21,6 +21,7 @@ test('setResourceLinkSchema', () => {
 
   expect(writer.write(openapi)).toHaveProperty(['components', 'schemas'], {
     EmployeeId: {
+      title: 'EmployeeId',
       type: 'object',
       required: ['type', 'id'],
       properties: {
@@ -29,6 +30,7 @@ test('setResourceLinkSchema', () => {
       },
     },
     GenericResourceId: {
+      title: 'GenericResourceId',
       type: 'object',
       required: ['type', 'id'],
       properties: {
@@ -52,6 +54,7 @@ test('setResourceSchema', () => {
   setResourceSchema(openapi.components.setSchema('Employee', 'object'), 'employees');
 
   expect(writer.write(openapi)).toHaveProperty(['components', 'schemas', 'Employee'], {
+    title: 'Employee',
     type: 'object',
     required: ['type', 'id', 'attributes'],
     properties: {
@@ -79,6 +82,7 @@ test('addResourceAttribute', () => {
   addResourceAttribute(schema, 'createdAt', 'date-time');
 
   expect(writer.write(openapi)).toHaveProperty(['components', 'schemas', 'Organization'], {
+    title: 'Organization',
     type: 'object',
     required: ['type', 'id', 'attributes'],
     properties: {
@@ -108,6 +112,7 @@ test('addResourceAttributes', () => {
   });
 
   expect(writer.write(openapi)).toHaveProperty(['components', 'schemas', 'Organization'], {
+    title: 'Organization',
     type: 'object',
     required: ['type', 'id', 'attributes'],
     properties: {
@@ -240,6 +245,7 @@ test('setDataDocumentSchema', () => {
   setDataDocumentSchema(schema, 'employees');
 
   expect(writer.write(openapi)).toHaveProperty(['components', 'schemas', 'DataDocument'], {
+    title: 'DataDocument',
     type: 'object',
     required: ['data'],
     properties: {

--- a/packages/openapi-model/examples/petstore.yaml
+++ b/packages/openapi-model/examples/petstore.yaml
@@ -122,6 +122,7 @@ paths:
 components:
   schemas:
     Pet:
+      title: Pet
       allOf:
         - $ref: '#/components/schemas/NewPet'
         - type: object
@@ -133,6 +134,7 @@ components:
               format: int64
 
     NewPet:
+      title: NewPet
       type: object
       required:
         - name
@@ -143,6 +145,7 @@ components:
           type: string
 
     Error:
+      title: Error
       type: object
       required:
         - code

--- a/packages/openapi-model/src/3.0.3/model/Components.ts
+++ b/packages/openapi-model/src/3.0.3/model/Components.ts
@@ -93,6 +93,7 @@ export class Components extends BasicNode<ComponentsModelParent> implements Comp
   setSchema(name: string, type?: SchemaCreateType): SchemaModel {
     assert(!this.schemas.has(name));
     const result = SchemaFactory.create(this, type ?? null);
+    result.title = name;
     this.schemas.set(name, result);
     return result;
   }

--- a/packages/openapi-model/src/3.0.3/model/OpenAPIWriter.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPIWriter.test.ts
@@ -65,6 +65,7 @@ test('shared schemas + references', () => {
 
   expect(openapiObject.components?.schemas).toStrictEqual({
     Error: {
+      title: 'Error',
       type: 'object',
       required: ['code'],
       properties: {
@@ -72,6 +73,7 @@ test('shared schemas + references', () => {
       },
     },
     ErrorList: {
+      title: 'ErrorList',
       type: 'array',
       items: { $ref: '#/components/schemas/Error' },
     },
@@ -152,6 +154,7 @@ test('serialises operation with shared schemas', () => {
 
   expect(openapiObject.components?.schemas).toStrictEqual({
     Error: {
+      title: 'Error',
       type: 'object',
       required: ['code'],
       properties: {
@@ -159,6 +162,7 @@ test('serialises operation with shared schemas', () => {
       },
     },
     ErrorList: {
+      title: 'ErrorList',
       type: 'array',
       items: { $ref: '#/components/schemas/Error' },
     },


### PR DESCRIPTION
## Motivation and Context

This PR makes `Components.setSchema` to set schema title to the key it is associated with. It adds some convenience when working with code generators.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

Some unit tests have to be adapted.
