### PR TITLE
Add convenience methods to SchemaModel class

### DIFF
--- a/packages/openapi-model/src/3.0.3/model/Schema.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Schema.test.ts
@@ -77,9 +77,51 @@ describe('SchemaFactory', () => {
 describe('Schema', () => {
   test('isNull', () => {
     const openapi = new OpenAPI('isNull', '0.1.0');
+
+    const nullTypedButNoEnum = openapi.components.setSchema('OnlyNullType');
+    expect(nullTypedButNoEnum.isNull()).toBeFalsy();
+
+    const typedWithEnum = openapi.components.setSchema('OnlyNullEnum', 'boolean');
+    typedWithEnum.enum = [null];
+    expect(typedWithEnum.isNull()).toBeFalsy();
+
+    const nullSchema = openapi.components.setSchema('Null');
+    nullSchema.enum = [null];
+    expect(nullSchema.isNull()).toBeTruthy();
   });
 
   test('isComposite', () => {
+    const openapi = new OpenAPI('isComposite', '0.1.0');
+
+    const objectSchema = openapi.components.setSchema('ObjectSchema', 'object');
+    objectSchema.setProperties({
+      one: 'string',
+      two: 'boolean',
+    });
+
+    expect(objectSchema.isComposite()).toBeFalsy();
+
+    const arraySchema = openapi.components.setSchema('ArraySchema', 'array');
+    arraySchema.items = SchemaFactory.create(arraySchema, 'object');
+
+    expect(arraySchema.isComposite()).toBeFalsy();
+
+    const schemaWithAllOf = openapi.components.setSchema('WithAllOf', null);
+    schemaWithAllOf.addAllOf('boolean');
+    schemaWithAllOf.addAllOf('object');
+
+    expect(schemaWithAllOf.isComposite()).toBeTruthy();
+
+    const schemaWithOneOf = openapi.components.setSchema('WithOneOf', null);
+    schemaWithOneOf.addOneOf('boolean');
+    schemaWithOneOf.addOneOf('date-time');
+
+    expect(schemaWithAllOf.isComposite()).toBeTruthy();
+
+    const schemaWithAnyOf = openapi.components.setSchema('WithAnyOf', null);
+    schemaWithAnyOf.addAnyOf('boolean');
+
+    expect(schemaWithAnyOf.isComposite()).toBeTruthy();
   });
 
   test('getProperty + getPropertyOrThrow', () => {

--- a/packages/openapi-model/src/3.0.3/model/Schema.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Schema.test.ts
@@ -75,6 +75,13 @@ describe('SchemaFactory', () => {
 });
 
 describe('Schema', () => {
+  test('isNull', () => {
+    const openapi = new OpenAPI('isNull', '0.1.0');
+  });
+
+  test('isComposite', () => {
+  });
+
   test('getProperty + getPropertyOrThrow', () => {
     const openapi = new OpenAPI('example', '0.1.0');
 

--- a/packages/openapi-model/src/3.0.3/model/Schema.ts
+++ b/packages/openapi-model/src/3.0.3/model/Schema.ts
@@ -187,12 +187,22 @@ export class Schema extends BasicNode<SchemaModelParent> implements SchemaModel 
     this.deprecated = false;
   }
 
+  isComposite(): boolean {
+    return !!(this.allOf.length || this.oneOf.length || this.anyOf.length);
+  }
+
   isNull(): boolean {
     return !!(this.type === null && this.enum?.length === 1 && this.enum[0] === null);
   }
 
-  isComposite(): boolean {
-    return !!(this.allOf.length || this.oneOf.length || this.anyOf.length);
+  isNullish(): boolean {
+    return !!(
+      this.nullable ||
+      this.isNull() ||
+      this.allOf.some(s => s.isNullish()) ||
+      this.oneOf.some(s => s.isNullish()) ||
+      this.anyOf.some(s => s.isNullish())
+    );
   }
 
   *getProperties(): IterableIterator<SchemaPropertyObject> {

--- a/packages/openapi-model/src/3.0.3/model/Schema.ts
+++ b/packages/openapi-model/src/3.0.3/model/Schema.ts
@@ -187,6 +187,14 @@ export class Schema extends BasicNode<SchemaModelParent> implements SchemaModel 
     this.deprecated = false;
   }
 
+  isNull(): boolean {
+    return !!(this.type === null && this.enum?.length === 1 && this.enum[0] === null);
+  }
+
+  isComposite(): boolean {
+    return !!(this.allOf.length || this.oneOf.length || this.anyOf.length);
+  }
+
   *getProperties(): IterableIterator<SchemaPropertyObject> {
     for (const [name, schema] of this.properties) {
       yield { name, schema, required: this.isPropertyRequired(name) };

--- a/packages/openapi-model/src/3.0.3/model/Schema.ts
+++ b/packages/openapi-model/src/3.0.3/model/Schema.ts
@@ -382,6 +382,20 @@ export class Schema extends BasicNode<SchemaModelParent> implements SchemaModel 
     this.oneOf.splice(0, this.oneOf.length);
   }
 
+  addAnyOf(typeOrSchema: SchemaCreateOptions): SchemaModel {
+    const schema = Schema.internalCreate(this, typeOrSchema);
+    this.anyOf.push(schema);
+    return schema;
+  }
+
+  deleteAnyOfAt(index: number): void {
+    this.anyOf.splice(index, 1);
+  }
+
+  clearAnyOf(): void {
+    this.anyOf.splice(0, this.anyOf.length);
+  }
+
   arrayOf(parent: SchemaModelParent): SchemaModel {
     return Schema.createArray(parent, this);
   }

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -166,6 +166,12 @@ export interface SchemaModel extends TreeNode<SchemaModelParent>, SpecificationE
   deprecated: boolean;
 
   /**
+   * Returns true if this schema has at least one subschema in allOf, oneOf or anyOf lists;
+   * return false otherwise.
+   */
+  isComposite(): boolean;
+
+  /**
    * Returns true if this schema represents only the null value; returns false otherwise.
    * Technically this is the schema without explicitly given type, and with the single
    * enum value of null.
@@ -173,10 +179,10 @@ export interface SchemaModel extends TreeNode<SchemaModelParent>, SpecificationE
   isNull(): boolean;
 
   /**
-   * Returns true if this schema has at least one subschema in allOf, oneOf or anyOf lists;
-   * return false otherwise.
+   * Returns true if this schemas or one of its subschemas (allOf, oneOf or anyOf) are either
+   * null schemas or nullable (i.e. have nullable attribute set to true).
    */
-  isComposite(): boolean;
+  isNullish(): boolean;
 
   getProperties(): IterableIterator<SchemaPropertyObject>;
   getProperty(name: string): SchemaModel | undefined;

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -165,6 +165,19 @@ export interface SchemaModel extends TreeNode<SchemaModelParent>, SpecificationE
   example: Nullable<JSONValue>;
   deprecated: boolean;
 
+  /**
+   * Returns true if this schema represents only the null value; returns false otherwise.
+   * Technically this is the schema without explicitly given type, and with the single
+   * enum value of null.
+   */
+  isNull(): boolean;
+
+  /**
+   * Returns true if this schema has at least one subschema in allOf, oneOf or anyOf lists;
+   * return false otherwise.
+   */
+  isComposite(): boolean;
+
   getProperties(): IterableIterator<SchemaPropertyObject>;
   getProperty(name: string): SchemaModel | undefined;
   getPropertyOrThrow(name: string): SchemaModel;

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -197,6 +197,10 @@ export interface SchemaModel extends TreeNode<SchemaModelParent>, SpecificationE
   deleteOneOfAt(index: number): void;
   clearOneOf(): void;
 
+  addAnyOf(options: SchemaCreateOptions): SchemaModel;
+  deleteAnyOfAt(index: number): void;
+  clearAnyOf(): void;
+
   arrayOf(parent: SchemaModelParent): SchemaModel;
 }
 


### PR DESCRIPTION
## Motivation and Context

This PR adds several convenience methods to `SchemaModel` in `@fresha/openapi-model`. They will be used in multiple places, most notably in code generators.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

Methods added:

- `.isNull()`
- `.isComposite()`
- `.addAnyOf()`
- `.deleteAnyOfAt()`
- `.clearAnyOf()`
