### PR TITLE
Add convenience methods related to SchemaModel handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1466,6 +1466,12 @@
       "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
       "dev": true
     },
+    "node_modules/@types/pluralize": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.29.tgz",
+      "integrity": "sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==",
+      "dev": true
+    },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
@@ -5205,6 +5211,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6782,6 +6796,7 @@
       "dependencies": {
         "@fresha/api-tools-core": "0.3.0",
         "@fresha/openapi-model": "0.4.0",
+        "pluralize": "^8.0.0",
         "ts-morph": "^16.0.0",
         "winston": "^3.8.2"
       },
@@ -6789,6 +6804,7 @@
         "@fresha/eslint-config": "0.1.0",
         "@fresha/jest-config": "0.1.0",
         "@fresha/typescript-config": "0.1.0",
+        "@types/pluralize": "^0.0.29",
         "typescript": "^4.7.2"
       }
     },
@@ -7907,6 +7923,8 @@
         "@fresha/jest-config": "0.1.0",
         "@fresha/openapi-model": "0.4.0",
         "@fresha/typescript-config": "0.1.0",
+        "@types/pluralize": "^0.0.29",
+        "pluralize": "^8.0.0",
         "ts-morph": "^16.0.0",
         "typescript": "^4.7.2",
         "winston": "^3.8.2"
@@ -8492,6 +8510,12 @@
       "version": "18.11.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
       "integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
+      "dev": true
+    },
+    "@types/pluralize": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.29.tgz",
+      "integrity": "sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==",
       "dev": true
     },
     "@types/prettier": {
@@ -11221,6 +11245,11 @@
       "requires": {
         "find-up": "^4.0.0"
       }
+    },
+    "pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/packages/json-api-model/src/Registry.ts
+++ b/packages/json-api-model/src/Registry.ts
@@ -41,9 +41,7 @@ export class Registry implements RegistryModel {
   }
 
   parseResource(schema: SchemaModel): ResourceModel {
-    assert(schema.type === 'object', 'Resource schemas must have type "object"');
-
-    const typeAttr = schema.getPropertyOrThrow('type');
+    const typeAttr = schema.getPropertyDeepOrThrow('type');
     assert(typeAttr.enum?.length === 1, `Resource schemas must have a single enum value`);
 
     const resourceType = typeAttr.enum[0];

--- a/packages/json-api-model/src/Resource.ts
+++ b/packages/json-api-model/src/Resource.ts
@@ -29,7 +29,7 @@ export class Resource implements ResourceModel {
       this.schema = null;
     } else {
       this.schema = schema;
-      const resourceType = this.schema.getPropertyOrThrow('type').enum?.at(0);
+      const resourceType = this.schema.getPropertyDeepOrThrow('type').enum?.at(0);
       assert(resourceType && typeof resourceType === 'string');
       this.type = resourceType;
     }
@@ -38,12 +38,12 @@ export class Resource implements ResourceModel {
     this.relationships = new Map<string, RelationshipModel>();
 
     if (this.schema) {
-      const attributesSchema = this.schema.getPropertyOrThrow('attributes');
+      const attributesSchema = this.schema.getPropertyDeepOrThrow('attributes');
       for (const [attrName, attrSchema] of attributesSchema.properties) {
         const attribute = new Attribute(this, attrName, attrSchema);
         this.attributes.set(attrName, attribute);
       }
-      const relationshipsSchema = this.schema.getProperty('relationships');
+      const relationshipsSchema = this.schema.getPropertyDeep('relationships');
       if (relationshipsSchema) {
         for (const [relName, relSchema] of relationshipsSchema.properties) {
           const relationship = new Relationship(this, relName, relSchema);

--- a/packages/openapi-codegen-server-elixir/src/parts/Action.ts
+++ b/packages/openapi-codegen-server-elixir/src/parts/Action.ts
@@ -221,7 +221,7 @@ export class Action {
           this.sourceFile.writeLine('id: [:id, :required],');
           this.sourceFile.writeLine('attributes: %{');
           this.sourceFile.writeIndented(() => {
-            const attributesSchema = resourceSchema.getPropertyOrThrow('attributes');
+            const attributesSchema = resourceSchema.getPropertyDeepOrThrow('attributes');
             for (const [attrName, attrSchema] of attributesSchema.properties) {
               switch (attrSchema.type) {
                 case 'boolean': {
@@ -248,7 +248,7 @@ export class Action {
           this.sourceFile.writeLine('},');
           this.sourceFile.writeLine('relationships: %{');
           this.sourceFile.writeIndented(() => {
-            const relationshipsSchema = resourceSchema.getPropertyOrThrow('relationships');
+            const relationshipsSchema = resourceSchema.getPropertyDeepOrThrow('relationships');
 
             for (const [relName] of relationshipsSchema.properties) {
               const elixirAtttName = snakeCase(relName);

--- a/packages/openapi-codegen-server-elixir/src/parts/Controller.test.ts
+++ b/packages/openapi-codegen-server-elixir/src/parts/Controller.test.ts
@@ -1,6 +1,7 @@
 import {
   addResourceRelationship,
   MEDIA_TYPE_JSON_API,
+  RelationshipCardinality,
   setDataDocumentSchema,
 } from '@fresha/openapi-codegen-utils';
 import { SchemaFactory } from '@fresha/openapi-model/build/3.0.3';
@@ -103,7 +104,7 @@ test('request body leads to generating parse_XXXX_conn function, as well as erro
   setDataDocumentSchema(requestBodySchema, 'profile-settings');
   const attributesSchema = requestBodySchema
     .getPropertyOrThrow('data')
-    .getPropertyOrThrow('attributes');
+    .getPropertyDeepOrThrow('attributes');
   attributesSchema.setProperties({
     name: { type: 'string', required: true },
     age: { type: 'integer', required: true, minimum: 18, maximum: 200 },
@@ -114,8 +115,14 @@ test('request body leads to generating parse_XXXX_conn function, as well as erro
   });
 
   const resourceSchema = requestBodySchema.getPropertyOrThrow('data');
-  addResourceRelationship(resourceSchema, 'location', { type: 'locations', required: true });
-  addResourceRelationship(resourceSchema, 'employee', { type: 'employees', required: false });
+  addResourceRelationship(resourceSchema, 'location', 'locations');
+  addResourceRelationship(
+    resourceSchema,
+    'employee',
+    'employees',
+    RelationshipCardinality.One,
+    false,
+  );
 
   const controller = new Controller(context, '/profile', 'AwesomeWeb.ProfileController');
   controller.collectData(pathItem);

--- a/packages/openapi-codegen-server-elixir/src/parts/Resource.test.ts
+++ b/packages/openapi-codegen-server-elixir/src/parts/Resource.test.ts
@@ -20,7 +20,7 @@ const makeResource = (
 
   const resourceName = titleCase(resourceType);
 
-  const resourceSchema = generator.context.openapi.components.setSchema(resourceName, 'object');
+  const resourceSchema = generator.context.openapi.components.setSchema(resourceName);
   setResourceSchema(resourceSchema, resourceType);
 
   const resource = new Resource(
@@ -98,7 +98,7 @@ test('happy path', () => {
 
   const resourceType = 'users';
   const resourceName = titleCase(resourceType);
-  const resourceSchema = generator.context.openapi.components.setSchema(resourceName, 'object');
+  const resourceSchema = generator.context.openapi.components.setSchema(resourceName);
 
   // need to initialize resource schema before calling registry.parseResource
   setResourceSchema(resourceSchema, resourceType);

--- a/packages/openapi-codegen-test-utils/src/index.ts
+++ b/packages/openapi-codegen-test-utils/src/index.ts
@@ -1,1 +1,2 @@
 export * from './context';
+export * from './mocks';

--- a/packages/openapi-codegen-test-utils/src/mocks/buildEmployeeSchemasForTesting.ts
+++ b/packages/openapi-codegen-test-utils/src/mocks/buildEmployeeSchemasForTesting.ts
@@ -1,0 +1,25 @@
+import {
+  addResourceAttributes,
+  addResourceRelationships,
+  RelationshipCardinality,
+  setResourceSchema,
+} from '@fresha/openapi-codegen-utils';
+
+import type { OpenAPIModel, SchemaModel } from '@fresha/openapi-model/build/3.0.3';
+
+export const buildEmployeeSchemasForTesting = (openapi: OpenAPIModel): SchemaModel => {
+  const employee = openapi.components.setSchema('EmployeeResource');
+  setResourceSchema(employee, 'employees');
+  addResourceAttributes(employee, {
+    name: { type: 'string', required: true },
+    age: { type: 'number', nullable: true },
+    gender: { type: 'string', enum: ['male', 'female', 'other'], nullable: true },
+    active: { type: 'boolean', nullable: false },
+  });
+  addResourceRelationships(employee, {
+    manager: { resourceType: 'employees', cardinality: RelationshipCardinality.One },
+    buddy: { resourceType: 'employees', cardinality: RelationshipCardinality.ZeroOrOne },
+    subordinates: { resourceType: 'employees', cardinality: RelationshipCardinality.Many },
+  });
+  return employee;
+};

--- a/packages/openapi-codegen-test-utils/src/mocks/index.ts
+++ b/packages/openapi-codegen-test-utils/src/mocks/index.ts
@@ -1,0 +1,1 @@
+export * from './buildEmployeeSchemasForTesting';

--- a/packages/openapi-codegen-utils/package.json
+++ b/packages/openapi-codegen-utils/package.json
@@ -41,11 +41,13 @@
     "@fresha/eslint-config": "0.1.0",
     "@fresha/jest-config": "0.1.0",
     "@fresha/typescript-config": "0.1.0",
+    "@types/pluralize": "^0.0.29",
     "typescript": "^4.7.2"
   },
   "dependencies": {
     "@fresha/api-tools-core": "0.3.0",
     "@fresha/openapi-model": "0.4.0",
+    "pluralize": "^8.0.0",
     "ts-morph": "^16.0.0",
     "winston": "^3.8.2"
   }

--- a/packages/openapi-codegen-utils/src/jsonapi.ts
+++ b/packages/openapi-codegen-utils/src/jsonapi.ts
@@ -1,29 +1,49 @@
 import assert from 'assert';
 
+import { titleCase } from '@fresha/api-tools-core';
 import {
   SchemaCreateOptions,
   SchemaFactory,
   SchemaModel,
   SchemaModelParent,
 } from '@fresha/openapi-model/build/3.0.3';
+import pluralize from 'pluralize';
 
-export const setResourceIdSchema = (linkSchema: SchemaModel, type?: string): void => {
-  assert(linkSchema.type === 'object');
-  linkSchema.setProperties({
-    type: { type: 'string', required: true, minLength: 1, enum: type ? [type] : undefined },
-    id: { type: 'string', required: true, minLength: 1 },
-  });
+/**
+ * Creates a null SchemaModel.
+ *
+ * @param parent schema parent
+ * @returns a schema representing the (and only) null value
+ */
+export const createNullSchema = (parent: SchemaModelParent): SchemaModel => {
+  let result: SchemaModel;
+
+  if (parent.root.components === parent) {
+    result = parent.root.components.setSchema('Null');
+  } else {
+    result = SchemaFactory.create(parent, null);
+    result.title = 'Null';
+  }
+  result.enum = [null];
+
+  return result;
 };
 
-export const createResourceIdSchema = (parent: SchemaModelParent, type?: string): SchemaModel => {
-  const linkSchema = SchemaFactory.create(parent, 'object');
-  setResourceIdSchema(linkSchema, type);
-  return linkSchema;
-};
-
-export const setResourceSchema = (resourceSchema: SchemaModel, resourceType: string): void => {
-  assert(resourceSchema.type === 'object');
-  resourceSchema.setProperties({
+/**
+ * Given a SchemaModel instance, sets it to represent a JSON:API resource identifier.
+ *
+ * @param schema schema model to set up
+ * @param resourceType JSON:API resource type. If not given, the resulting schema
+ *  will represent a generic resource, without specific type
+ * @see [JSON:API spec on resource identifiers](https://jsonapi.org/format/#document-resource-identifier-objects)
+ * @see {@link createResourceIdSchema}
+ */
+export const setResourceIdSchema = (schema: SchemaModel, resourceType?: string): void => {
+  assert(schema.type === 'object', "Resource ID schema must have type set to 'object'");
+  if (resourceType) {
+    schema.title = `${titleCase(pluralize.singular(resourceType))}ResourceID`;
+  }
+  schema.setProperties({
     type: {
       type: 'string',
       required: true,
@@ -31,28 +51,101 @@ export const setResourceSchema = (resourceSchema: SchemaModel, resourceType: str
       enum: resourceType ? [resourceType] : undefined,
     },
     id: { type: 'string', required: true, minLength: 1 },
+  });
+};
+
+/**
+ * Creates a SchemaModel instance, representing a JSON:API resource identifier.
+ * Uses {@link setResourceIdSchema} under the hood to set up the model.
+ *
+ * @param parent parent schema
+ * @param resourceType JSON:API resource type
+ * @returns a newly created schema model
+ * @see [JSON:API spec on resource identifiers](https://jsonapi.org/format/#document-resource-identifier-objects)
+ * @see {@link setResourceIdSchema}
+ */
+export const createResourceIdSchema = (
+  parent: SchemaModelParent,
+  resourceType?: string,
+): SchemaModel => {
+  const result = SchemaFactory.create(parent, 'object');
+  setResourceIdSchema(result, resourceType);
+  return result;
+};
+
+/**
+ * Given a SchemaModel instance, sets it up to represent a JSON:API resource structure
+ * with given resource type.
+ *
+ * @param schema schema model to set up
+ * @param resourceType type of resource JSON:API resource
+ * @see {@link createResourceSchema}
+ * @see [JSON:API spec on resources](https://jsonapi.org/format/#document-resource-objects)
+ */
+export const setResourceSchema = (schema: SchemaModel, resourceType?: string): void => {
+  assert(schema.type === null, `Resource schema must have type set to null`);
+
+  if (resourceType) {
+    schema.title = `${titleCase(pluralize.singular(resourceType))}Resource`;
+  }
+
+  const idSchema = schema.addAllOf('object');
+  setResourceIdSchema(idSchema, resourceType);
+
+  const bodySchema = schema.addAllOf('object');
+  bodySchema.setProperties({
     attributes: { type: 'object', required: true },
     relationships: 'object',
   });
 };
 
+/**
+ * Creates a SchemaModel instance representing a JSON:API resource structure
+ * with given resource type.
+ *
+ * @param schema schema model to set up
+ * @param resourceType type of JSON:API resource
+ * @see {@link setResourceSchema}
+ * @see [JSON:API spec on resources](https://jsonapi.org/format/#document-resource-objects)
+ */
 export const createResourceSchema = (parent: SchemaModelParent, type: string): SchemaModel => {
-  const resourceSchema = SchemaFactory.create(parent, 'object');
+  const resourceSchema = SchemaFactory.create(parent, null);
   setResourceSchema(resourceSchema, type);
   return resourceSchema;
 };
 
+/**
+ * Given a SchemaModel instance, representing a JSON:API resource, adds
+ * a single attribute to it.
+ *
+ * @param resourceSchema resource SchemaModel
+ * @param name attribute name
+ * @param options properties of the attribute
+ * @returns attribute's SchemaModel
+ * @see {@link addResourceAttributes}
+ * @see [JSON:API spec on resources](https://jsonapi.org/format/#document-resource-objects)
+ */
 export const addResourceAttribute = (
   resourceSchema: SchemaModel,
   name: string,
   options: SchemaCreateOptions,
 ): SchemaModel => {
-  assert(resourceSchema.type === 'object');
-  const attributesSchema = resourceSchema.getPropertyOrThrow('attributes');
-  assert(attributesSchema.type === 'object');
+  assert(resourceSchema.type === null, `Resource schema must have type set to null`);
+  const attributesSchema = resourceSchema.allOf?.at(1)?.getPropertyOrThrow('attributes');
+  assert(attributesSchema?.type === 'object');
   return attributesSchema.setProperty(name, options);
 };
 
+/**
+ * Given a SchemaModel instance that represents a JSON:API resource, adds multiple
+ * attributes to it.
+ *
+ * @param resourceSchema resource schema
+ * @param attrs map of attribute names to attribute schemas
+ * @param options properties of the attribute
+ * @see {@link addResourceAttribute}
+ * @see [JSON:API spec on resources](https://jsonapi.org/format/#document-resource-objects)
+ */
 export const addResourceAttributes = (
   resourceSchema: SchemaModel,
   attrs: Record<string, SchemaCreateOptions>,
@@ -62,88 +155,162 @@ export const addResourceAttributes = (
   }
 };
 
-export type RelationshipCreateOptions =
-  | string
-  | {
-      type: string;
-      required?: boolean;
-      multiple?: boolean;
-    };
+export enum RelationshipCardinality {
+  ZeroOrOne = '0',
+  One = '1',
+  Many = 'N',
+}
 
+/**
+ * Given a SchemaModel instance, representing a JSON:API resource, adds subschemas
+ * representing a relationship with given characteristics.
+ *
+ * @param resourceSchema schema to modify
+ * @param name name of the relationship
+ * @param resourceType type of the resource on the other side of the relationship
+ * @param cardinality relationship cardinality
+ * @param required is this relationship always present ? If not, the field is
+ *  marked as optional
+ * @see [JSON:API spec on relationships](https://jsonapi.org/format/#document-resource-object-relationships)
+ * @see {@link addResourceRelationships}
+ */
 export const addResourceRelationship = (
   resourceSchema: SchemaModel,
   name: string,
-  options: RelationshipCreateOptions,
+  resourceType: string,
+  cardinality: RelationshipCardinality = RelationshipCardinality.One,
+  required = true,
 ): void => {
-  let relationshipsSchema = resourceSchema.getProperty('relationships');
+  const bodySchema = resourceSchema.allOf?.at(1);
+  assert(bodySchema?.type === 'object');
+
+  let relationshipsSchema = bodySchema.getProperty('relationships');
   if (!relationshipsSchema) {
-    relationshipsSchema = resourceSchema.setProperty('relationships', 'object');
+    relationshipsSchema = bodySchema.setProperty('relationships', 'object');
   }
   assert(relationshipsSchema.type === 'object');
 
-  if (typeof options === 'string') {
-    setResourceIdSchema(
-      relationshipsSchema
-        .setProperty(name, { type: 'object', required: false })
-        .setProperty('data', { type: 'object', required: true, nullable: true }),
-      options,
-    );
-  } else if (options.multiple) {
-    const dataSchema = relationshipsSchema
-      .setProperty(name, { type: 'object', required: !!options.required })
-      .setProperty('data', { type: 'array', required: true });
-    dataSchema.items = createResourceIdSchema(dataSchema, options.type);
-  } else {
-    setResourceIdSchema(
-      relationshipsSchema
-        .setProperty(name, { type: 'object', required: !!options.required })
-        .setProperty('data', { type: 'object', required: true }),
-      options.type,
-    );
+  const relationshipSchema = relationshipsSchema.setProperty(name, {
+    type: 'object',
+    required,
+  });
+  switch (cardinality) {
+    case RelationshipCardinality.Many: {
+      const dataSchema = relationshipSchema.setProperty('data', 'array');
+      dataSchema.items = createResourceIdSchema(dataSchema, resourceType);
+      break;
+    }
+    case RelationshipCardinality.One: {
+      const dataSchema = relationshipSchema.setProperty('data', 'object');
+      setResourceIdSchema(dataSchema, resourceType);
+      break;
+    }
+    case RelationshipCardinality.ZeroOrOne: {
+      const dataSchema = relationshipSchema.setProperty('data', null);
+      setResourceIdSchema(dataSchema.addAllOf('object'), resourceType);
+      dataSchema.addAllOf(null).enum = [null];
+      break;
+    }
+    default:
+      assert.fail(`Unhandled cardinality ${String(cardinality)}`);
   }
 };
 
-type PrimaryDataOptions =
-  | string
-  | {
-      type: string;
-      multiple?: string;
-    };
+type RelationshipSpec = {
+  resourceType: string;
+  cardinality?: RelationshipCardinality;
+  required?: boolean;
+};
 
+/**
+ * Given a SchemaModel instance, adds subschemas to it to represent JSON:API relationships
+ * with specified characteristics.
+ *
+ * @param schema resource schema
+ * @param relationships map of relationship specifications
+ * @see [JSON:API spec on relationships](https://jsonapi.org/format/#document-resource-object-relationships)
+ * @see {@link addResourceRelationships}
+ */
+export const addResourceRelationships = (
+  schema: SchemaModel,
+  relationships: Record<string, RelationshipSpec>,
+): void => {
+  for (const [relName, { resourceType, cardinality, required }] of Object.entries(relationships)) {
+    addResourceRelationship(schema, relName, resourceType, cardinality, required);
+  }
+};
+
+/**
+ * Given a SchemaModel instance, sets it up to represent the structure of a JSON:API document
+ * with given types of primary and included resources.
+ *
+ * @param documentSchema schema to modify
+ * @param primaryResourceType type of primary data resources
+ * @param includedResourceTypes types of included resources
+ * @param multiplePrimaryResources if true, document primary data will be an array
+ * @see [JSON:API spec on documents](https://jsonapi.org/format/#document-structure)
+ * @see {@link createDataDocumentSchema}
+ */
 export const setDataDocumentSchema = (
   documentSchema: SchemaModel,
-  dataOptions: PrimaryDataOptions,
+  primaryResourceType: string,
+  includedResourceTypes?: string[],
+  multiplePrimaryResources?: boolean,
 ): void => {
-  assert(documentSchema.type === 'object');
+  assert(
+    documentSchema.type === 'object',
+    `Schema of JSON:API documents must have 'object' type. Got ${String(
+      documentSchema.type,
+    )} instead`,
+  );
 
   documentSchema
     .setProperty('jsonapi', 'object')
     .setProperty('version', { type: 'string', required: true, enum: ['1.0'] });
 
-  if (typeof dataOptions === 'string') {
-    setResourceSchema(
-      documentSchema.setProperty('data', { type: 'object', required: true }),
-      dataOptions,
-    );
-  } else if (dataOptions.multiple) {
-    const dataSchema = documentSchema.setProperty('data', { type: 'array', required: true });
-    dataSchema.items = createResourceSchema(dataSchema, dataOptions.type);
+  if (multiplePrimaryResources) {
+    const dataSchema = documentSchema.setProperty('data', 'array');
+    dataSchema.items = SchemaFactory.create(dataSchema, null);
+    setResourceSchema(dataSchema.items, primaryResourceType);
   } else {
-    setResourceSchema(
-      documentSchema.setProperty('data', { type: 'object', required: true }),
-      dataOptions.type,
-    );
+    const dataSchema = createResourceSchema(documentSchema, primaryResourceType);
+    documentSchema.setProperty('data', { type: dataSchema, required: true });
+  }
+
+  if (includedResourceTypes?.length) {
+    const includedSchema = documentSchema.setProperty('included', 'array');
+    includedSchema.items = SchemaFactory.create(includedSchema, null);
+    for (const includedType of includedResourceTypes) {
+      const includedAltSchema = includedSchema.items.addAnyOf('object');
+      setResourceIdSchema(includedAltSchema, includedType);
+    }
   }
 };
 
+/**
+ * Creates a SchemaModel instance defining the structure of a JSON:API document
+ * with given types of primary and included resources.
+ *
+ * @param documentSchema schema to modify
+ * @param primaryResourceType type of primary data resources
+ * @param includedResourceTypes types of included resources
+ * @param multiplePrimaryResources if true, document primary data will be an array
+ * @returns a SchemaModel instance
+ * @see [JSON:API spec on documents](https://jsonapi.org/format/#document-structure)
+ * @see {@link setDataDocumentSchema}
+ */
 export const createDataDocumentSchema = (
   parent: SchemaModelParent,
-  dataOptions: PrimaryDataOptions,
+  primaryResourceType: string,
+  includedResourceTypes?: string[],
+  multiplePrimaryResources?: boolean,
 ): SchemaModel => {
   const documentSchema = SchemaFactory.create(parent, 'object');
-  setDataDocumentSchema(documentSchema, dataOptions);
+  setDataDocumentSchema(
+    documentSchema,
+    primaryResourceType,
+    includedResourceTypes,
+    multiplePrimaryResources,
+  );
   return documentSchema;
 };
-
-// export const createErrorDocumentSchema = (parent: SchemaModelParent): SchemaModel => {
-// };

--- a/packages/openapi-codegen-utils/src/openapi.test.ts
+++ b/packages/openapi-codegen-utils/src/openapi.test.ts
@@ -12,6 +12,7 @@ import {
   getOperationCacheOptionsOrThrow,
   getOperationCacheOptions,
   getOperations,
+  getSchemaProperties,
 } from './openapi';
 
 test('getAPIName', () => {
@@ -187,4 +188,25 @@ test('getOperationCacheOptionsOrThrow', () => {
 test('pathUrlToUrlExp', () => {
   expect(pathUrlToUrlExp('/employees')).toBe('employees');
   expect(pathUrlToUrlExp('/employees/{id}/pets/{status}')).toBe('employees/:id/pets/:status');
+});
+
+test('getSchemaProperties', () => {
+  const openapi = OpenAPIFactory.create();
+
+  const schema = openapi.components.setSchema('AllOf');
+  schema.setProperties({
+    s1: 'boolean',
+    s2: 'integer',
+  });
+  schema.addAllOf('object').setProperties({
+    p1: 'string',
+    p2: 'boolean',
+  });
+  schema.addAllOf('object').setProperties({
+    r1: 'string',
+    r2: 'boolean',
+  });
+
+  const keys = Array.from(getSchemaProperties(schema), ([name]) => name);
+  expect(keys).toStrictEqual(['s1', 's2', 'p1', 'p2', 'r1', 'r2']);
 });

--- a/packages/openapi-model/src/3.0.3/model/Schema.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Schema.test.ts
@@ -199,6 +199,24 @@ describe('Schema', () => {
     expect(() => schema.getPropertyOrThrow('_')).toThrow();
   });
 
+  test('getPropertyDeep + getPropertyDeepOrThrow', () => {
+    const openapi = new OpenAPI('example', '0.1.0');
+    const schema = openapi.components.setSchema('TestSchema', 'object');
+
+    const ownString = schema.setProperty('own', 'string');
+
+    const allOf1 = schema.addAllOf('object');
+    allOf1.setProperty('own', 'string'); // same name as own property
+
+    const allOf2 = schema.addAllOf('object');
+    const idString = allOf2.setProperty('id', 'string');
+
+    expect(schema.getPropertyDeep('own')).toBe(ownString);
+    expect(schema.getPropertyDeep('id')).toBe(idString);
+
+    expect(() => schema.getPropertyDeepOrThrow('none')).toThrow();
+  });
+
   describe('setProperty', () => {
     const makeSchema = (): SchemaModel => {
       const openapi = new OpenAPI('example', '0.1.0');

--- a/packages/openapi-model/src/3.0.3/model/Schema.ts
+++ b/packages/openapi-model/src/3.0.3/model/Schema.ts
@@ -217,7 +217,43 @@ export class Schema extends BasicNode<SchemaModelParent> implements SchemaModel 
 
   getPropertyOrThrow(name: string): SchemaModel {
     const result = this.getProperty(name);
-    assert(result);
+    assert(result, `Expected to find property ${name}, but got none`);
+    return result;
+  }
+
+  *getPropertiesDeep(): IterableIterator<SchemaPropertyObject> {
+    // here we should iterate over any kind of schemas
+    for (const prop of this.getProperties()) {
+      yield prop;
+    }
+    for (const subschema of this.allOf) {
+      for (const subprop of subschema.getProperties()) {
+        yield subprop;
+      }
+    }
+  }
+
+  getPropertyDeep(name: string): SchemaModel | undefined {
+    if (this.type === 'object') {
+      const prop = this.getProperty(name);
+      if (prop) {
+        return prop;
+      }
+    }
+    for (const subschema of this.allOf) {
+      if (subschema.type === 'object') {
+        const prop = subschema.getProperty(name);
+        if (prop) {
+          return prop;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  getPropertyDeepOrThrow(name: string): SchemaModel {
+    const result = this.getPropertyDeep(name);
+    assert(result, `Expected to find (deep) property ${name}, but got none`);
     return result;
   }
 

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -184,6 +184,11 @@ export interface SchemaModel extends TreeNode<SchemaModelParent>, SpecificationE
    */
   isNullish(): boolean;
 
+  // /**
+  //  * Returns type of this schema, deduced from own type and types of allOf subschemas.
+  //  */
+  // getTypeDeep(): SchemaType;
+
   getProperties(): IterableIterator<SchemaPropertyObject>;
   getProperty(name: string): SchemaModel | undefined;
   getPropertyOrThrow(name: string): SchemaModel;
@@ -191,6 +196,31 @@ export interface SchemaModel extends TreeNode<SchemaModelParent>, SpecificationE
   setProperties(props: Record<string, SchemaCreateOptions>): SchemaModel;
   deleteProperty(name: string): void;
   clearProperties(): void;
+
+  /**
+   * Iterates over properties of this schema. Includes nested properties
+   * from allOf clause. Goes 1 level deep.
+   */
+  getPropertiesDeep(): IterableIterator<SchemaPropertyObject>;
+
+  /**
+   * Returns a schema for a property with the given name. This function looks into
+   * schema's own properties, and then in own properties of subschemas from the allOf
+   * clauses (if any).
+   *
+   * @param name property name
+   * @returns property schema, or undefined if there is no property with given name
+   */
+  getPropertyDeep(name: string): SchemaModel | undefined;
+
+  /**
+   * Same as {@link getPropertyDeep}, but throws an exception if there is not property
+   * with given name.
+   *
+   * @param name property name
+   * @returns property schema
+   */
+  getPropertyDeepOrThrow(name: string): SchemaModel;
 
   isPropertyRequired(name: string): boolean;
   setPropertyRequired(name: string, value: boolean): void;


### PR DESCRIPTION
## Motivation and Context

This PR adds new (and refactors existing) convenience methods in `@fresha/openapi-codegen-utils`, aimed to simplify creation of `SchemaModel` objects representing JSON:API structures, like resources or documents.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring

## Details

- `SchemaModel.getPropertiesDeep`
- `SchemaModel.getPropertyDeep`
- `SchemaModel.getPropertyDeepOrThrow`

- `getOperationResponseSchemas`
- `getSchemaMultiProperty`
- `getSchemaProperties`
- `buildEmployeeSchemasForTesting`
- `createNullSchema`
- `setResourceIdSchema`
- `createResourceIdSchema`
- `setResourceSchema`
- `createResourceSchema`
- `addResourceAttribute`
- `addResourceAttributes`
- `addResourceRelationship`
- `addResourceRelationships`
- `setDataDocumentSchema`
- `createDataDocumentSchema`
- `getOperationResponseSchemas`