### PR TITLE
Made OperationModel.security nullable

### DIFF
--- a/packages/openapi-model/src/3.0.3/model/OpenAPIWriter.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPIWriter.ts
@@ -912,7 +912,7 @@ export class OpenAPIWriter {
     if (operation.deprecated) {
       result.deprecated = operation.deprecated;
     }
-    if (operation.security.length) {
+    if (operation.security) {
       result.security = this.writeSecurityRequirementArray(operation.security);
     }
     if (operation.servers?.length) {

--- a/packages/openapi-model/src/3.0.3/model/Operation.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Operation.test.ts
@@ -18,7 +18,7 @@ test('default properties', () => {
   expect(operation.responses.codes.size).toBe(0);
   expect(operation.callbacks.size).toBe(0);
   expect(operation.deprecated).toBeFalsy();
-  expect(operation.security).toHaveLength(0);
+  expect(operation.security).toBeNull();
   expect(operation.servers).toHaveLength(0);
 });
 
@@ -162,8 +162,8 @@ test('security requirement collection', () => {
 
   operation.deleteSecurityRequirementAt(1);
   expect(operation.security).toHaveLength(2);
-  expect(operation.security[0]).toBe(s1);
-  expect(operation.security[1]).toBe(s3);
+  expect(operation.security?.[0]).toBe(s1);
+  expect(operation.security?.[1]).toBe(s3);
 
   operation.clearSecurityRequirements();
   expect(operation.security).toHaveLength(0);

--- a/packages/openapi-model/src/3.0.3/model/Operation.ts
+++ b/packages/openapi-model/src/3.0.3/model/Operation.ts
@@ -38,7 +38,7 @@ export class Operation extends BasicNode<OperationModelParent> implements Operat
   readonly responses: Responses;
   readonly callbacks: Map<string, CallbackModel>;
   deprecated: boolean;
-  readonly security: SecurityRequirementModel[];
+  security: Nullable<SecurityRequirementModel[]>;
   readonly servers: ServerModel[];
 
   constructor(parent: OperationModelParent) {
@@ -53,7 +53,7 @@ export class Operation extends BasicNode<OperationModelParent> implements Operat
     this.responses = new Responses(this);
     this.callbacks = new Map<string, CallbackModel>();
     this.deprecated = false;
-    this.security = [];
+    this.security = null;
     this.servers = [];
   }
 
@@ -199,18 +199,33 @@ export class Operation extends BasicNode<OperationModelParent> implements Operat
     this.callbacks.clear();
   }
 
+  getSecurityRequirements(): readonly SecurityRequirementModel[] {
+    return this.security ?? this.root.security;
+  }
+
   addSecurityRequirement(): SecurityRequirementModel {
     const result = new SecurityRequirement(this);
+    if (!this.security) {
+      this.security = [];
+    }
     this.security.push(result);
     return result;
   }
 
   deleteSecurityRequirementAt(index: number): void {
-    this.security.splice(index, 1);
+    if (this.security) {
+      this.security.splice(index, 1);
+    }
   }
 
   clearSecurityRequirements(): void {
-    this.security.splice(0, this.security.length);
+    if (this.security) {
+      this.security.splice(0, this.security.length);
+    }
+  }
+
+  resetSecurityRequirements(): void {
+    this.security = null;
   }
 
   getServer(url: ParametrisedURLString): ServerModel | undefined {

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -602,7 +602,12 @@ export interface OperationModel
   readonly responses: ResponsesModel;
   readonly callbacks: ReadonlyMap<string, CallbackModel>;
   deprecated: boolean;
-  readonly security: ReadonlyArray<SecurityRequirementModel>;
+
+  /**
+   * List of own security requirements.
+   */
+  readonly security: Nullable<ReadonlyArray<SecurityRequirementModel>>;
+
   readonly servers: ReadonlyArray<ServerModel>;
 
   /**
@@ -642,9 +647,33 @@ export interface OperationModel
   deleteCallback(key: string): void;
   clearCallbacks(): void;
 
+  /**
+   * Return effective security requirements for this operation. It uses own requirements,
+   * if defined; otherwise uses global requirements defined in {@link OpenAPIModel}.
+   */
+  getSecurityRequirements(): ReadonlyArray<SecurityRequirementModel>;
+
+  /**
+   * Adds own security requirement.
+   */
   addSecurityRequirement(): SecurityRequirementModel;
+
+  /**
+   * Removes own security requirement at specified index.
+   *
+   * @param index zero-based index
+   */
   deleteSecurityRequirementAt(index: number): void;
+
+  /**
+   * Removes all own security requirements. Does NOT set own requirements to null.
+   */
   clearSecurityRequirements(): void;
+
+  /**
+   * Makes this operation use global security requirements.
+   */
+  resetSecurityRequirements(): void;
 
   getServer(url: ParametrisedURLString): ServerModel | undefined;
   getServerOrThrow(url: ParametrisedURLString): ServerModel;


### PR DESCRIPTION
## Motivation and Context

This PR fixes the bug in treating `OperationModel.security` field. Before it was not possible to distinguish between empty list of sequrity requirements and absence thereof. Therefore, it was not possible to override default security requirements for specific operation.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

- `OperationModel.security` became nullable. If it is `null`, the operation uses default security requirements
- `OperationModel.getSecurityRequirements()` was added, which returns the resolved requirements
- `OperationModel.resetSecurityRequirements()` was added, which makes the operation use default requirements

### Typical use case

```ts
const operation = ... // uses default requirements

const req1 = operation.addSecurityRequirement(); // from now on, uses own requirements
operation.clearSecurityRequirements(); // has empty list of own requirements. In other words, has no security requirements
operation.resetSecurityRequirements(); // uses default requirements, again
```
