### PR TITLE
Add JSONAPIClientDocument definition

### DIFF
--- a/packages/api-tools-core/src/types.test.ts
+++ b/packages/api-tools-core/src/types.test.ts
@@ -1,4 +1,6 @@
 import type {
+  JSONAPIClientDocument,
+  JSONAPIClientResource,
   JSONAPIDataDocument,
   JSONAPIResourceID,
   JSONAPIResourceRelationship,
@@ -101,6 +103,36 @@ test('specific server resource definition', () => {
 
   const anyResource: JSONAPIServerResource = shelter;
   expect(anyResource).toBeTruthy();
+});
+
+test('client documents', () => {
+  type PersonCreateType = 'people-create';
+  type PersonCreate = JSONAPIClientResource<PersonCreateType, { name: string }>;
+
+  type PersonCreateRequest = JSONAPIClientDocument<PersonCreate>;
+
+  const req: PersonCreateRequest = {
+    jsonapi: { version: '1.0' },
+    data: {
+      type: 'people-create',
+      attributes: {
+        name: 'John Dow',
+      },
+    },
+  };
+  expect(req).toBeTruthy();
+
+  type PersonID = JSONAPIResourceID<PersonCreateType>;
+
+  type PersonCreateByIDRequest = JSONAPIClientDocument<PersonID[]>;
+  const req2: PersonCreateByIDRequest = {
+    jsonapi: { version: '1.0' },
+    data: [
+      { type: 'people-create', id: '89' },
+      { type: 'people-create', id: '12' },
+    ],
+  };
+  expect(req2).toBeTruthy();
 });
 
 test('data documents', () => {

--- a/packages/api-tools-core/src/types.ts
+++ b/packages/api-tools-core/src/types.ts
@@ -391,6 +391,39 @@ interface JSONAPIDocumentBase {
   meta?: JSONAPIMeta;
 }
 
+export type JSONAPIClientDocumentPrimaryData =
+  | JSONAPIClientResource
+  | JSONAPIClientResource[]
+  | JSONAPIResourceID
+  | JSONAPIResourceID[];
+
+/**
+ * Client (request) document.
+ *
+ * @typeParam TPrimaryData determines the type of document's primary data. This
+ *  must be either resource ID type or a resource type
+ * @typeParam TIncludedData determines the type(-s) of resources included in
+ *  the document. This must be a resource or a union of resource types.
+ *
+ * @example
+ * type Company = JSONAPIResource<'companies', ...>;
+ * type Department = JSONAPIResource<'departments', ...>;
+ * type Person = JSONAPIResource<'people', ...>;
+ *
+ * // this document has a single company resource as its primary data,
+ * // and a list of either department of person resources included
+ * type CompanyDocument = JSONAPIDataDocument<Company, Department | Person>;
+ *
+ * @see https://jsonapi.org/format/#document-top-level
+ */
+export interface JSONAPIClientDocument<
+  TPrimaryData extends JSONAPIClientDocumentPrimaryData = JSONAPIClientResource,
+  TIncludedData extends JSONAPIClientResource = JSONAPIClientResource,
+> extends JSONAPIDocumentBase {
+  data: TPrimaryData;
+  included?: TIncludedData[];
+}
+
 export type JSONAPIPrimaryDocumentData =
   | JSONAPIServerResource
   | JSONAPIServerResource[]
@@ -399,7 +432,7 @@ export type JSONAPIPrimaryDocumentData =
   | null;
 
 /**
- * Document that contains data.
+ * Server (response) document that contains data.
  *
  * @typeParam TPrimaryData determines the type of document's primary data. This
  *  must be either resource ID type or a resource type
@@ -447,7 +480,7 @@ export interface JSONAPIError {
 }
 
 /**
- * Document that contains error objects.
+ * Server (response) document that contains error objects.
  *
  * @see https://jsonapi.org/format/#document-top-level
  */


### PR DESCRIPTION
## Motivation and Context

This PR adds the `JSONAPIClientDocument` type, to specifically represent client-originating (i.e. request) JSON:API documents. The difference is in the primary data and include types. In client documents, they must extend the `JSONAPIClientResource` instead of `JSONAPIServerResource`.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
