### PR TITLE
Implement OpenAPI linter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1349,6 +1349,16 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/chalk": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-2.2.0.tgz",
+      "integrity": "sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==",
+      "deprecated": "This is a stub types definition for chalk (https://github.com/chalk/chalk). chalk provides its own type definitions, so you don't need @types/chalk installed!",
+      "dev": true,
+      "dependencies": {
+        "chalk": "*"
+      }
+    },
     "node_modules/@types/glob": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.0.0.tgz",
@@ -6823,13 +6833,76 @@
     },
     "packages/openapi-lint": {
       "name": "@fresha/openapi-lint",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
+      "dependencies": {
+        "@fresha/openapi-model": "^0.4.0",
+        "chalk": "^4.1.0",
+        "glob": "^8.0.3",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "fresha-openapi-lint": "bin/fresha-openapi-lint.js"
+      },
       "devDependencies": {
         "@fresha/eslint-config": "0.1.0",
         "@fresha/jest-config": "0.1.0",
         "@fresha/typescript-config": "0.1.0",
+        "@types/chalk": "^2.2.0",
+        "@types/glob": "^8.0.0",
         "typescript": "^4.7.2"
+      }
+    },
+    "packages/openapi-lint/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "packages/openapi-lint/node_modules/chalk": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/openapi-lint/node_modules/glob": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+      "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/openapi-lint/node_modules/minimatch": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+      "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "packages/openapi-model": {
@@ -7944,8 +8017,53 @@
       "requires": {
         "@fresha/eslint-config": "0.1.0",
         "@fresha/jest-config": "0.1.0",
+        "@fresha/openapi-model": "^0.4.0",
         "@fresha/typescript-config": "0.1.0",
-        "typescript": "^4.7.2"
+        "@types/chalk": "^2.2.0",
+        "@types/glob": "^8.0.0",
+        "chalk": "^4.1.0",
+        "glob": "^8.0.3",
+        "typescript": "^4.7.2",
+        "yargs": "^17.6.2"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "glob": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.2.tgz",
+          "integrity": "sha512-bNH9mmM9qsJ2X4r2Nat1B//1dJVcn3+iBLa3IgqJ7EbGaDNepL9QSHOxN4ng33s52VMMhhIfgCYDk3C4ZmlDAg==",
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "@fresha/openapi-model": {
@@ -8388,6 +8506,15 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
+      }
+    },
+    "@types/chalk": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-2.2.0.tgz",
+      "integrity": "sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==",
+      "dev": true,
+      "requires": {
+        "chalk": "*"
       }
     },
     "@types/glob": {

--- a/packages/openapi-lint/bin/fresha-openapi-lint.js
+++ b/packages/openapi-lint/bin/fresha-openapi-lint.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('@fresha/openapi-lint/build/index');

--- a/packages/openapi-lint/package.json
+++ b/packages/openapi-lint/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@fresha/openapi-lint",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Linting tool for OpenAPI schemas",
   "main": "build/index.js",
+  "bin": {
+    "fresha-openapi-lint": "./bin/fresha-openapi-lint.js"
+  },
   "scripts": {
     "build": "tsc",
     "build:watch": "tsc --watch",
@@ -18,6 +21,12 @@
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },
+  "files": [
+    "build/",
+    "package.json",
+    "LICENSE",
+    "README.md"
+  ],
   "keywords": [
     "OpenAPI",
     "lint"
@@ -42,6 +51,14 @@
     "@fresha/eslint-config": "0.1.0",
     "@fresha/jest-config": "0.1.0",
     "@fresha/typescript-config": "0.1.0",
+    "@types/chalk": "^2.2.0",
+    "@types/glob": "^8.0.0",
     "typescript": "^4.7.2"
+  },
+  "dependencies": {
+    "@fresha/openapi-model": "^0.4.0",
+    "chalk": "^4.1.0",
+    "glob": "^8.0.3",
+    "yargs": "^17.6.2"
   }
 }

--- a/packages/openapi-lint/src/Linter.ts
+++ b/packages/openapi-lint/src/Linter.ts
@@ -1,0 +1,40 @@
+import { LinterResult } from './LinterResult';
+import { Rule, preset } from './rules';
+
+import type { OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
+
+export type ConfigOptions = {
+  configPath?: string;
+  autoFix: boolean;
+  verbose: boolean;
+};
+
+export class Linter {
+  readonly #rules: Rule[];
+  readonly #result: LinterResult;
+  readonly #options: ConfigOptions;
+
+  constructor(options: ConfigOptions) {
+    this.#rules = [];
+    this.#result = new LinterResult();
+    this.#options = options;
+  }
+
+  configure(): void {
+    this.#rules.push(...preset);
+  }
+
+  run(openapi: OpenAPIModel, filePath?: string): boolean {
+    this.#result.setCurrentFile(filePath);
+
+    let modified = false;
+    for (const rule of this.#rules) {
+      modified ||= !!rule.run(openapi, this.#result, this.#options);
+    }
+    return modified;
+  }
+
+  print(): void {
+    this.#result.print();
+  }
+}

--- a/packages/openapi-lint/src/LinterResult.ts
+++ b/packages/openapi-lint/src/LinterResult.ts
@@ -1,0 +1,56 @@
+import chalk from 'chalk';
+
+export class LinterResult {
+  #currentFile?: string;
+  #fileItems: Map<string, string[]>;
+  #errorCount: number;
+  #warningCount: number;
+
+  constructor() {
+    this.#currentFile = undefined;
+    this.#fileItems = new Map<string, string[]>();
+    this.#errorCount = 0;
+    this.#warningCount = 0;
+  }
+
+  setCurrentFile(filePath?: string): void {
+    this.#currentFile = filePath;
+  }
+
+  protected addItem(item: string): void {
+    const key = this.#currentFile ?? 'unknown';
+    let items = this.#fileItems.get(key);
+    if (!items) {
+      items = [];
+      this.#fileItems.set(key, items);
+    }
+    items.push(item);
+  }
+
+  addError(message: string): void {
+    this.addItem(`${chalk.red('[error]')} ${message}`);
+    this.#errorCount += 1;
+  }
+
+  addWarning(message: string): void {
+    this.addItem(`${chalk.yellow('[warn] ')} ${message}`);
+    this.#warningCount += 1;
+  }
+
+  print(): void {
+    const fileNames = Array.from(this.#fileItems.keys()).sort();
+    for (const fileName of fileNames) {
+      global.console.log(fileName);
+      for (const item of this.#fileItems.get(fileName)!) {
+        global.console.log(`  ${item}`);
+      }
+    }
+    if (this.#errorCount + this.#warningCount > 0) {
+      global.console.log(
+        `Summary: ${chalk.red(`${this.#errorCount} errors`)}, ${chalk.yellow(
+          `${this.#warningCount} warnings`,
+        )}`,
+      );
+    }
+  }
+}

--- a/packages/openapi-lint/src/index.ts
+++ b/packages/openapi-lint/src/index.ts
@@ -1,0 +1,49 @@
+import { OpenAPIReader, OpenAPIWriter } from '@fresha/openapi-model/build/3.0.3';
+import glob from 'glob';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+import { Linter } from './Linter';
+
+try {
+  const argv = yargs(hideBin(process.argv))
+    .epilog(
+      'For more information, see https://github.com/fresha/api-tools/tree/main/packages/openapi-lint',
+    )
+    .usage('Usage: $0 [OPTIONS] FILES')
+    .string('config')
+    .alias('config', 'c')
+    .describe('config', 'Path to configuration file')
+    .boolean('fix')
+    .describe('fix', 'Automatically fix problems')
+    .boolean('verbose')
+    .alias('verbose', 'v')
+    .describe('verbose', 'Print more information on console')
+    .parseSync();
+
+  const reader = new OpenAPIReader();
+
+  const linter = new Linter({
+    configPath: argv.config,
+    autoFix: !!argv.fix,
+    verbose: !!argv.verbose,
+  });
+  linter.configure();
+
+  for (const elem of argv._) {
+    if (typeof elem === 'string') {
+      for (const fpath of glob.sync(String(elem))) {
+        const openapi = reader.parseFromFile(fpath);
+        if (linter.run(openapi, fpath)) {
+          const writer = new OpenAPIWriter();
+          writer.writeToFile(openapi, fpath);
+        }
+      }
+    }
+  }
+
+  linter.print();
+} catch (err) {
+  global.console.log(err);
+  process.exit(1);
+}

--- a/packages/openapi-lint/src/rules/fresha/audienceValue.ts
+++ b/packages/openapi-lint/src/rules/fresha/audienceValue.ts
@@ -1,0 +1,28 @@
+import { isDisabled } from '../utils';
+
+import type { LinterResult } from '../../LinterResult';
+import type { RuleFunc } from '../types';
+import type { OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
+
+const ALLOWED_AUDIENCE = [
+  'internal-team',
+  'internal-company',
+  'external-partner',
+  'external-public',
+];
+
+export const id = 'schema-audience-is-set';
+
+export const autoFixable = false;
+
+export const run: RuleFunc = (openapi: OpenAPIModel, result: LinterResult): boolean => {
+  if (!isDisabled(openapi.info, id)) {
+    const audience = openapi.info.getExtension('audience');
+    if (!audience || typeof audience !== 'string') {
+      result.addError('x-audience property is missing');
+    } else if (!ALLOWED_AUDIENCE.includes(audience)) {
+      result.addError(`Audience property has illegal value: ${audience}`);
+    }
+  }
+  return false;
+};

--- a/packages/openapi-lint/src/rules/fresha/contactProperties.ts
+++ b/packages/openapi-lint/src/rules/fresha/contactProperties.ts
@@ -1,0 +1,18 @@
+import type { LinterResult } from '../../LinterResult';
+import type { RuleFunc } from '../types';
+import type { OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
+
+export const id = 'contact-properties';
+
+export const autoFixable = false;
+
+export const run: RuleFunc = (openapi: OpenAPIModel, result: LinterResult): boolean => {
+  const { contact } = openapi.info;
+  if (!contact.name?.match(/^team-/)) {
+    result.addError('Contact name must be valid team name');
+  }
+  if (!contact.url?.startsWith('https://github.com/orgs/surgeventures/teams/team-')) {
+    result.addError('Contact URL must point to GitHub team page');
+  }
+  return false;
+};

--- a/packages/openapi-lint/src/rules/fresha/identifierMustBeAnUuid.ts
+++ b/packages/openapi-lint/src/rules/fresha/identifierMustBeAnUuid.ts
@@ -1,0 +1,21 @@
+import type { LinterResult } from '../../LinterResult';
+import type { RuleFunc } from '../types';
+import type { OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
+
+export const id = 'schema-id-is-uuid';
+
+export const autoFixable = false;
+
+export const run: RuleFunc = (openapi: OpenAPIModel, result: LinterResult): boolean => {
+  const schemaId = openapi.info.getExtension('id');
+  if (
+    !schemaId ||
+    typeof schemaId !== 'string' ||
+    !schemaId.match(
+      /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/,
+    )
+  ) {
+    result.addError('Schema ID must be a GUID');
+  }
+  return false;
+};

--- a/packages/openapi-lint/src/rules/fresha/identifierMustBeUnique.ts
+++ b/packages/openapi-lint/src/rules/fresha/identifierMustBeUnique.ts
@@ -1,0 +1,17 @@
+import type { LinterResult } from '../../LinterResult';
+import type { RuleFunc } from '../types';
+import type { OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
+
+export const id = 'schemas-ids-are-unique';
+
+export const autoFixable = false;
+
+const uuids = new Map<string, Set<string>>();
+
+export const run: RuleFunc = (openapi: OpenAPIModel, result: LinterResult): boolean => {
+  const schemaId = openapi.info.getExtension('id');
+  if (schemaId && typeof schemaId === 'string' && uuids.has(schemaId)) {
+    result.addError(`Duplicate schema ID: ${schemaId}`);
+  }
+  return false;
+};

--- a/packages/openapi-lint/src/rules/fresha/index.ts
+++ b/packages/openapi-lint/src/rules/fresha/index.ts
@@ -1,0 +1,21 @@
+import * as audienceValue from './audienceValue';
+import * as contactProperties from './contactProperties';
+import * as identifierMustBeAnUuid from './identifierMustBeAnUuid';
+import * as identifierMustBeUnique from './identifierMustBeUnique';
+import * as sharedSchemaTitle from './sharedSchemaTitles';
+import * as sortPathItem from './sortPathItem';
+import * as sortSharedSchema from './sortSharedSchema';
+import * as versionIsSemver from './versionIsSemver';
+
+import type { Rule } from '../types';
+
+export const preset: Rule[] = [
+  audienceValue,
+  contactProperties,
+  identifierMustBeAnUuid,
+  identifierMustBeUnique,
+  sharedSchemaTitle,
+  sortPathItem,
+  sortSharedSchema,
+  versionIsSemver,
+];

--- a/packages/openapi-lint/src/rules/fresha/sharedSchemaTitles.ts
+++ b/packages/openapi-lint/src/rules/fresha/sharedSchemaTitles.ts
@@ -1,0 +1,36 @@
+import { isDisabled } from '../utils';
+
+import type { LinterResult } from '../../LinterResult';
+import type { RuleFunc, RuleOptions } from '../types';
+import type { OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
+
+export const id = 'shared-schema-title-is-set';
+
+export const autoFixable = true;
+
+export const run: RuleFunc = (
+  openapi: OpenAPIModel,
+  result: LinterResult,
+  options: RuleOptions,
+): boolean => {
+  let modified = false;
+
+  if (!isDisabled(openapi, id)) {
+    for (const [key, schema] of openapi.components.schemas) {
+      if (!schema.title) {
+        if (options.autoFix) {
+          schema.title = key;
+          modified = true;
+        } else {
+          result.addError(`Schema title for key ${key} must not be empty`);
+        }
+      } else if (schema.title !== key) {
+        result.addWarning(
+          `Shared schema title (${String(schema.title)}) is different from key (${key})`,
+        );
+      }
+    }
+  }
+
+  return modified;
+};

--- a/packages/openapi-lint/src/rules/fresha/sortPathItem.ts
+++ b/packages/openapi-lint/src/rules/fresha/sortPathItem.ts
@@ -1,0 +1,36 @@
+import { arrayEqual, isDisabled } from '../utils';
+
+import type { LinterResult } from '../../LinterResult';
+import type { RuleFunc, RuleOptions } from '../types';
+import type { OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
+
+export const id = 'path-items-sort';
+
+export const autoFixable = true;
+
+export const run: RuleFunc = (
+  openapi: OpenAPIModel,
+  result: LinterResult,
+  options: RuleOptions,
+): boolean => {
+  let modified = false;
+
+  if (!isDisabled(openapi, id)) {
+    const pathUrls = Array.from(openapi.paths.keys());
+    const sortedPathUrls = pathUrls.slice();
+    sortedPathUrls.sort();
+
+    if (!arrayEqual(pathUrls, sortedPathUrls)) {
+      if (options.autoFix) {
+        openapi.paths.sort(([key1]: [string, unknown], [key2]: [string, unknown]) =>
+          key1.localeCompare(key2),
+        );
+        modified = true;
+      } else {
+        result.addWarning('Path items must be sorted according to their URLs');
+      }
+    }
+  }
+
+  return modified;
+};

--- a/packages/openapi-lint/src/rules/fresha/sortSharedSchema.ts
+++ b/packages/openapi-lint/src/rules/fresha/sortSharedSchema.ts
@@ -1,0 +1,36 @@
+import { arrayEqual, isDisabled } from '../utils';
+
+import type { LinterResult } from '../../LinterResult';
+import type { RuleFunc, RuleOptions } from '../types';
+import type { OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
+
+export const id = 'shared-schema-sort';
+
+export const autoFixable = true;
+
+export const run: RuleFunc = (
+  openapi: OpenAPIModel,
+  result: LinterResult,
+  options: RuleOptions,
+): boolean => {
+  let modified = false;
+
+  if (!isDisabled(openapi, id)) {
+    const schemaKeys = Array.from(openapi.components.schemas.keys());
+    const sortedSchemaKeys = schemaKeys.slice();
+    sortedSchemaKeys.sort();
+
+    if (!arrayEqual(schemaKeys, sortedSchemaKeys)) {
+      if (options.autoFix) {
+        openapi.components.sortSchemas(([key1]: [string, unknown], [key2]: [string, unknown]) =>
+          key1.localeCompare(key2),
+        );
+        modified = true;
+      } else {
+        result.addWarning('Shared schemas must be sorted according to their keys');
+      }
+    }
+  }
+
+  return modified;
+};

--- a/packages/openapi-lint/src/rules/fresha/versionIsSemver.ts
+++ b/packages/openapi-lint/src/rules/fresha/versionIsSemver.ts
@@ -1,0 +1,15 @@
+import type { LinterResult } from '../../LinterResult';
+import type { RuleFunc } from '../types';
+import type { OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
+
+export const id = 'schema-version-is-semver';
+
+export const autoFixable = false;
+
+export const run: RuleFunc = (openapi: OpenAPIModel, result: LinterResult): boolean => {
+  const { version } = openapi.info;
+  if (!version || typeof version !== 'string' || !version.match(/^\d+\.\d+\.\d+$/)) {
+    result.addError('Version does not conform to semver 2.0 spec');
+  }
+  return false;
+};

--- a/packages/openapi-lint/src/rules/index.ts
+++ b/packages/openapi-lint/src/rules/index.ts
@@ -1,0 +1,9 @@
+import { preset as freshaPreset } from './fresha';
+import { preset as jsonApiPreset } from './json-api';
+import { preset as openApiPreset } from './oas3';
+
+import type { Rule } from './types';
+
+export * from './types';
+
+export const preset: Rule[] = [...openApiPreset, ...jsonApiPreset, ...freshaPreset];

--- a/packages/openapi-lint/src/rules/json-api/index.ts
+++ b/packages/openapi-lint/src/rules/json-api/index.ts
@@ -1,0 +1,5 @@
+import * as jsonApiContentType from './jsonApiContentType';
+
+import type { Rule } from '../types';
+
+export const preset: Rule[] = [jsonApiContentType];

--- a/packages/openapi-lint/src/rules/json-api/jsonApiContentType.ts
+++ b/packages/openapi-lint/src/rules/json-api/jsonApiContentType.ts
@@ -1,0 +1,48 @@
+import { isDisabled } from '../utils';
+
+import type { LinterResult } from '../../LinterResult';
+import type { RuleFunc } from '../types';
+import type { OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
+
+export const id = 'json-api-content-type';
+
+export const autoFixable = false;
+
+const JSON_API_MEDIA_TYPE = 'application/vnd.api+json';
+
+export const run: RuleFunc = (openapi: OpenAPIModel, result: LinterResult): boolean => {
+  for (const [pathUrl, pathItem] of openapi.paths) {
+    for (const [httpMethod, { requestBody, responses }] of pathItem.operations()) {
+      if (requestBody && !isDisabled(requestBody, id)) {
+        if (requestBody?.content && !requestBody.getContent(JSON_API_MEDIA_TYPE)) {
+          result.addError(
+            `Operation ${httpMethod.toUpperCase()} '${pathUrl}' does not define '${JSON_API_MEDIA_TYPE}' request body`,
+          );
+        }
+      }
+      if (responses.default && !isDisabled(responses.default, id)) {
+        if (responses.default.content.size && !responses.default?.getContent(JSON_API_MEDIA_TYPE)) {
+          result.addError(
+            `Operation ${httpMethod.toUpperCase()} '${pathUrl}' does not define '${JSON_API_MEDIA_TYPE}' default response`,
+          );
+        }
+        for (const [code, response] of responses.codes) {
+          if (!isDisabled(response, id)) {
+            if (response.content.size && !response.getContent(JSON_API_MEDIA_TYPE)) {
+              global.console.log({
+                pathUrl,
+                httpMethod,
+                mediaTypes: Array.from(response.content.keys()),
+              });
+              result.addError(
+                `Operation ${httpMethod.toUpperCase()} '${pathUrl}' does not define '${JSON_API_MEDIA_TYPE}' response for ${code} code`,
+              );
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return false;
+};

--- a/packages/openapi-lint/src/rules/oas3/duplicateTags.ts
+++ b/packages/openapi-lint/src/rules/oas3/duplicateTags.ts
@@ -1,0 +1,42 @@
+import { isDisabled } from '../utils';
+
+import type { LinterResult } from '../../LinterResult';
+import type { RuleFunc, RuleOptions } from '../types';
+import type { OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
+
+export const id = 'duplicate-tags';
+
+export const autoFixable = true;
+
+export const run: RuleFunc = (
+  openapi: OpenAPIModel,
+  result: LinterResult,
+  options: RuleOptions,
+): boolean => {
+  const modified = false;
+
+  if (!isDisabled(openapi, id)) {
+    if (options.autoFix) {
+      let i = openapi.tags.length;
+      while (i >= 0) {
+        const tagName = openapi.tags[i].name;
+        const j = openapi.tags.findIndex(tag => tag.name === tagName);
+        if (j >= 0 && j < i) {
+          openapi.deleteTagAt(i);
+        }
+        i -= 1;
+      }
+    } else {
+      const tagNames = new Set<string>();
+      for (const tag of openapi.tags) {
+        if (tagNames.has(tag.name)) {
+          result.addError(`Duplicate tag '${tag.name}'`);
+        } else {
+          tagNames.add(tag.name);
+        }
+      }
+    }
+  }
+
+  return modified;
+};

--- a/packages/openapi-lint/src/rules/oas3/index.ts
+++ b/packages/openapi-lint/src/rules/oas3/index.ts
@@ -1,0 +1,27 @@
+import * as duplicateTags from './duplicateTags';
+import * as infoProperties from './infoProperties';
+import * as noServerUrlTrailingSlash from './noServerUrlTrailingSlash';
+import * as noUnusedSharedComponents from './noUnusedSharedComponents';
+import * as operationMustHaveUniqueId from './operationMustHaveUniqueId';
+import * as operationMustDefineSuccessResponses from './operationSuccessResponse';
+import * as operationTagsDefined from './operationTagsDefined';
+import * as operationParamsMustBeUnique from './operationUniqueParams';
+import * as parameterDescription from './parameterDescription';
+import * as serverList from './serverList';
+import * as tagsDescriptions from './tagsDescriptions';
+
+import type { Rule } from '../types';
+
+export const preset: Rule[] = [
+  infoProperties,
+  operationMustHaveUniqueId,
+  operationMustDefineSuccessResponses,
+  operationParamsMustBeUnique,
+  noUnusedSharedComponents,
+  serverList,
+  noServerUrlTrailingSlash,
+  parameterDescription,
+  operationTagsDefined,
+  tagsDescriptions,
+  duplicateTags,
+];

--- a/packages/openapi-lint/src/rules/oas3/infoProperties.ts
+++ b/packages/openapi-lint/src/rules/oas3/infoProperties.ts
@@ -1,0 +1,18 @@
+import type { LinterResult } from '../../LinterResult';
+import type { RuleFunc } from '../types';
+import type { OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
+
+export const id = 'info-properties';
+
+export const autoFixable = false;
+
+export const run: RuleFunc = (openapi: OpenAPIModel, result: LinterResult): boolean => {
+  const { title, description } = openapi.info;
+  if (!title || typeof title !== 'string') {
+    result.addError('Schema title must not be empty');
+  }
+  if (!description || typeof description !== 'string') {
+    result.addError('Schema description must not be empty');
+  }
+  return false;
+};

--- a/packages/openapi-lint/src/rules/oas3/noServerUrlTrailingSlash.ts
+++ b/packages/openapi-lint/src/rules/oas3/noServerUrlTrailingSlash.ts
@@ -1,0 +1,16 @@
+import type { LinterResult } from '../../LinterResult';
+import type { RuleFunc } from '../types';
+import type { OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
+
+export const id = 'no-server-url-trailing-slash';
+
+export const autoFixable = false;
+
+export const run: RuleFunc = (openapi: OpenAPIModel, result: LinterResult): boolean => {
+  for (const server of openapi.servers) {
+    if (server.url.endsWith('/')) {
+      result.addWarning(`Server URL '${server.url}' must not have trailing slash`);
+    }
+  }
+  return false;
+};

--- a/packages/openapi-lint/src/rules/oas3/noUnusedSharedComponents.ts
+++ b/packages/openapi-lint/src/rules/oas3/noUnusedSharedComponents.ts
@@ -1,0 +1,98 @@
+import { OpenAPIModel, SchemaModel } from '@fresha/openapi-model/build/3.0.3';
+
+import type { LinterResult } from '../../LinterResult';
+import type { RuleFunc } from '../types';
+
+export const id = 'no-unused-shared-components';
+
+export const autoFixable = false;
+
+const removeReferenceSchema = (schema: SchemaModel, sharedSchemas: Set<SchemaModel>): void => {
+  for (const prop of schema.properties.values()) {
+    removeReferenceSchema(prop, sharedSchemas);
+  }
+  if (schema.additionalProperties && schema.additionalProperties instanceof Object) {
+    removeReferenceSchema(schema.additionalProperties, sharedSchemas);
+  }
+  if (schema.items) {
+    removeReferenceSchema(schema.items, sharedSchemas);
+  }
+  if (schema.allOf?.length) {
+    for (const alt of schema.allOf) {
+      removeReferenceSchema(alt, sharedSchemas);
+    }
+  }
+  if (schema.anyOf?.length) {
+    for (const alt of schema.anyOf) {
+      removeReferenceSchema(alt, sharedSchemas);
+    }
+  }
+  if (schema.oneOf?.length) {
+    for (const alt of schema.oneOf) {
+      removeReferenceSchema(alt, sharedSchemas);
+    }
+  }
+
+  sharedSchemas.delete(schema);
+};
+
+const findUnusedSharedSchemas = (openapi: OpenAPIModel): Set<SchemaModel> => {
+  const sharedSchemas = new Set<SchemaModel>(openapi.components.schemas.values());
+
+  for (const pathItem of openapi.paths.values()) {
+    for (const param of pathItem.parameters) {
+      if (param.schema) {
+        removeReferenceSchema(param.schema, sharedSchemas);
+      }
+    }
+
+    for (const [, operation] of pathItem.operations()) {
+      for (const param of operation.parameters) {
+        if (param.schema) {
+          removeReferenceSchema(param.schema, sharedSchemas);
+        }
+      }
+
+      if (operation.requestBody) {
+        for (const content of operation.requestBody.content.values()) {
+          if (content.schema) {
+            removeReferenceSchema(content.schema, sharedSchemas);
+          }
+        }
+      }
+      if (operation.responses.default) {
+        for (const content of operation.responses.default.content.values()) {
+          if (content.schema) {
+            removeReferenceSchema(content.schema, sharedSchemas);
+          }
+        }
+      }
+      for (const response of operation.responses.codes.values()) {
+        for (const content of response.content.values()) {
+          if (content.schema) {
+            removeReferenceSchema(content.schema, sharedSchemas);
+          }
+        }
+      }
+    }
+  }
+
+  for (const sharedResponse of openapi.components.responses.values()) {
+    for (const content of sharedResponse.content.values()) {
+      if (content.schema) {
+        removeReferenceSchema(content.schema, sharedSchemas);
+      }
+    }
+  }
+
+  return sharedSchemas;
+};
+
+export const run: RuleFunc = (openapi: OpenAPIModel, result: LinterResult): boolean => {
+  const unusedSchemas = findUnusedSharedSchemas(openapi);
+  for (const schema of unusedSchemas) {
+    result.addWarning(`Shared schema ${schema.title ?? 'anonymous'} is unused`);
+  }
+
+  return false;
+};

--- a/packages/openapi-lint/src/rules/oas3/operationMustHaveUniqueId.ts
+++ b/packages/openapi-lint/src/rules/oas3/operationMustHaveUniqueId.ts
@@ -1,0 +1,34 @@
+import type { LinterResult } from '../../LinterResult';
+import type { RuleFunc } from '../types';
+import type { OpenAPIModel, OperationModel } from '@fresha/openapi-model/build/3.0.3';
+
+export const id = 'operation-id-is-unique';
+
+export const autoFixable = false;
+
+export const run: RuleFunc = (openapi: OpenAPIModel, result: LinterResult): boolean => {
+  const operationIds = new Map<string, Set<OperationModel>>();
+
+  for (const [pathUrl, pathItem] of openapi.paths) {
+    for (const [httpMethod, operation] of pathItem.operations()) {
+      if (!operation.operationId) {
+        result.addError(`Operation ${httpMethod.toUpperCase()} '${pathUrl}' has empty ID`);
+      } else {
+        let ops = operationIds.get(operation.operationId);
+        if (!ops) {
+          ops = new Set<OperationModel>();
+          operationIds.set(operation.operationId, ops);
+        }
+        ops.add(operation);
+      }
+    }
+  }
+
+  for (const [operationId, operations] of operationIds) {
+    if (operations.size > 1) {
+      result.addError(`Operation ID '${operationId}' is used in ${operations.size} operations`);
+    }
+  }
+
+  return false;
+};

--- a/packages/openapi-lint/src/rules/oas3/operationSuccessResponse.ts
+++ b/packages/openapi-lint/src/rules/oas3/operationSuccessResponse.ts
@@ -1,0 +1,31 @@
+import { isDisabled } from '../utils';
+
+import type { LinterResult } from '../../LinterResult';
+import type { RuleFunc } from '../types';
+import type { OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
+
+export const id = 'operation-success-response';
+
+export const autoFixable = false;
+
+export const run: RuleFunc = (openapi: OpenAPIModel, result: LinterResult): boolean => {
+  for (const [pathUrl, pathItem] of openapi.paths) {
+    for (const [httpMethod, operation] of pathItem.operations()) {
+      if (!isDisabled(operation, id)) {
+        let hasSuccessResponse = false;
+        for (const code of operation.responses.codes.keys()) {
+          const codeNumber = Number(code);
+          if (codeNumber >= 200 && codeNumber < 400) {
+            hasSuccessResponse = true;
+          }
+        }
+        if (!hasSuccessResponse) {
+          result.addError(
+            `Operation ${httpMethod.toUpperCase()} '${pathUrl}' does not define any success responses`,
+          );
+        }
+      }
+    }
+  }
+  return false;
+};

--- a/packages/openapi-lint/src/rules/oas3/operationTagsDefined.ts
+++ b/packages/openapi-lint/src/rules/oas3/operationTagsDefined.ts
@@ -1,0 +1,23 @@
+import type { LinterResult } from '../../LinterResult';
+import type { RuleFunc } from '../types';
+import type { OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
+
+export const id = 'operation-tags-defined';
+
+export const autoFixable = false;
+
+export const run: RuleFunc = (openapi: OpenAPIModel, result: LinterResult): boolean => {
+  const tagNames = new Set<string>(openapi.tags.map(t => t.name));
+  for (const [pathUrl, pathItem] of openapi.paths) {
+    for (const [httpMethod, operation] of pathItem.operations()) {
+      for (const operationTag of operation.tags) {
+        if (!tagNames.has(operationTag)) {
+          result.addWarning(
+            `Operation ${httpMethod.toUpperCase()} ${pathUrl} has tag ${operationTag} which is not defined in the schema`,
+          );
+        }
+      }
+    }
+  }
+  return false;
+};

--- a/packages/openapi-lint/src/rules/oas3/operationUniqueParams.ts
+++ b/packages/openapi-lint/src/rules/oas3/operationUniqueParams.ts
@@ -1,0 +1,43 @@
+import { OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
+
+import { LinterResult } from '../../LinterResult';
+import { RuleFunc } from '../types';
+import { isDisabled } from '../utils';
+
+export const id = 'operation-params-unique';
+
+export const autoFixable = false;
+
+export const run: RuleFunc = (openapi: OpenAPIModel, result: LinterResult): boolean => {
+  for (const [pathUrl, pathItem] of openapi.paths) {
+    const pathItemParams = new Set<string>();
+    for (const param of pathItem.parameters) {
+      if (!isDisabled(pathItem, id)) {
+        const key = `${param.in}:${param.name}`;
+        if (pathItemParams.has(key)) {
+          result.addError(`Duplicate parameter '${key}' in path item '${pathUrl}'`);
+        } else {
+          pathItemParams.add(key);
+        }
+      }
+    }
+
+    for (const [httpMethod, operation] of pathItem.operations()) {
+      if (!isDisabled(operation, id)) {
+        const operationParams = new Set<string>();
+        for (const param of operation.parameters) {
+          const key = `${param.in}:${param.name}`;
+          if (pathItemParams.has(key)) {
+            result.addError(
+              `Duplicate parameter ${key} in operation ${httpMethod.toLocaleUpperCase()} '${pathUrl}'`,
+            );
+          } else {
+            operationParams.add(key);
+          }
+        }
+      }
+    }
+  }
+
+  return false;
+};

--- a/packages/openapi-lint/src/rules/oas3/parameterDescription.ts
+++ b/packages/openapi-lint/src/rules/oas3/parameterDescription.ts
@@ -1,0 +1,39 @@
+import { isDisabled } from '../utils';
+
+import type { LinterResult } from '../../LinterResult';
+import type { RuleFunc } from '../types';
+import type { OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
+
+export const id = 'parameter-description';
+
+export const autoFixable = false;
+
+export const run: RuleFunc = (openapi: OpenAPIModel, result: LinterResult): boolean => {
+  for (const [pathUrl, pathItem] of openapi.paths) {
+    if (!isDisabled(pathItem, id)) {
+      for (const param of pathItem.parameters) {
+        if (!param.description) {
+          result.addError(
+            `Parameter ${param.name} of the ${pathUrl} item does not have a description`,
+          );
+        }
+      }
+    }
+
+    for (const [httpMethod, operation] of pathItem.operations()) {
+      if (!isDisabled(operation, id)) {
+        for (const param of operation.parameters) {
+          if (!param.description) {
+            result.addError(
+              `Parameter ${
+                param.name
+              } of ${httpMethod.toUpperCase()} ${pathUrl} operation does not have a description`,
+            );
+          }
+        }
+      }
+    }
+  }
+
+  return false;
+};

--- a/packages/openapi-lint/src/rules/oas3/serverList.ts
+++ b/packages/openapi-lint/src/rules/oas3/serverList.ts
@@ -1,0 +1,18 @@
+import { isDisabled } from '../utils';
+
+import type { LinterResult } from '../../LinterResult';
+import type { RuleFunc } from '../types';
+import type { OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
+
+export const id = 'server-list';
+
+export const autoFixable = false;
+
+export const run: RuleFunc = (openapi: OpenAPIModel, result: LinterResult): boolean => {
+  if (!isDisabled(openapi, id)) {
+    if (!openapi.servers.length) {
+      result.addError(`Server list must not be empty`);
+    }
+  }
+  return false;
+};

--- a/packages/openapi-lint/src/rules/oas3/tagsDescriptions.ts
+++ b/packages/openapi-lint/src/rules/oas3/tagsDescriptions.ts
@@ -1,0 +1,17 @@
+import { OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
+
+import { LinterResult } from '../../LinterResult';
+import { RuleFunc } from '../types';
+
+export const id = 'tags-descriptions';
+
+export const autoFixable = false;
+
+export const run: RuleFunc = (openapi: OpenAPIModel, result: LinterResult): boolean => {
+  for (const tag of openapi.tags) {
+    if (!tag.description) {
+      result.addWarning(`Tag '${tag.name}' does not have a description`);
+    }
+  }
+  return false;
+};

--- a/packages/openapi-lint/src/rules/types.ts
+++ b/packages/openapi-lint/src/rules/types.ts
@@ -1,0 +1,19 @@
+import type { LinterResult } from '../LinterResult';
+import type { OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
+
+export interface RuleOptions {
+  autoFix: boolean;
+}
+
+export type RuleFunc = (
+  openapi: OpenAPIModel,
+  result: LinterResult,
+  options: RuleOptions,
+) => boolean;
+
+export interface Rule {
+  readonly id: string;
+  readonly autoFixable: boolean;
+
+  run: RuleFunc;
+}

--- a/packages/openapi-lint/src/rules/utils.ts
+++ b/packages/openapi-lint/src/rules/utils.ts
@@ -1,0 +1,38 @@
+import type { OpenAPIModel, SpecificationExtensionsModel } from '@fresha/openapi-model/build/3.0.3';
+
+export const arrayEqual = (arr1: string[], arr2: string[]): boolean => {
+  if (arr1 === arr2) {
+    return true;
+  }
+  if (arr1.length !== arr2.length) {
+    return false;
+  }
+  for (let i = 0; i < arr1.length; i += 1) {
+    if (arr1[i] !== arr2[i]) {
+      return false;
+    }
+  }
+  return true;
+};
+
+type Node = SpecificationExtensionsModel & {
+  root: OpenAPIModel;
+};
+
+const isDisabledOnSelf = (obj: SpecificationExtensionsModel, ruleId: string): boolean => {
+  const ext = obj.getExtension('fresha-lint-disable');
+  if (ext == null) {
+    return false;
+  }
+  if (ext === true) {
+    return true;
+  }
+  if (Array.isArray(ext)) {
+    return ext.includes(ruleId);
+  }
+  return false;
+};
+
+export const isDisabled = (obj: Node, ruleId: string): boolean => {
+  return isDisabledOnSelf(obj, ruleId) || isDisabledOnSelf(obj.root, ruleId);
+};

--- a/packages/openapi-model/src/3.0.3/model/Components.ts
+++ b/packages/openapi-model/src/3.0.3/model/Components.ts
@@ -106,6 +106,16 @@ export class Components extends BasicNode<ComponentsModelParent> implements Comp
     this.schemas.clear();
   }
 
+  sortSchemas(
+    sorter: (entry1: [string, SchemaModel], entry2: [string, SchemaModel]) => number,
+  ): void {
+    const entries = Array.from(this.schemas.entries()).sort(sorter);
+    this.schemas.clear();
+    for (const [key, value] of entries) {
+      this.schemas.set(key, value);
+    }
+  }
+
   getResponse(name: string): ResponseModel | undefined {
     return this.responses.get(name);
   }

--- a/packages/openapi-model/src/3.0.3/model/Paths.ts
+++ b/packages/openapi-model/src/3.0.3/model/Paths.ts
@@ -90,4 +90,13 @@ export class Paths extends BasicNode<PathsModelParent> implements PathsModel {
   get [Symbol.toStringTag](): string {
     return this.items[Symbol.toStringTag];
   }
+
+  sort(sorter: (entry1: [string, PathItemModel], entry2: [string, PathItemModel]) => number): void {
+    const entries = Array.from(this.items).sort(sorter);
+
+    this.items.clear();
+    for (const [key, value] of entries) {
+      this.items.set(key, value);
+    }
+  }
 }

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -774,6 +774,13 @@ export interface PathsModel
    * in this paths collection, throws an exception.
    */
   getItemUrlOrThrow(pathItem: PathItemModel): ParametrisedURLString;
+
+  sort(
+    sorter: (
+      entry1: [ParametrisedURLString, PathItemModel],
+      entry2: [ParametrisedURLString, PathItemModel],
+    ) => number,
+  ): void;
 }
 
 export type SecuritySchemaModelParent = ComponentsModel;
@@ -977,6 +984,9 @@ export interface ComponentsModel
   setSchema(name: string, type?: SchemaType): SchemaModel;
   deleteSchema(name: string): void;
   clearSchemas(): void;
+  sortSchemas(
+    sorter: (entry1: [string, SchemaModel], entry2: [string, SchemaModel]) => number,
+  ): void;
 
   getResponse(name: string): ResponseModel | undefined;
   getResponseOrThrow(name: string): ResponseModel;


### PR DESCRIPTION
## Motivation and Context

This PR implements the `fresha-openapi-lint` command. Which is a linter for OpenAPI schemas.

Previously, we've been using Spectral linter from Stoplight. However, it lacked a couple of features we need:

- ability to disable certain rules, both globally and per schema object (e.g. for specific Operation). This is very useful during schema migrations
- auto-fix mode, when the linter automatically fixes some mistakes (e.g. sorting or duplicates, which would be time-consuming to fix by hand)

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
