### PR TITLE
Openapi codegen client fetch improvement

### DIFF
--- a/packages/openapi-codegen-client-fetch/src/Generator.ts
+++ b/packages/openapi-codegen-client-fetch/src/Generator.ts
@@ -1,5 +1,3 @@
-import path from 'path';
-
 import { Generator as GeneratorBase, getOperations } from '@fresha/openapi-codegen-utils';
 import { SourceFile, ts } from 'ts-morph';
 
@@ -18,11 +16,7 @@ export class Generator extends GeneratorBase<Context> {
   constructor(context: Context) {
     super(context);
     this.context = context;
-    this.sourceFile = this.context.project.createSourceFile(
-      path.join(this.context.outputPath, 'src', 'actions.ts'),
-      '',
-      { overwrite: true },
-    );
+    this.sourceFile = this.context.createSourceFile('src/actions.ts');
     this.actionFuncs = new Map<string, ActionFunc>();
     this.namedTypes = new Map<string, NamedType>();
     this.indexFile = new IndexFile(this.context);

--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
@@ -1,5 +1,5 @@
 import { buildEmployeeSchemasForTesting } from '@fresha/openapi-codegen-test-utils';
-import { MEDIA_TYPE_JSON_API } from '@fresha/openapi-codegen-utils';
+import { MEDIA_TYPE_JSON_API, setResourceSchema } from '@fresha/openapi-codegen-utils';
 import { OpenAPIFactory, OperationModel } from '@fresha/openapi-model/build/3.0.3';
 
 import '@fresha/openapi-codegen-test-utils/build/matchers';
@@ -39,7 +39,7 @@ test('simple test', () => {
       COMMON_HEADERS,
       authorizeRequest,
       makeUrl,
-      makeCall,
+      callJsonApi,
       toString,
     } from './utils';
     import type {
@@ -74,9 +74,66 @@ test('simple test', () => {
         headers: COMMON_HEADERS,
       };
 
-      const response = await makeCall(url, request);
+      const response = await callJsonApi(url, request);
 
       return response as unknown as ReadEmployeeListResponse;
+    }
+  `);
+});
+
+test('action returns raw response', () => {
+  const openapi = OpenAPIFactory.create();
+
+  const schema = openapi.components.setSchema('EmployeeResource');
+  setResourceSchema(schema, 'employees');
+
+  const operation = openapi.setPathItem('/employees').setOperation('get');
+  operation.operationId = 'readEmployeeList';
+  operation
+    .setResponse(200, 'returns a list of employees')
+    .setContent(MEDIA_TYPE_JSON_API)
+    .setSchema('object')
+    .setProperty('data', 'array').items = schema;
+  operation.setExtension('fresha-codegen', {
+    'client-fetch': {
+      return: 'response',
+    },
+  });
+
+  const namedTypes = new Map<string, NamedType>();
+  const generatedTypes = new Set<string>();
+
+  const action = createAction(operation);
+  action.collectData(namedTypes);
+  action.generateCode(generatedTypes);
+
+  expect(action.context.project.getSourceFile('src/index.ts')).toHaveFormattedTypeScriptText(`
+    import {
+      COMMON_HEADERS,
+      authorizeRequest,
+      makeUrl,
+      callApi,
+      toString,
+    } from './utils';
+    import type {
+      JSONAPIServerResource,
+      JSONAPIDataDocument,
+    } from "@fresha/api-tools-core";
+
+    export type EmployeeResource = JSONAPIServerResource<'employees'>;
+
+    export type ReadEmployeeListResponse = JSONAPIDataDocument<EmployeeResource[]>;
+
+    export async function readEmployeeList(): Promise<Response> {
+      const url = makeUrl(\`/employees\`);
+
+      const request = {
+        headers: COMMON_HEADERS,
+      };
+
+      const response = await callApi(url, request);
+
+      return response;
     }
   `);
 });

--- a/packages/openapi-codegen-client-fetch/src/parts/DocumentType.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/DocumentType.test.ts
@@ -85,7 +85,7 @@ describe('primary data', () => {
         JSONAPIDataDocument,
       } from '@fresha/api-tools-core';
 
-      export type Employee = JSONAPIServerResource<'employees', {}>;
+      export type Employee = JSONAPIServerResource<'employees'>;
 
       export type SimpleResponseDocument = JSONAPIDataDocument<Employee>;
     `);
@@ -111,7 +111,7 @@ describe('primary data', () => {
         JSONAPIDataDocument,
       } from '@fresha/api-tools-core';
 
-      export type Unknown1 = JSONAPIServerResource<'employees', {}>;
+      export type Unknown1 = JSONAPIServerResource<'employees'>;
 
       export type SimpleResponseDocument = JSONAPIDataDocument<Unknown1>;
     `);
@@ -139,9 +139,9 @@ describe('primary data', () => {
         JSONAPIDataDocument,
       } from '@fresha/api-tools-core';
 
-      export type EmployeeResource = JSONAPIServerResource<'employees', {}>;
+      export type EmployeeResource = JSONAPIServerResource<'employees'>;
 
-      export type OrganizationResource = JSONAPIServerResource<'organizations', {}>;
+      export type OrganizationResource = JSONAPIServerResource<'organizations'>;
 
       export type ResponseDocumentWithUnionTypes = JSONAPIDataDocument<EmployeeResource | OrganizationResource>;
     `);
@@ -169,7 +169,7 @@ describe('primary data', () => {
         JSONAPIDataDocument,
       } from '@fresha/api-tools-core';
 
-      export type Employee = JSONAPIServerResource<'employees', {}>;
+      export type Employee = JSONAPIServerResource<'employees'>;
 
       export type SimpleResponseDocument = JSONAPIDataDocument<Employee[]>;
     `);
@@ -218,7 +218,7 @@ describe('included', () => {
         JSONAPIDataDocument,
       } from '@fresha/api-tools-core';
 
-      export type Employee = JSONAPIServerResource<'employees', {}>;
+      export type Employee = JSONAPIServerResource<'employees'>;
 
       export type DocumentWithIncludedResources = JSONAPIDataDocument<
         Employee,
@@ -261,9 +261,9 @@ describe('included', () => {
         JSONAPIDataDocument,
       } from '@fresha/api-tools-core';
 
-      export type Employee = JSONAPIServerResource<'employees', {}>;
+      export type Employee = JSONAPIServerResource<'employees'>;
 
-      export type Organization = JSONAPIServerResource<'organizations', {}>;
+      export type Organization = JSONAPIServerResource<'organizations'>;
 
       export type DocumentWithIncludedResources = JSONAPIDataDocument<
         Employee,

--- a/packages/openapi-codegen-client-fetch/src/parts/IndexFile.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/IndexFile.ts
@@ -1,7 +1,4 @@
-import path from 'path';
-
-import { Context } from '../context';
-
+import type { Context } from '../context';
 import type { SourceFile } from 'ts-morph';
 
 export class IndexFile {
@@ -10,11 +7,7 @@ export class IndexFile {
 
   constructor(context: Context) {
     this.context = context;
-    this.sourceFile = this.context.project.createSourceFile(
-      path.join(this.context.outputPath, 'src', 'index.ts'),
-      '',
-      { overwrite: true },
-    );
+    this.sourceFile = this.context.createSourceFile('src/index.ts');
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/packages/openapi-codegen-client-fetch/src/parts/ResourceType.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ResourceType.ts
@@ -192,7 +192,7 @@ export class ResourceType extends NamedType {
     if (this.resourceType) {
       typeAliasType.addTypeArgument(`'${this.resourceType}'`);
     }
-    if (this.attributesSchema) {
+    if (this.attributesSchema?.properties.size) {
       const typeLiteral = typeAliasType.addTypeArgument('{}').asKindOrThrow(SyntaxKind.TypeLiteral);
       for (const [name, schema] of this.attributesSchema.properties) {
         const typeName = schemaToType(schema);
@@ -207,7 +207,7 @@ export class ResourceType extends NamedType {
       }
     }
     if (this.relationships.size) {
-      if (!this.attributesSchema) {
+      if (!this.attributesSchema?.properties.size) {
         typeAliasType.addTypeArgument('{}');
       }
 

--- a/packages/openapi-codegen-client-fetch/src/parts/UtilsFile.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/UtilsFile.ts
@@ -1,7 +1,4 @@
-import path from 'path';
-
-import { Context } from '../context';
-
+import type { Context } from '../context';
 import type { SourceFile } from 'ts-morph';
 
 export class UtilsFile {
@@ -10,11 +7,7 @@ export class UtilsFile {
 
   constructor(context: Context) {
     this.context = context;
-    this.sourceFile = this.context.project.createSourceFile(
-      path.join(this.context.outputPath, 'src', 'utils.ts'),
-      '',
-      { overwrite: true },
-    );
+    this.sourceFile = this.context.createSourceFile('src/utils.ts');
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/packages/openapi-codegen-client-fetch/src/parts/UtilsFile.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/UtilsFile.ts
@@ -78,7 +78,7 @@ export class UtilsFile {
         }
       }
 
-      export const makeCall = async (url: URL, request: RequestInit): Promise<JSONValue> => {
+      export const callApi = async (url: URL, request: RequestInit): Promise<Response> => {
         let result: Response;
 
         try {
@@ -90,6 +90,12 @@ export class UtilsFile {
         if (!result.ok) {
           throw new APIError('Request failed', result);
         }
+
+        return result;
+      };
+
+      export const callJsonApi = async (url: URL, request: RequestInit): Promise<JSONValue> => {
+        const result = await callApi(url, request);
 
         let json: unknown;
         try {

--- a/packages/openapi-codegen-test-utils/src/context.ts
+++ b/packages/openapi-codegen-test-utils/src/context.ts
@@ -1,10 +1,12 @@
+import path from 'path';
+
 import {
   Context,
   createConsole,
   createLogger,
   TSProjectContext,
 } from '@fresha/openapi-codegen-utils';
-import { Project } from 'ts-morph';
+import { Project, SourceFile } from 'ts-morph';
 
 import type { OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
 
@@ -32,5 +34,10 @@ export const createTSProjectTestContext = (
   return {
     ...base,
     project,
+    createSourceFile(relPath: string, text = ''): SourceFile {
+      return this.project.createSourceFile(path.join(this.outputPath, relPath), text, {
+        overwrite: true,
+      });
+    },
   };
 };

--- a/packages/openapi-codegen-utils/src/assert.ts
+++ b/packages/openapi-codegen-utils/src/assert.ts
@@ -2,9 +2,9 @@ import nodeAssert from 'assert';
 
 import type { OperationModel } from '@fresha/openapi-model/build/3.0.3';
 
-export const assert = (cond: unknown, message: string, operation: OperationModel): asserts cond => {
+export function assert(cond: unknown, message: string, operation: OperationModel): asserts cond {
   nodeAssert(
     cond,
     `${message}. Operation (${operation.httpMethod.toUpperCase()} '${operation.parent.pathUrl}')`,
   );
-};
+}

--- a/packages/openapi-codegen-utils/src/context.ts
+++ b/packages/openapi-codegen-utils/src/context.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { OpenAPIModel, OpenAPIReader } from '@fresha/openapi-model/build/3.0.3';
-import { Project } from 'ts-morph';
+import { Project, SourceFile } from 'ts-morph';
 
 import { createConsole, createLogger, Logger } from './logging';
 
@@ -19,6 +19,8 @@ export interface Context {
 
 export interface TSProjectContext extends Context {
   readonly project: Project;
+
+  createSourceFile(relPath: string, text?: string): SourceFile;
 }
 
 export const createContext = (args: ArgumentsCamelCase<Params>): Context => {
@@ -41,5 +43,10 @@ export const createTSProjectContext = (args: ArgumentsCamelCase<Params>): TSProj
     project: new Project({
       tsConfigFilePath: path.join(args.output, 'tsconfig.json'),
     }),
+    createSourceFile(relPath: string, text = ''): SourceFile {
+      return this.project.createSourceFile(path.join(this.outputPath, relPath), text, {
+        overwrite: true,
+      });
+    },
   };
 };

--- a/packages/openapi-codegen-utils/src/openapi.ts
+++ b/packages/openapi-codegen-utils/src/openapi.ts
@@ -1,8 +1,10 @@
 import assert from 'assert';
 
+import { isJSONObject, JSONObject, Nullable } from '@fresha/api-tools-core';
+
+import { assert as operationAssert } from './assert';
 import { camelCase } from './string';
 
-import type { Nullable } from '@fresha/api-tools-core';
 import type {
   OpenAPIModel,
   OperationModel,
@@ -26,6 +28,27 @@ export const getRootUrl = (openapi: OpenAPIModel): string | undefined => {
 export const getRootUrlOrThrow = (openapi: OpenAPIModel): string => {
   const result = getRootUrl(openapi);
   assert(result, `x-root-url extension is not specified in paths, using default API_URL`);
+  return result;
+};
+
+export const getCodegenOptions = (
+  operation: OperationModel,
+  codegenName: string,
+): JSONObject | undefined => {
+  const ext = operation.getExtension('fresha-codegen');
+  if (ext === undefined) {
+    return undefined;
+  }
+  operationAssert(isJSONObject(ext), 'x-fresha-codegen must be a JSON object', operation);
+  const result = ext[codegenName];
+  if (result === undefined) {
+    return undefined;
+  }
+  operationAssert(
+    isJSONObject(result),
+    'x-fresha-codegen for specific generator must be a JSON object',
+    operation,
+  );
   return result;
 };
 


### PR DESCRIPTION
## Motivation and Context

This PR extends client-fetch code generator to generate "raw" actions, which do not parse response bodies.

Adding the following annotation to OpenAPI operation

```yaml
/login:
  post:
    operationId: login
    x-fresha-codegen:
      client-fetch:
        return: response
```

will makes the generated action look like:

```ts
export const login = (body: LoginRequest): Promise<Response> => {
  ...
};
```

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
