### PR TITLE
Handle case when the same JSON:API resource is used in multiple documents

### DIFF
--- a/packages/openapi-codegen-client-fetch/src/parts/DocumentType.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/DocumentType.ts
@@ -79,11 +79,12 @@ export class DocumentType extends NamedType {
         primaryDataSchema,
         this.isRequestBody,
       );
-      this.primaryResourceTypes.push(existingNamedType);
       namedTypes.set(primaryDataSchemaName, existingNamedType);
 
       existingNamedType.collectData(namedTypes);
     }
+
+    this.primaryResourceTypes.push(existingNamedType);
   }
 
   private determineIncludedDataTypes(


### PR DESCRIPTION
## Motivation and Context

This PR fixes a bug in `client-fetch` code generator. When the same JSON:API resource was used in multiple documents as their primary data, only the first document had proper type generated. The rest had generic `JSONAPIServerResource` instead.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
