### PR TITLE
Allow custom fetch() function in generated fetch-based clients

### DIFF
--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
@@ -133,12 +133,15 @@ export class ActionFunc {
     addImportDeclarations(this.context.sourceFile, {
       './utils': [
         'COMMON_HEADERS',
-        'authorizeRequest',
         'makeUrl',
         this.parsesResponse ? 'callJsonApi' : 'callApi',
         'toString',
       ],
     });
+
+    if (this.usesAuthCookie) {
+      addImportDeclaration(this.context.sourceFile, './utils', 'authorizeRequest');
+    }
 
     if (this.requestType) {
       this.requestType.generateCode(generatedTypes);
@@ -205,12 +208,13 @@ export class ActionFunc {
       }
 
       if (this.parsesResponse) {
-        writer.writeLine(`const response = await callJsonApi(url, request);`);
-        writer.newLine();
-
         if (this.responseType) {
+          writer.writeLine(`const response = await callJsonApi(url, request);`);
+          writer.newLine();
           writer.writeLine(`return response as unknown as ${this.responseType.name};`);
         } else {
+          writer.writeLine(`await callJsonApi(url, request);`);
+          writer.newLine();
           writer.writeLine(`return`);
         }
       } else {

--- a/packages/openapi-codegen-client-fetch/src/parts/UtilsFile.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/UtilsFile.ts
@@ -21,15 +21,22 @@ export class UtilsFile {
 
       import type { JSONValue } from '@fresha/api-tools-core';
 
+      export type FetchFunc = (url: string, init: RequestInit) => Promise<Response>;
+
       let rootUrl = '';
+      let fetcher: FetchFunc = global.fetch;
 
       export type InitParams = {
         rootUrl: string;
+        fetcher?: FetchFunc;
       };
 
       export const init = (params: InitParams): void => {
         assert(params.rootUrl, 'Expected rootUrl to be a non-empty string');
         rootUrl = params.rootUrl;
+        if (params.fetcher) {
+          fetcher = params.fetcher;
+        }
       };
 
       export const makeUrl = (url: string): URL => {
@@ -79,10 +86,12 @@ export class UtilsFile {
       }
 
       export const callApi = async (url: URL, request: RequestInit): Promise<Response> => {
+        assert(fetcher, 'Fetch function is not set');
+
         let result: Response;
 
         try {
-          result = await fetch(url.toString(), request);
+          result = await fetcher(url.toString(), request);
         } catch (err) {
           throw new APIError(\`Error calling \${url.toString()}\`, err);
         }


### PR DESCRIPTION
## Motivation and Context

This PR extends `client-fetch` code generator. The client libraries generated by it allow supplying custom `fetch()` implementation, instead of always using `global.fetch`. This simplifies testing of the code that uses client libraries.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

At the moment type definition of the `fetcher` function is identical to that of browser `fetch()`. In next release, it will be defined more precisely as a common subset of node-fetch and browser fetch.
