### PR TITLE
Add SchemaModel.setItems() member

### DIFF
--- a/packages/json-api-model/src/RelationshipSchema.test.ts
+++ b/packages/json-api-model/src/RelationshipSchema.test.ts
@@ -1,4 +1,4 @@
-import { OpenAPIFactory, SchemaFactory, SchemaModel } from '@fresha/openapi-model/build/3.0.3';
+import { OpenAPIFactory, SchemaModel } from '@fresha/openapi-model/build/3.0.3';
 
 import { parseRelationshipSchema } from './RelationshipSchema';
 
@@ -42,8 +42,7 @@ describe('parseRelationshipSchema', () => {
 
   test('many', () => {
     dataSchema.type = 'array';
-    dataSchema.items = SchemaFactory.create(dataSchema, 'object');
-    dataSchema.items.setProperties({
+    dataSchema.setItems('object').setProperties({
       type: { type: 'string', enum: ['payments'] },
       id: 'string',
     });
@@ -55,8 +54,7 @@ describe('parseRelationshipSchema', () => {
   });
 
   test('invalid many', () => {
-    dataSchema.items = SchemaFactory.create(dataSchema, 'object');
-    dataSchema.items.setProperties({
+    dataSchema.setItems('object').setProperties({
       type: { type: 'string', enum: ['payments'] },
       id: 'string',
     });

--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
@@ -27,7 +27,8 @@ test('simple test', () => {
     .setResponse(200, 'returns a list of employees')
     .setContent(MEDIA_TYPE_JSON_API)
     .setSchema('object')
-    .setProperty('data', 'array').items = openapi.components.getSchemaOrThrow('EmployeeResource');
+    .setProperty('data', 'array')
+    .setItems(openapi.components.getSchemaOrThrow('EmployeeResource'));
   operation.addSecurityRequirement().addScopes('the_auth');
 
   const namedTypes = new Map<string, NamedType>();
@@ -98,7 +99,8 @@ test('action returns raw response', () => {
     .setResponse(200, 'returns a list of employees')
     .setContent(MEDIA_TYPE_JSON_API)
     .setSchema('object')
-    .setProperty('data', 'array').items = schema;
+    .setProperty('data', 'array')
+    .setItems(schema);
   operation.setExtension('fresha-codegen', {
     'client-fetch': {
       return: 'response',

--- a/packages/openapi-codegen-client-fetch/src/parts/DocumentType.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/DocumentType.test.ts
@@ -5,7 +5,7 @@ import {
   MEDIA_TYPE_JSON_API,
   setResourceSchema,
 } from '@fresha/openapi-codegen-utils';
-import { OpenAPIFactory, OperationModel, SchemaFactory } from '@fresha/openapi-model/build/3.0.3';
+import { OpenAPIFactory, OperationModel } from '@fresha/openapi-model/build/3.0.3';
 
 import { createActionTestContext } from '../testHelpers';
 
@@ -155,7 +155,7 @@ describe('primary data', () => {
       attributes: { type: 'object', required: true },
     });
 
-    responseSchema.setProperty('data', 'array').items = employee;
+    responseSchema.setProperty('data', 'array').setItems(employee);
 
     const documentType = createDocumentType(operation, 'SimpleResponseDocument');
 
@@ -183,7 +183,7 @@ describe('primary data', () => {
       attributes: { type: 'object', required: true },
     });
 
-    responseSchema.setProperty('data', 'array').items = employee;
+    responseSchema.setProperty('data', 'array').setItems(employee);
 
     // pretend that this resource is used in multiple documents, and rendered before
     generatedTypes.add('Employee');
@@ -228,7 +228,7 @@ describe('included', () => {
     });
 
     responseSchema.setProperty('data', employee);
-    responseSchema.setProperty('included', 'array').items = employee;
+    responseSchema.setProperty('included', 'array').setItems(employee);
 
     const documentType = createDocumentType(operation, 'DocumentWithIncludedResources');
 
@@ -269,9 +269,9 @@ describe('included', () => {
     responseSchema.setProperty('data', employee);
 
     const includedSchema = responseSchema.setProperty('included', 'array');
-    includedSchema.items = SchemaFactory.create(includedSchema, null);
-    includedSchema.items.addOneOf(organization);
-    includedSchema.items.addOneOf(employee);
+    const includedItemSchema = includedSchema.setItems(null);
+    includedItemSchema.addOneOf(organization);
+    includedItemSchema.addOneOf(employee);
 
     const documentType = createDocumentType(operation, 'DocumentWithIncludedResources');
 

--- a/packages/openapi-codegen-server-nestjs/src/DTO.test.ts
+++ b/packages/openapi-codegen-server-nestjs/src/DTO.test.ts
@@ -1,5 +1,3 @@
-import { SchemaFactory } from '@fresha/openapi-model/build/3.0.3';
-
 import '@fresha/openapi-codegen-test-utils/build/matchers';
 
 import { DTO } from './DTO';
@@ -248,8 +246,7 @@ describe('serialization', () => {
   test('array', () => {
     const schema = context.openapi.components.setSchema('Error', 'object');
 
-    const intArrayProp = schema.setProperty('intArray', 'array');
-    intArrayProp.items = SchemaFactory.create(intArrayProp, 'integer');
+    schema.setProperty('intArray', 'array').setItems('integer');
 
     new DTO(context, 'AnotherResponse', schema).generateCode();
 

--- a/packages/openapi-codegen-server-nestjs/src/Generator.test.ts
+++ b/packages/openapi-codegen-server-nestjs/src/Generator.test.ts
@@ -16,7 +16,7 @@ const buildBasicJSONAPI = (openapi: OpenAPIModel): void => {
   });
 
   const resourceIdListSchema = openapi.components.setSchema('JSONAPIResourceIdList', 'array');
-  resourceIdListSchema.items = resourceIdSchema;
+  resourceIdListSchema.setItems(resourceIdSchema);
 
   const relationshipSchema = openapi.components.setSchema('JSONAPIRelationship', 'object');
   const relationshipDataSchema = relationshipSchema.setProperty('data', {
@@ -37,7 +37,7 @@ const buildBasicJSONAPI = (openapi: OpenAPIModel): void => {
   resourceSchema.getPropertyOrThrow('relationships').additionalProperties = relationshipSchema;
 
   const resourceListSchema = openapi.components.setSchema('JSONAPIResourceList', 'array');
-  resourceListSchema.items = resourceSchema;
+  resourceListSchema.setItems(resourceSchema);
 
   const dataDocumentSchema = openapi.components.setSchema('JSONAPIDataDocument', 'object');
   dataDocumentSchema.setProperty('jsonapi', versionSchema);

--- a/packages/openapi-codegen-utils/src/jsonapi.ts
+++ b/packages/openapi-codegen-utils/src/jsonapi.ts
@@ -197,7 +197,7 @@ export const addResourceRelationship = (
   switch (cardinality) {
     case RelationshipCardinality.Many: {
       const dataSchema = relationshipSchema.setProperty('data', 'array');
-      dataSchema.items = createResourceIdSchema(dataSchema, resourceType);
+      dataSchema.setItems(createResourceIdSchema(dataSchema, resourceType));
       break;
     }
     case RelationshipCardinality.One: {
@@ -269,19 +269,19 @@ export const setDataDocumentSchema = (
     .setProperty('version', { type: 'string', required: true, enum: ['1.0'] });
 
   if (multiplePrimaryResources) {
-    const dataSchema = documentSchema.setProperty('data', 'array');
-    dataSchema.items = SchemaFactory.create(dataSchema, null);
-    setResourceSchema(dataSchema.items, primaryResourceType);
+    setResourceSchema(
+      documentSchema.setProperty('data', 'array').setItems(null),
+      primaryResourceType,
+    );
   } else {
     const dataSchema = createResourceSchema(documentSchema, primaryResourceType);
     documentSchema.setProperty('data', { type: dataSchema, required: true });
   }
 
   if (includedResourceTypes?.length) {
-    const includedSchema = documentSchema.setProperty('included', 'array');
-    includedSchema.items = SchemaFactory.create(includedSchema, null);
+    const includedItemSchema = documentSchema.setProperty('included', 'array').setItems(null);
     for (const includedType of includedResourceTypes) {
-      const includedAltSchema = includedSchema.items.addAnyOf('object');
+      const includedAltSchema = includedItemSchema.addAnyOf('object');
       setResourceIdSchema(includedAltSchema, includedType);
     }
   }

--- a/packages/openapi-model/src/3.0.3/model/OpenAPIReader.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPIReader.ts
@@ -511,7 +511,7 @@ export class OpenAPIReader {
       model.not = this.parseSchema(json.not, model);
     }
     if (json.items) {
-      model.items = this.parseSchema(json.items, model);
+      model.setItems(this.parseSchema(json.items, model));
     }
     if (json.properties) {
       for (const [key, value] of Object.entries(json.properties)) {

--- a/packages/openapi-model/src/3.0.3/model/OpenAPIWriter.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPIWriter.test.ts
@@ -58,8 +58,7 @@ test('shared schemas + references', () => {
   const errorSchema = openapi.components.setSchema('Error', 'object');
   errorSchema.setProperty('code', { type: 'integer', required: true });
 
-  const errorListSchema = openapi.components.setSchema('ErrorList', 'array');
-  errorListSchema.items = errorSchema;
+  openapi.components.setSchema('ErrorList', 'array').setItems(errorSchema);
 
   const writer = new OpenAPIWriter();
   const openapiObject = writer.write(openapi);
@@ -123,7 +122,7 @@ test('serialises operation with shared schemas', () => {
   errorSchema.setProperty('code', { type: 'integer', required: true });
 
   const errorListSchema = openapi.components.setSchema('ErrorList', 'array');
-  errorListSchema.items = errorSchema;
+  errorListSchema.setItems(errorSchema);
 
   const employeesPathItem = openapi.setPathItem('/employees');
 

--- a/packages/openapi-model/src/3.0.3/model/Schema.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Schema.test.ts
@@ -87,7 +87,7 @@ describe('Schema', () => {
     expect(objectSchema.isComposite()).toBeFalsy();
 
     const arraySchema = openapi.components.setSchema('ArraySchema', 'array');
-    arraySchema.items = SchemaFactory.create(arraySchema, 'object');
+    arraySchema.setItems('object');
 
     expect(arraySchema.isComposite()).toBeFalsy();
 

--- a/packages/openapi-model/src/3.0.3/model/Schema.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Schema.test.ts
@@ -590,6 +590,18 @@ describe('Schema', () => {
     expect(schema.required).toStrictEqual(new Set<string>(['a', 'c']));
   });
 
+  test('setItems', () => {
+    const openapi = new OpenAPI('example', '0.1.0');
+
+    const schema = SchemaFactory.create(openapi.components, 'array');
+    expect(schema.items).toBeNull();
+
+    const itemsSchema = schema.setItems('double');
+    expect(itemsSchema).toBe(schema.items);
+    expect(itemsSchema.type).toBe('number');
+    expect(itemsSchema.format).toBe('double');
+  });
+
   test('addAllOf', () => {
     const openapi = new OpenAPI('example', '0.1.0');
 

--- a/packages/openapi-model/src/3.0.3/model/Schema.ts
+++ b/packages/openapi-model/src/3.0.3/model/Schema.ts
@@ -400,6 +400,12 @@ export class Schema extends BasicNode<SchemaModelParent> implements SchemaModel 
     }
   }
 
+  setItems(options: SchemaCreateOptions): SchemaModel {
+    assert(!this.items, `This schema's items have already been set`);
+    this.items = Schema.internalCreate(this, options);
+    return this.items;
+  }
+
   addAllOf(typeOrSchema: SchemaCreateOptions): SchemaModel {
     const schema = Schema.internalCreate(this, typeOrSchema);
     this.allOf.push(schema);

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -225,6 +225,14 @@ export interface SchemaModel extends TreeNode<SchemaModelParent>, SpecificationE
   isPropertyRequired(name: string): boolean;
   setPropertyRequired(name: string, value: boolean): void;
 
+  /**
+   * Initializes subschema for the `items` property of this schema.
+   *
+   * @param options creation options
+   * @return this.items
+   */
+  setItems(options: SchemaCreateOptions): SchemaModel;
+
   addAllOf(options: SchemaCreateOptions): SchemaModel;
   deleteAllOfAt(index: number): void;
   clearAllOf(): void;


### PR DESCRIPTION
## Motivation and Context

This PR makes it more convenient to set up array-like schemas. Now it is possible to set array item schema directly, as:

```ts
schema.setProperty('data', 'array').setItems('object');

// now schema.setProperty has 'data' property which represents an array of object schemas
```

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.