### PR TITLE
Extend SchemaModelFactory.create and ComponentsModel.setSchema

### DIFF
--- a/packages/json-api-model/src/ResourceSchema.ts
+++ b/packages/json-api-model/src/ResourceSchema.ts
@@ -15,9 +15,9 @@ import type {
 
 import { parseRelationshipSchema, Relationship } from './RelationshipSchema';
 
-import type { SchemaCreateOptions, SchemaModel } from '@fresha/openapi-model/build/3.0.3';
+import type { SchemaModel, SchemaPropertyCreateOptions } from '@fresha/openapi-model/build/3.0.3';
 
-const isSchemaModel = (obj: SchemaCreateOptions): obj is SchemaModel => {
+const isSchemaModel = (obj: SchemaPropertyCreateOptions): obj is SchemaModel => {
   return (
     !!obj &&
     typeof obj === 'object' &&
@@ -156,7 +156,7 @@ export class ResourceSchema implements JSONAPIResourceSchema {
     this.#relationshipsSchema = null;
   }
 
-  addAttribute(name: string, options: SchemaCreateOptions): JSONAPIAttributeSchema {
+  addAttribute(name: string, options: SchemaPropertyCreateOptions): JSONAPIAttributeSchema {
     assert(!this.#attributes.has(name), `Attribute '${name}' already exists`);
 
     if (!this.#schema) {
@@ -174,7 +174,7 @@ export class ResourceSchema implements JSONAPIResourceSchema {
     return result;
   }
 
-  addAttributes(attrs: Record<string, SchemaCreateOptions>): JSONAPIResourceSchema {
+  addAttributes(attrs: Record<string, SchemaPropertyCreateOptions>): JSONAPIResourceSchema {
     for (const [name, options] of Object.entries(attrs)) {
       this.addAttribute(name, options);
     }

--- a/packages/json-api-model/src/types.ts
+++ b/packages/json-api-model/src/types.ts
@@ -1,8 +1,8 @@
 import type { JSONObject, Nullable } from '@fresha/api-tools-core';
 import type {
-  SchemaCreateOptions,
   SchemaModel,
   OpenAPIModel,
+  SchemaPropertyCreateOptions,
 } from '@fresha/openapi-model/build/3.0.3';
 
 /**
@@ -91,8 +91,8 @@ export interface JSONAPIResourceSchema {
   getAttributeNames(): string[];
   getAttribute(name: string): JSONAPIAttributeSchema | undefined;
   getAttributeOrThrow(name: string): JSONAPIAttributeSchema;
-  addAttribute(name: string, options: SchemaCreateOptions): JSONAPIAttributeSchema;
-  addAttributes(attrs: Record<string, SchemaCreateOptions>): JSONAPIResourceSchema;
+  addAttribute(name: string, options: SchemaPropertyCreateOptions): JSONAPIAttributeSchema;
+  addAttributes(attrs: Record<string, SchemaPropertyCreateOptions>): JSONAPIResourceSchema;
   deleteAttribute(name: string): void;
   clearAttributes(): void;
 

--- a/packages/openapi-codegen-utils/src/jsonapi.ts
+++ b/packages/openapi-codegen-utils/src/jsonapi.ts
@@ -2,10 +2,10 @@ import assert from 'assert';
 
 import { titleCase } from '@fresha/api-tools-core';
 import {
-  SchemaCreateOptions,
   SchemaFactory,
   SchemaModel,
   SchemaModelParent,
+  SchemaPropertyCreateOptions,
 } from '@fresha/openapi-model/build/3.0.3';
 import pluralize from 'pluralize';
 
@@ -128,7 +128,7 @@ export const createResourceSchema = (parent: SchemaModelParent, type: string): S
 export const addResourceAttribute = (
   resourceSchema: SchemaModel,
   name: string,
-  options: SchemaCreateOptions,
+  options: SchemaPropertyCreateOptions,
 ): SchemaModel => {
   assert(resourceSchema.type === null, `Resource schema must have type set to null`);
   const attributesSchema = resourceSchema.allOf?.at(1)?.getPropertyOrThrow('attributes');
@@ -148,7 +148,7 @@ export const addResourceAttribute = (
  */
 export const addResourceAttributes = (
   resourceSchema: SchemaModel,
-  attrs: Record<string, SchemaCreateOptions>,
+  attrs: Record<string, SchemaPropertyCreateOptions>,
 ): void => {
   for (const [attrName, attrOptions] of Object.entries(attrs)) {
     addResourceAttribute(resourceSchema, attrName, attrOptions);

--- a/packages/openapi-model/src/3.0.3/model/Components.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Components.test.ts
@@ -2,14 +2,16 @@ import { Callback } from './Callback';
 import { Example } from './Example';
 import { Link } from './Link';
 import { OpenAPIFactory } from './OpenAPI';
+
+import type { ComponentsModel, OpenAPIModel, ParameterLocation, SecuritySchemeType } from './types';
+
 import { PathParameter, QueryParameter } from './Parameter';
 import { RequestBody } from './RequestBody';
 import { Response } from './Response';
 import { SchemaFactory } from './Schema';
-import { ParameterLocation, SecuritySchemeType } from './types';
 
-let openapi = OpenAPIFactory.create();
-let { components } = openapi;
+let openapi: OpenAPIModel;
+let components: ComponentsModel;
 
 beforeEach(() => {
   openapi = OpenAPIFactory.create();
@@ -51,6 +53,15 @@ describe('schemas', () => {
 
     const emptySchema = components.schemas.get('Empty');
     expect(emptySchema).toHaveProperty('parent', components);
+
+    const idStringSchema = components.setSchema('IDString', {
+      type: 'string',
+      nullable: false,
+      minLength: 1,
+    });
+    expect(idStringSchema).toHaveProperty('parent', components);
+    expect(idStringSchema).toHaveProperty('minLength', 1);
+    expect(idStringSchema).toHaveProperty('nullable', false);
   });
 
   test('deleteSchema', () => {

--- a/packages/openapi-model/src/3.0.3/model/Components.ts
+++ b/packages/openapi-model/src/3.0.3/model/Components.ts
@@ -14,7 +14,7 @@ import type {
   ParameterModel,
   RequestBodyModel,
   ResponseModel,
-  SchemaCreateType,
+  SchemaCreateTypeOrObject,
   SchemaModel,
   SecuritySchemaModel,
 } from './types';
@@ -93,9 +93,9 @@ export class Components extends BasicNode<ComponentsModelParent> implements Comp
     this.schemas.set(name, model);
   }
 
-  setSchema(name: string, type?: SchemaCreateType): SchemaModel {
+  setSchema(name: string, options: SchemaCreateTypeOrObject = null): SchemaModel {
     assert(!this.schemas.has(name));
-    const result = SchemaFactory.create(this, type ?? null);
+    const result = SchemaFactory.create(this, options);
     result.title = name;
     this.schemas.set(name, result);
     return result;

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -99,13 +99,19 @@ export type SchemaCreateObject = (
       maxLength?: number;
     }
 ) & {
-  required?: boolean;
   nullable?: boolean;
   readOnly?: boolean;
   writeOnly?: boolean;
 };
 
-export type SchemaCreateOptions = SchemaCreateType | SchemaModel | SchemaCreateObject;
+export type SchemaCreateTypeOrObject = SchemaCreateType | SchemaCreateObject;
+
+export type SchemaCreateOptions = SchemaCreateTypeOrObject | SchemaModel;
+
+export type SchemaPropertyCreateOptions =
+  | SchemaCreateType
+  | (SchemaCreateObject & { required?: boolean })
+  | SchemaModel;
 
 export type SchemaModelParent =
   | ComponentsModel
@@ -192,8 +198,8 @@ export interface SchemaModel extends TreeNode<SchemaModelParent>, SpecificationE
   getProperties(): IterableIterator<SchemaPropertyObject>;
   getProperty(name: string): SchemaModel | undefined;
   getPropertyOrThrow(name: string): SchemaModel;
-  setProperty(name: string, options: SchemaCreateOptions): SchemaModel;
-  setProperties(props: Record<string, SchemaCreateOptions>): SchemaModel;
+  setProperty(name: string, options: SchemaPropertyCreateOptions): SchemaModel;
+  setProperties(props: Record<string, SchemaPropertyCreateOptions>): SchemaModel;
   deleteProperty(name: string): void;
   clearProperties(): void;
 
@@ -260,9 +266,12 @@ export type SchemaCreateArrayOptions = SchemaCreateType | SchemaModel | SchemaCr
  * This class provides convenience methods for creating SchemaObject-s.
  */
 export interface SchemaModelFactory {
-  create(parent: SchemaModelParent, params: Exclude<SchemaCreateType, SchemaModel>): SchemaModel;
+  create(parent: SchemaModelParent, params: SchemaCreateTypeOrObject): SchemaModel;
   createArray(parent: SchemaModelParent, options: SchemaCreateArrayOptions): SchemaModel;
-  createObject(parent: SchemaModelParent, props: Record<string, SchemaCreateOptions>): SchemaModel;
+  createObject(
+    parent: SchemaModelParent,
+    props: Record<string, SchemaPropertyCreateOptions>,
+  ): SchemaModel;
 }
 
 export type ContactModelParent = InfoModel;
@@ -989,7 +998,7 @@ export interface ComponentsModel
   getSchema(name: string): SchemaModel | undefined;
   getSchemaOrThrow(name: string): SchemaModel;
   setSchemaModel(name: string, model: SchemaModel): void;
-  setSchema(name: string, type?: SchemaType): SchemaModel;
+  setSchema(name: string, options?: SchemaCreateOptions): SchemaModel;
   deleteSchema(name: string): void;
   clearSchemas(): void;
   sortSchemas(


### PR DESCRIPTION
## Motivation and Context

This PR improves the experience of creating schema models. Now it is possible to pass extra options to `SchemaModel.create` and `ComponentsModel.setSchema`

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

SchemaModelFactory methods require some refactor, because there is duplicated code between `.create` and `.setProperty` methods.