### PR TITLE
Allow creating deep hierarchies of SchemaModel objects in schema properties

### DIFF
--- a/packages/json-api-model/src/ResourceSchema.ts
+++ b/packages/json-api-model/src/ResourceSchema.ts
@@ -15,9 +15,9 @@ import type {
 
 import { parseRelationshipSchema, Relationship } from './RelationshipSchema';
 
-import type { SchemaModel, SchemaPropertyCreateOptions } from '@fresha/openapi-model/build/3.0.3';
+import type { SchemaModel, CreateSchemaPropertyOptions } from '@fresha/openapi-model/build/3.0.3';
 
-const isSchemaModel = (obj: SchemaPropertyCreateOptions): obj is SchemaModel => {
+const isSchemaModel = (obj: CreateSchemaPropertyOptions): obj is SchemaModel => {
   return (
     !!obj &&
     typeof obj === 'object' &&
@@ -156,7 +156,7 @@ export class ResourceSchema implements JSONAPIResourceSchema {
     this.#relationshipsSchema = null;
   }
 
-  addAttribute(name: string, options: SchemaPropertyCreateOptions): JSONAPIAttributeSchema {
+  addAttribute(name: string, options: CreateSchemaPropertyOptions): JSONAPIAttributeSchema {
     assert(!this.#attributes.has(name), `Attribute '${name}' already exists`);
 
     if (!this.#schema) {
@@ -174,7 +174,7 @@ export class ResourceSchema implements JSONAPIResourceSchema {
     return result;
   }
 
-  addAttributes(attrs: Record<string, SchemaPropertyCreateOptions>): JSONAPIResourceSchema {
+  addAttributes(attrs: Record<string, CreateSchemaPropertyOptions>): JSONAPIResourceSchema {
     for (const [name, options] of Object.entries(attrs)) {
       this.addAttribute(name, options);
     }

--- a/packages/json-api-model/src/types.ts
+++ b/packages/json-api-model/src/types.ts
@@ -2,7 +2,7 @@ import type { JSONObject, Nullable } from '@fresha/api-tools-core';
 import type {
   SchemaModel,
   OpenAPIModel,
-  SchemaPropertyCreateOptions,
+  CreateSchemaPropertyOptions,
 } from '@fresha/openapi-model/build/3.0.3';
 
 /**
@@ -91,8 +91,8 @@ export interface JSONAPIResourceSchema {
   getAttributeNames(): string[];
   getAttribute(name: string): JSONAPIAttributeSchema | undefined;
   getAttributeOrThrow(name: string): JSONAPIAttributeSchema;
-  addAttribute(name: string, options: SchemaPropertyCreateOptions): JSONAPIAttributeSchema;
-  addAttributes(attrs: Record<string, SchemaPropertyCreateOptions>): JSONAPIResourceSchema;
+  addAttribute(name: string, options: CreateSchemaPropertyOptions): JSONAPIAttributeSchema;
+  addAttributes(attrs: Record<string, CreateSchemaPropertyOptions>): JSONAPIResourceSchema;
   deleteAttribute(name: string): void;
   clearAttributes(): void;
 

--- a/packages/json-schema-model/src/types.ts
+++ b/packages/json-schema-model/src/types.ts
@@ -81,7 +81,7 @@ export interface IObjectSchema extends ISchemaBase {
   clearProperties(): void;
 }
 
-export type ObjectSchemaCreateOptions = Partial<{
+export type ObjectCreateOrSetSchemaOptions = Partial<{
   required: boolean;
 }>;
 
@@ -90,7 +90,7 @@ export interface IArraySchema extends ISchemaBase {
   readonly itemSchema: JSONSchemaOrReference;
 }
 
-export type ArraySchemaCreateOptions = Partial<{
+export type ArrayCreateOrSetSchemaOptions = Partial<{
   required: boolean;
 }>;
 
@@ -99,7 +99,7 @@ export interface INotSchema extends ISchemaBase {
   readonly baseSchema: JSONSchemaOrReference;
 }
 
-export type NotSchemaCreateOptions = Partial<{
+export type NotCreateOrSetSchemaOptions = Partial<{
   required: boolean;
 }>;
 
@@ -108,7 +108,7 @@ export interface IOneOfSchema extends ISchemaBase {
   readonly alternatives: ReadonlyArray<JSONSchemaOrReference>;
 }
 
-export type OneOfSchemaCreateOptions = Partial<{
+export type OneOfCreateOrSetSchemaOptions = Partial<{
   required: boolean;
 }>;
 
@@ -117,7 +117,7 @@ export interface IAnyOfSchema extends ISchemaBase {
   readonly alternatives: ReadonlyArray<JSONSchemaOrReference>;
 }
 
-export type AnyOfSchemaCreateOptions = Partial<{
+export type AnyOfCreateOrSetSchemaOptions = Partial<{
   required: boolean;
 }>;
 
@@ -126,7 +126,7 @@ export interface IAllOfSchema extends ISchemaBase {
   readonly alternatives: ReadonlyArray<JSONSchemaOrReference>;
 }
 
-export type AllOfSchemaCreateOptions = Partial<{
+export type AllOfCreateOrSetSchemaOptions = Partial<{
   required: boolean;
 }>;
 

--- a/packages/openapi-codegen-utils/src/jsonapi.ts
+++ b/packages/openapi-codegen-utils/src/jsonapi.ts
@@ -5,7 +5,7 @@ import {
   SchemaFactory,
   SchemaModel,
   SchemaModelParent,
-  SchemaPropertyCreateOptions,
+  CreateSchemaPropertyOptions,
 } from '@fresha/openapi-model/build/3.0.3';
 import pluralize from 'pluralize';
 
@@ -128,7 +128,7 @@ export const createResourceSchema = (parent: SchemaModelParent, type: string): S
 export const addResourceAttribute = (
   resourceSchema: SchemaModel,
   name: string,
-  options: SchemaPropertyCreateOptions,
+  options: CreateSchemaPropertyOptions,
 ): SchemaModel => {
   assert(resourceSchema.type === null, `Resource schema must have type set to null`);
   const attributesSchema = resourceSchema.allOf?.at(1)?.getPropertyOrThrow('attributes');
@@ -148,7 +148,7 @@ export const addResourceAttribute = (
  */
 export const addResourceAttributes = (
   resourceSchema: SchemaModel,
-  attrs: Record<string, SchemaPropertyCreateOptions>,
+  attrs: Record<string, CreateSchemaPropertyOptions>,
 ): void => {
   for (const [attrName, attrOptions] of Object.entries(attrs)) {
     addResourceAttribute(resourceSchema, attrName, attrOptions);

--- a/packages/openapi-model/src/3.0.3/model/Components.ts
+++ b/packages/openapi-model/src/3.0.3/model/Components.ts
@@ -14,7 +14,7 @@ import type {
   ParameterModel,
   RequestBodyModel,
   ResponseModel,
-  SchemaCreateTypeOrObject,
+  CreateSchemaOptions,
   SchemaModel,
   SecuritySchemaModel,
 } from './types';
@@ -93,7 +93,7 @@ export class Components extends BasicNode<ComponentsModelParent> implements Comp
     this.schemas.set(name, model);
   }
 
-  setSchema(name: string, options: SchemaCreateTypeOrObject = null): SchemaModel {
+  setSchema(name: string, options: CreateSchemaOptions = null): SchemaModel {
     assert(!this.schemas.has(name));
     const result = SchemaFactory.create(this, options);
     result.title = name;

--- a/packages/openapi-model/src/3.0.3/model/MediaType.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/MediaType.test.ts
@@ -28,6 +28,18 @@ test('schema property', () => {
   expect(mediaType.schema).toBeNull();
 });
 
+test('schema property w/ external model', () => {
+  const schema = mediaType.root.components.setSchema('Shared', {
+    type: 'object',
+    properties: { one: 'string', two: 'integer' },
+  });
+
+  mediaType.setSchema(schema);
+
+  expect(mediaType.schema).toBe(schema);
+  expect(schema.parent).toBe(mediaType.root.components);
+});
+
 test('examples collection', () => {
   mediaType.setExample('1');
   mediaType.setExample('2');

--- a/packages/openapi-model/src/3.0.3/model/MediaType.ts
+++ b/packages/openapi-model/src/3.0.3/model/MediaType.ts
@@ -1,7 +1,5 @@
 import assert from 'assert';
 
-import { SchemaType } from '../types';
-
 import { BasicNode } from './BasicNode';
 import { Encoding } from './Encoding';
 
@@ -10,6 +8,7 @@ import type {
   ExampleModel,
   MediaTypeModel,
   MediaTypeModelParent,
+  CreateOrSetSchemaOptions,
   SchemaModel,
 } from './types';
 
@@ -36,8 +35,8 @@ export class MediaType extends BasicNode<MediaTypeModelParent> implements MediaT
     this.encoding = new Map<string, EncodingModel>();
   }
 
-  setSchema(type: SchemaType): SchemaModel {
-    const result = SchemaFactory.create(this, type);
+  setSchema(options: CreateOrSetSchemaOptions): SchemaModel {
+    const result = SchemaFactory.createOrGet(this, options);
     this.schema = result;
     return result;
   }

--- a/packages/openapi-model/src/3.0.3/model/types.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.test.ts
@@ -83,9 +83,7 @@ test('build schema - petstore', () => {
 
   const petSchema = api.components.setSchema('Pet');
   petSchema.addAllOf(newPetSchema);
-
-  const idSchema = petSchema.addAllOf('object');
-  idSchema.setProperty('id', { type: 'int64', required: true });
+  petSchema.addAllOf({ type: 'object', properties: { id: { type: 'int64', required: true } } });
 
   //
   // pathItems


### PR DESCRIPTION
## Motivation and Context

As described in https://github.com/fresha/api-tools/issues/60.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring

## Details

Public types were refined. Now we have 3 of them:

- `CreateSchemaOptions` - this should be accepted by methods that only create schemas. `ComponentsModel.setSchema` is a good example of such a method
- `CreateOrSetSchemaOptions` - this should be accepted by methods that can either create schemas, or using schemas passed from outside. `MediaType.setSchema` is an example of such a method.
- `CreateSchemaPropertyOptions` - this is used specifically by `SchemaModel.setProperty` and `SchemaModel.setProperties`. It is very similar to `CreateOrSetSchemaOptions`, except it allows for `required` property.

Methods' signatures were extended:

- `MediaTypeModel.setSchema` now accepts `CreateOrSetSchemaOptions`
- `ComponentsModel.setSchema` now accepts `CreateSchemaOptions`

New methods:

`SchemaModelFactory.createOrGet` - it either creates a new schema or returns the passed one. Basically, it allows not to expose the `isSchemaModel` and `isSchemaModelType` guards, until their signature becomes stable.