### PR TITLE
Implement extra call params in client-fetch codegen

### DIFF
--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
@@ -45,6 +45,8 @@ test('simple test', () => {
       callJsonApi,
       toString,
       authorizeRequest,
+      ExtraCallParams,
+      applyExtraParams,
     } from './utils';
     import type {
       JSONAPIServerResource,
@@ -71,14 +73,18 @@ test('simple test', () => {
 
     export type ReadEmployeeListResponse = JSONAPIDataDocument<EmployeeResource[]>;
 
-    export async function readEmployeeList(): Promise<ReadEmployeeListResponse> {
+    export async function readEmployeeList(
+      extraParams?: ExtraCallParams,
+    ): Promise<ReadEmployeeListResponse> {
       const url = makeUrl(\`/employees\`);
 
       const request = {
         headers: COMMON_HEADERS,
       };
 
-      authorizeRequest(request);
+      authorizeRequest(request, extraParams);
+
+      applyExtraParams(request, extraParams);
 
       const response = await callJsonApi(url, request);
 
@@ -120,6 +126,8 @@ test('action returns raw response', () => {
       makeUrl,
       callApi,
       toString,
+      ExtraCallParams,
+      applyExtraParams
     } from './utils';
     import type {
       JSONAPIServerResource,
@@ -130,12 +138,16 @@ test('action returns raw response', () => {
 
     export type ReadEmployeeListResponse = JSONAPIDataDocument<EmployeeResource[]>;
 
-    export async function readEmployeeList(): Promise<Response> {
+    export async function readEmployeeList(
+      extraParams?: ExtraCallParams,
+    ): Promise<Response> {
       const url = makeUrl(\`/employees\`);
 
       const request = {
         headers: COMMON_HEADERS,
       };
+
+      applyExtraParams(request, extraParams);
 
       const response = await callApi(url, request);
 

--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
@@ -167,6 +167,8 @@ export class ActionFunc {
       true,
     );
     actionFunc.setIsAsync(true);
+    actionFunc.getParameterOrThrow('extraParams').setHasQuestionToken(true);
+
     actionFunc.addStatements((writer: CodeBlockWriter) => {
       writer.writeLine(`const url = makeUrl(${this.generateCallUrl()});`);
 
@@ -205,9 +207,12 @@ export class ActionFunc {
       writer.newLine();
 
       if (this.usesAuthCookie) {
-        writer.writeLine('authorizeRequest(request);');
+        writer.writeLine('authorizeRequest(request, extraParams);');
         writer.newLine();
       }
+
+      writer.writeLine('applyExtraParams(request, extraParams)');
+      writer.newLine();
 
       if (this.parsesResponse) {
         if (this.responseType) {
@@ -241,6 +246,11 @@ export class ActionFunc {
       }
       params[paramName] = paramInfo.typeString;
     }
+
+    addImportDeclarations(this.context.sourceFile, {
+      './utils': ['t:ExtraCallParams', 'applyExtraParams'],
+    });
+    params.extraParams = 'ExtraCallParams';
 
     return params;
   }


### PR DESCRIPTION
## Motivation and Context

This PR makes it possible to:

- pass proxy-related headers in API client libraries generated by `client-fetch` codegen
- pass authorisation cookie on a per-request basis

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
