### PR TITLE
Improve client fetch codegen

### DIFF
--- a/packages/openapi-codegen-client-fetch/src/Generator.ts
+++ b/packages/openapi-codegen-client-fetch/src/Generator.ts
@@ -24,7 +24,11 @@ export class Generator extends GeneratorBase<Context> {
   }
 
   collectData(): void {
-    for (const operation of getOperations(this.context.openapi)) {
+    for (const operation of getOperations(this.context.openapi, {
+      deprecated: this.context.includeDeprecated,
+      internal: this.context.includeInternal,
+      tags: Array.from(this.context.includedTags),
+    })) {
       const actionFunc = new ActionFunc({
         ...this.context,
         sourceFile: this.sourceFile,

--- a/packages/openapi-codegen-client-fetch/src/command.ts
+++ b/packages/openapi-codegen-client-fetch/src/command.ts
@@ -15,6 +15,7 @@ export const description = 'generates code for fetch() API clients';
 
 type Params = BaseParams & {
   withDeprecated?: boolean;
+  withInternal?: boolean;
   withTags?: string[];
   withoutTags?: string[];
   transformRequest?: NamingConvention;
@@ -24,15 +25,18 @@ type Params = BaseParams & {
 export const builder = (args: Argv): Argv<Params> =>
   baseBuilder(args)
     .boolean('with-deprecated')
-    .default('with-deprecated', false)
     .describe('with-deprecated', 'Generated code for deprecated operations')
+    .default('with-deprecated', false)
+    .boolean('with-internal')
+    .describe('with-internal', 'Generate code for internal operation')
+    .default('with-internal', false)
     .array('with-tags')
     .describe('with-tags', 'Generate only operation with tags')
     .array('without-tags')
     .describe('without-tags', 'Generates operations not assigned with this tags')
-    .choices('transform-request', ['camel', 'kebab', 'snake'])
+    .choices('transform-request', ['camel', 'kebab', 'snake', 'title'])
     .describe('transform-request', 'Transforms request bodies to specified convention')
-    .choices('transform-response', ['camel', 'kebab', 'snake'])
+    .choices('transform-response', ['camel', 'kebab', 'snake', 'title'])
     .describe('transform-response', 'Converts responses to specified convention');
 
 export const handler = (args: ArgumentsCamelCase<Params>): void => {
@@ -41,6 +45,7 @@ export const handler = (args: ArgumentsCamelCase<Params>): void => {
   const generator = new Generator({
     ...baseContext,
     includeDeprecated: !!args.withDeprecated,
+    includeInternal: !!args.withInternal,
     includedTags: new Set<string>(args.withTags),
     excludedTags: new Set<string>(args.withoutTags),
     transformRequest: args.transformRequest ?? null,

--- a/packages/openapi-codegen-client-fetch/src/context.ts
+++ b/packages/openapi-codegen-client-fetch/src/context.ts
@@ -3,10 +3,11 @@ import type { TSProjectContext } from '@fresha/openapi-codegen-utils';
 import type { OperationModel } from '@fresha/openapi-model/build/3.0.3';
 import type { SourceFile } from 'ts-morph';
 
-export type NamingConvention = 'camel' | 'kebab' | 'snake';
+export type NamingConvention = 'camel' | 'kebab' | 'snake' | 'title';
 
 export interface Context extends TSProjectContext {
   readonly includeDeprecated: boolean;
+  readonly includeInternal: boolean;
   readonly includedTags: Set<string>;
   readonly excludedTags: Set<string>;
   readonly transformRequest: Nullable<NamingConvention>;

--- a/packages/openapi-codegen-client-fetch/src/parts/IndexFile.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/IndexFile.ts
@@ -17,7 +17,7 @@ export class IndexFile {
     this.sourceFile.insertText(
       0,
       `export * from './actions';
-      export { init, setAuthCookie } from './utils';
+      export { init, setAuthCookie, APIClientErrorKind, APIClientError } from './utils';
       `,
     );
   }

--- a/packages/openapi-codegen-client-fetch/src/testHelpers.ts
+++ b/packages/openapi-codegen-client-fetch/src/testHelpers.ts
@@ -10,6 +10,7 @@ export const createTestContext = (openapi: OpenAPIModel): Context => {
   return {
     ...base,
     includeDeprecated: false,
+    includeInternal: false,
     includedTags: new Set<string>(),
     excludedTags: new Set<string>(),
     transformRequest: 'kebab',


### PR DESCRIPTION
## Motivation and Context

This PR improves `client-fetch` code generator:

- generated code has better support of error handling
- ability to skip generating code for certain actions, based on their status (deprecated, internal) and tags

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
