### PR TITLE
Add support for tuple-like schema models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13715,11 +13715,11 @@
     },
     "packages/json-api-model": {
       "name": "@fresha/json-api-model",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@fresha/api-tools-core": "^0.4.2",
-        "@fresha/openapi-model": "^0.6.0",
+        "@fresha/openapi-model": "^0.6.1",
         "pluralize": "^8.0.0"
       },
       "devDependencies": {
@@ -13757,15 +13757,15 @@
     },
     "packages/openapi-codegen-cli": {
       "name": "@fresha/openapi-codegen-cli",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "MIT",
       "dependencies": {
-        "@fresha/openapi-codegen-client-fetch": "^0.2.4",
-        "@fresha/openapi-codegen-client-fresha": "^0.2.3",
-        "@fresha/openapi-codegen-docs-json-api": "^0.1.4",
-        "@fresha/openapi-codegen-server-elixir": "^0.2.3",
-        "@fresha/openapi-codegen-server-mock": "^0.1.3",
-        "@fresha/openapi-codegen-server-nestjs": "^0.2.3",
+        "@fresha/openapi-codegen-client-fetch": "^0.2.5",
+        "@fresha/openapi-codegen-client-fresha": "^0.2.4",
+        "@fresha/openapi-codegen-docs-json-api": "^0.1.5",
+        "@fresha/openapi-codegen-server-elixir": "^0.2.4",
+        "@fresha/openapi-codegen-server-mock": "^0.1.4",
+        "@fresha/openapi-codegen-server-nestjs": "^0.2.4",
         "yargs": "^17.5.1"
       },
       "bin": {
@@ -13781,18 +13781,18 @@
     },
     "packages/openapi-codegen-client-fetch": {
       "name": "@fresha/openapi-codegen-client-fetch",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@fresha/api-tools-core": "^0.4.2",
         "@fresha/code-morph-ts": "^0.1.1",
-        "@fresha/openapi-codegen-utils": "^0.1.3",
-        "@fresha/openapi-model": "^0.6.0",
+        "@fresha/openapi-codegen-utils": "^0.1.4",
+        "@fresha/openapi-model": "^0.6.1",
         "ts-morph": "^16.0.0"
       },
       "devDependencies": {
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.2",
+        "@fresha/openapi-codegen-test-utils": "^0.1.3",
         "@fresha/typescript-config": "^0.1.1",
         "@types/pluralize": "^0.0.29",
         "pluralize": "^8.0.0",
@@ -13801,86 +13801,86 @@
     },
     "packages/openapi-codegen-client-fresha": {
       "name": "@fresha/openapi-codegen-client-fresha",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@fresha/api-tools-core": "^0.4.2",
         "@fresha/code-morph-ts": "^0.1.1",
-        "@fresha/openapi-codegen-utils": "^0.1.3",
-        "@fresha/openapi-model": "^0.6.0",
+        "@fresha/openapi-codegen-utils": "^0.1.4",
+        "@fresha/openapi-model": "^0.6.1",
         "ts-morph": "^16.0.0"
       },
       "devDependencies": {
         "@fresha/code-morph-test-utils": "^0.1.1",
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.2",
+        "@fresha/openapi-codegen-test-utils": "^0.1.3",
         "@fresha/typescript-config": "^0.1.1",
         "typescript": "^4.7.2"
       }
     },
     "packages/openapi-codegen-docs": {
       "name": "@fresha/openapi-codegen-docs-json-api",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@fresha/api-tools-core": "^0.4.2",
-        "@fresha/openapi-codegen-utils": "^0.1.3",
-        "@fresha/openapi-model": "^0.6.0"
+        "@fresha/openapi-codegen-utils": "^0.1.4",
+        "@fresha/openapi-model": "^0.6.1"
       },
       "devDependencies": {
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.2",
+        "@fresha/openapi-codegen-test-utils": "^0.1.3",
         "@fresha/typescript-config": "^0.1.1",
         "typescript": "^4.7.2"
       }
     },
     "packages/openapi-codegen-server-elixir": {
       "name": "@fresha/openapi-codegen-server-elixir",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.6.0",
         "@fresha/api-tools-core": "^0.4.2",
         "@fresha/code-morph-ex": "^0.1.1",
-        "@fresha/json-api-model": "^0.2.3",
-        "@fresha/openapi-codegen-utils": "^0.1.3",
-        "@fresha/openapi-model": "^0.6.0",
+        "@fresha/json-api-model": "^0.2.4",
+        "@fresha/openapi-codegen-utils": "^0.1.4",
+        "@fresha/openapi-model": "^0.6.1",
         "memfs": "^3.4.7"
       },
       "devDependencies": {
         "@fresha/code-morph-test-utils": "^0.1.1",
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.2",
+        "@fresha/openapi-codegen-test-utils": "^0.1.3",
         "@fresha/typescript-config": "^0.1.1",
         "typescript": "^4.7.2"
       }
     },
     "packages/openapi-codegen-server-mock": {
       "name": "@fresha/openapi-codegen-server-mock",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@fresha/code-morph-ts": "^0.1.1",
-        "@fresha/openapi-codegen-utils": "^0.1.3",
-        "@fresha/openapi-model": "^0.6.0",
+        "@fresha/openapi-codegen-utils": "^0.1.4",
+        "@fresha/openapi-model": "^0.6.1",
         "ts-morph": "^16.0.0"
       },
       "devDependencies": {
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.2",
+        "@fresha/openapi-codegen-test-utils": "^0.1.3",
         "@fresha/typescript-config": "^0.1.1",
         "typescript": "^4.7.2"
       }
     },
     "packages/openapi-codegen-server-nestjs": {
       "name": "@fresha/openapi-codegen-server-nestjs",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@fresha/api-tools-core": "^0.4.2",
         "@fresha/code-morph-ts": "^0.1.1",
-        "@fresha/openapi-codegen-utils": "^0.1.3",
-        "@fresha/openapi-model": "^0.6.0",
+        "@fresha/openapi-codegen-utils": "^0.1.4",
+        "@fresha/openapi-model": "^0.6.1",
         "lodash.camelcase": "^4.3.0",
         "lodash.get": "^4.4.2",
         "lodash.kebabcase": "^4.1.1",
@@ -13892,7 +13892,7 @@
       "devDependencies": {
         "@fresha/code-morph-test-utils": "^0.1.1",
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.2",
+        "@fresha/openapi-codegen-test-utils": "^0.1.3",
         "@fresha/typescript-config": "^0.1.1",
         "@types/lodash.camelcase": "^4.3.7",
         "@types/lodash.get": "^4.4.7",
@@ -13906,13 +13906,13 @@
     },
     "packages/openapi-codegen-test-utils": {
       "name": "@fresha/openapi-codegen-test-utils",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@fresha/api-tools-core": "^0.4.2",
         "@fresha/code-morph-test-utils": "^0.1.1",
-        "@fresha/openapi-codegen-utils": "^0.1.3",
-        "@fresha/openapi-model": "^0.6.0",
+        "@fresha/openapi-codegen-utils": "^0.1.4",
+        "@fresha/openapi-model": "^0.6.1",
         "jest-matcher-utils": "^29.1.2",
         "ts-morph": "^16.0.0"
       },
@@ -13925,11 +13925,11 @@
     },
     "packages/openapi-codegen-utils": {
       "name": "@fresha/openapi-codegen-utils",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@fresha/api-tools-core": "^0.4.2",
-        "@fresha/openapi-model": "^0.6.0",
+        "@fresha/openapi-model": "^0.6.1",
         "pluralize": "^8.0.0",
         "ts-morph": "^16.0.0",
         "winston": "^3.8.2"
@@ -13955,10 +13955,10 @@
     },
     "packages/openapi-lint": {
       "name": "@fresha/openapi-lint",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
-        "@fresha/openapi-model": "^0.6.0",
+        "@fresha/openapi-model": "^0.6.1",
         "chalk": "^4.1.0",
         "glob": "^8.0.3",
         "yargs": "^17.6.2"
@@ -14011,7 +14011,7 @@
     },
     "packages/openapi-model": {
       "name": "@fresha/openapi-model",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@fresha/api-tools-core": "^0.4.2",
@@ -14888,7 +14888,7 @@
         "@fresha/api-tools-core": "^0.4.2",
         "@fresha/eslint-config": "^0.1.1",
         "@fresha/jest-config": "^0.1.1",
-        "@fresha/openapi-model": "^0.6.0",
+        "@fresha/openapi-model": "^0.6.1",
         "@fresha/typescript-config": "^0.1.1",
         "@types/pluralize": "^0.0.29",
         "pluralize": "^8.0.0",
@@ -14919,12 +14919,12 @@
       "requires": {
         "@fresha/eslint-config": "^0.1.1",
         "@fresha/jest-config": "^0.1.1",
-        "@fresha/openapi-codegen-client-fetch": "^0.2.4",
-        "@fresha/openapi-codegen-client-fresha": "^0.2.3",
-        "@fresha/openapi-codegen-docs-json-api": "^0.1.4",
-        "@fresha/openapi-codegen-server-elixir": "^0.2.3",
-        "@fresha/openapi-codegen-server-mock": "^0.1.3",
-        "@fresha/openapi-codegen-server-nestjs": "^0.2.3",
+        "@fresha/openapi-codegen-client-fetch": "^0.2.5",
+        "@fresha/openapi-codegen-client-fresha": "^0.2.4",
+        "@fresha/openapi-codegen-docs-json-api": "^0.1.5",
+        "@fresha/openapi-codegen-server-elixir": "^0.2.4",
+        "@fresha/openapi-codegen-server-mock": "^0.1.4",
+        "@fresha/openapi-codegen-server-nestjs": "^0.2.4",
         "@fresha/typescript-config": "^0.1.1",
         "@types/yargs": "^17.0.12",
         "typescript": "^4.7.2",
@@ -14937,9 +14937,9 @@
         "@fresha/api-tools-core": "^0.4.2",
         "@fresha/code-morph-ts": "^0.1.1",
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.2",
-        "@fresha/openapi-codegen-utils": "^0.1.3",
-        "@fresha/openapi-model": "^0.6.0",
+        "@fresha/openapi-codegen-test-utils": "^0.1.3",
+        "@fresha/openapi-codegen-utils": "^0.1.4",
+        "@fresha/openapi-model": "^0.6.1",
         "@fresha/typescript-config": "^0.1.1",
         "@types/pluralize": "^0.0.29",
         "pluralize": "^8.0.0",
@@ -14954,9 +14954,9 @@
         "@fresha/code-morph-test-utils": "^0.1.1",
         "@fresha/code-morph-ts": "^0.1.1",
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.2",
-        "@fresha/openapi-codegen-utils": "^0.1.3",
-        "@fresha/openapi-model": "^0.6.0",
+        "@fresha/openapi-codegen-test-utils": "^0.1.3",
+        "@fresha/openapi-codegen-utils": "^0.1.4",
+        "@fresha/openapi-model": "^0.6.1",
         "@fresha/typescript-config": "^0.1.1",
         "ts-morph": "^16.0.0",
         "typescript": "^4.7.2"
@@ -14967,9 +14967,9 @@
       "requires": {
         "@fresha/api-tools-core": "^0.4.2",
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.2",
-        "@fresha/openapi-codegen-utils": "^0.1.3",
-        "@fresha/openapi-model": "^0.6.0",
+        "@fresha/openapi-codegen-test-utils": "^0.1.3",
+        "@fresha/openapi-codegen-utils": "^0.1.4",
+        "@fresha/openapi-model": "^0.6.1",
         "@fresha/typescript-config": "^0.1.1",
         "typescript": "^4.7.2"
       }
@@ -14982,10 +14982,10 @@
         "@fresha/code-morph-ex": "^0.1.1",
         "@fresha/code-morph-test-utils": "^0.1.1",
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/json-api-model": "^0.2.3",
-        "@fresha/openapi-codegen-test-utils": "^0.1.2",
-        "@fresha/openapi-codegen-utils": "^0.1.3",
-        "@fresha/openapi-model": "^0.6.0",
+        "@fresha/json-api-model": "^0.2.4",
+        "@fresha/openapi-codegen-test-utils": "^0.1.3",
+        "@fresha/openapi-codegen-utils": "^0.1.4",
+        "@fresha/openapi-model": "^0.6.1",
         "@fresha/typescript-config": "^0.1.1",
         "memfs": "^3.4.7",
         "typescript": "^4.7.2"
@@ -14996,9 +14996,9 @@
       "requires": {
         "@fresha/code-morph-ts": "^0.1.1",
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.2",
-        "@fresha/openapi-codegen-utils": "^0.1.3",
-        "@fresha/openapi-model": "^0.6.0",
+        "@fresha/openapi-codegen-test-utils": "^0.1.3",
+        "@fresha/openapi-codegen-utils": "^0.1.4",
+        "@fresha/openapi-model": "^0.6.1",
         "@fresha/typescript-config": "^0.1.1",
         "ts-morph": "^16.0.0",
         "typescript": "^4.7.2"
@@ -15011,9 +15011,9 @@
         "@fresha/code-morph-test-utils": "^0.1.1",
         "@fresha/code-morph-ts": "^0.1.1",
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.2",
-        "@fresha/openapi-codegen-utils": "^0.1.3",
-        "@fresha/openapi-model": "^0.6.0",
+        "@fresha/openapi-codegen-test-utils": "^0.1.3",
+        "@fresha/openapi-codegen-utils": "^0.1.4",
+        "@fresha/openapi-model": "^0.6.1",
         "@fresha/typescript-config": "^0.1.1",
         "@types/lodash.camelcase": "^4.3.7",
         "@types/lodash.get": "^4.4.7",
@@ -15038,8 +15038,8 @@
         "@fresha/api-tools-core": "^0.4.2",
         "@fresha/code-morph-test-utils": "^0.1.1",
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-utils": "^0.1.3",
-        "@fresha/openapi-model": "^0.6.0",
+        "@fresha/openapi-codegen-utils": "^0.1.4",
+        "@fresha/openapi-model": "^0.6.1",
         "@fresha/typescript-config": "^0.1.1",
         "@types/jest": "^29.1.2",
         "jest-matcher-utils": "^29.1.2",
@@ -15053,7 +15053,7 @@
         "@fresha/api-tools-core": "^0.4.2",
         "@fresha/eslint-config": "^0.1.1",
         "@fresha/jest-config": "^0.1.1",
-        "@fresha/openapi-model": "^0.6.0",
+        "@fresha/openapi-model": "^0.6.1",
         "@fresha/typescript-config": "^0.1.1",
         "@types/pluralize": "^0.0.29",
         "pluralize": "^8.0.0",
@@ -15076,7 +15076,7 @@
       "requires": {
         "@fresha/eslint-config": "^0.1.1",
         "@fresha/jest-config": "^0.1.1",
-        "@fresha/openapi-model": "^0.6.0",
+        "@fresha/openapi-model": "^0.6.1",
         "@fresha/typescript-config": "^0.1.1",
         "@types/chalk": "^2.2.0",
         "@types/glob": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13715,11 +13715,11 @@
     },
     "packages/json-api-model": {
       "name": "@fresha/json-api-model",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@fresha/api-tools-core": "^0.4.2",
-        "@fresha/openapi-model": "^0.5.1",
+        "@fresha/openapi-model": "^0.6.0",
         "pluralize": "^8.0.0"
       },
       "devDependencies": {
@@ -13757,15 +13757,15 @@
     },
     "packages/openapi-codegen-cli": {
       "name": "@fresha/openapi-codegen-cli",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
-        "@fresha/openapi-codegen-client-fetch": "^0.2.3",
-        "@fresha/openapi-codegen-client-fresha": "^0.2.2",
-        "@fresha/openapi-codegen-docs-json-api": "^0.1.3",
-        "@fresha/openapi-codegen-server-elixir": "^0.2.2",
-        "@fresha/openapi-codegen-server-mock": "^0.1.2",
-        "@fresha/openapi-codegen-server-nestjs": "^0.2.2",
+        "@fresha/openapi-codegen-client-fetch": "^0.2.4",
+        "@fresha/openapi-codegen-client-fresha": "^0.2.3",
+        "@fresha/openapi-codegen-docs-json-api": "^0.1.4",
+        "@fresha/openapi-codegen-server-elixir": "^0.2.3",
+        "@fresha/openapi-codegen-server-mock": "^0.1.3",
+        "@fresha/openapi-codegen-server-nestjs": "^0.2.3",
         "yargs": "^17.5.1"
       },
       "bin": {
@@ -13781,18 +13781,18 @@
     },
     "packages/openapi-codegen-client-fetch": {
       "name": "@fresha/openapi-codegen-client-fetch",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@fresha/api-tools-core": "^0.4.2",
         "@fresha/code-morph-ts": "^0.1.1",
-        "@fresha/openapi-codegen-utils": "^0.1.2",
-        "@fresha/openapi-model": "^0.5.1",
+        "@fresha/openapi-codegen-utils": "^0.1.3",
+        "@fresha/openapi-model": "^0.6.0",
         "ts-morph": "^16.0.0"
       },
       "devDependencies": {
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.1",
+        "@fresha/openapi-codegen-test-utils": "^0.1.2",
         "@fresha/typescript-config": "^0.1.1",
         "@types/pluralize": "^0.0.29",
         "pluralize": "^8.0.0",
@@ -13801,86 +13801,86 @@
     },
     "packages/openapi-codegen-client-fresha": {
       "name": "@fresha/openapi-codegen-client-fresha",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@fresha/api-tools-core": "^0.4.2",
         "@fresha/code-morph-ts": "^0.1.1",
-        "@fresha/openapi-codegen-utils": "^0.1.2",
-        "@fresha/openapi-model": "^0.5.1",
+        "@fresha/openapi-codegen-utils": "^0.1.3",
+        "@fresha/openapi-model": "^0.6.0",
         "ts-morph": "^16.0.0"
       },
       "devDependencies": {
         "@fresha/code-morph-test-utils": "^0.1.1",
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.1",
+        "@fresha/openapi-codegen-test-utils": "^0.1.2",
         "@fresha/typescript-config": "^0.1.1",
         "typescript": "^4.7.2"
       }
     },
     "packages/openapi-codegen-docs": {
       "name": "@fresha/openapi-codegen-docs-json-api",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@fresha/api-tools-core": "^0.4.2",
-        "@fresha/openapi-codegen-utils": "^0.1.2",
-        "@fresha/openapi-model": "^0.5.1"
+        "@fresha/openapi-codegen-utils": "^0.1.3",
+        "@fresha/openapi-model": "^0.6.0"
       },
       "devDependencies": {
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.1",
+        "@fresha/openapi-codegen-test-utils": "^0.1.2",
         "@fresha/typescript-config": "^0.1.1",
         "typescript": "^4.7.2"
       }
     },
     "packages/openapi-codegen-server-elixir": {
       "name": "@fresha/openapi-codegen-server-elixir",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@faker-js/faker": "^7.6.0",
         "@fresha/api-tools-core": "^0.4.2",
         "@fresha/code-morph-ex": "^0.1.1",
-        "@fresha/json-api-model": "^0.2.2",
-        "@fresha/openapi-codegen-utils": "^0.1.2",
-        "@fresha/openapi-model": "^0.5.1",
+        "@fresha/json-api-model": "^0.2.3",
+        "@fresha/openapi-codegen-utils": "^0.1.3",
+        "@fresha/openapi-model": "^0.6.0",
         "memfs": "^3.4.7"
       },
       "devDependencies": {
         "@fresha/code-morph-test-utils": "^0.1.1",
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.1",
+        "@fresha/openapi-codegen-test-utils": "^0.1.2",
         "@fresha/typescript-config": "^0.1.1",
         "typescript": "^4.7.2"
       }
     },
     "packages/openapi-codegen-server-mock": {
       "name": "@fresha/openapi-codegen-server-mock",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@fresha/code-morph-ts": "^0.1.1",
-        "@fresha/openapi-codegen-utils": "^0.1.2",
-        "@fresha/openapi-model": "^0.5.1",
+        "@fresha/openapi-codegen-utils": "^0.1.3",
+        "@fresha/openapi-model": "^0.6.0",
         "ts-morph": "^16.0.0"
       },
       "devDependencies": {
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.1",
+        "@fresha/openapi-codegen-test-utils": "^0.1.2",
         "@fresha/typescript-config": "^0.1.1",
         "typescript": "^4.7.2"
       }
     },
     "packages/openapi-codegen-server-nestjs": {
       "name": "@fresha/openapi-codegen-server-nestjs",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "@fresha/api-tools-core": "^0.4.2",
         "@fresha/code-morph-ts": "^0.1.1",
-        "@fresha/openapi-codegen-utils": "^0.1.2",
-        "@fresha/openapi-model": "^0.5.1",
+        "@fresha/openapi-codegen-utils": "^0.1.3",
+        "@fresha/openapi-model": "^0.6.0",
         "lodash.camelcase": "^4.3.0",
         "lodash.get": "^4.4.2",
         "lodash.kebabcase": "^4.1.1",
@@ -13892,7 +13892,7 @@
       "devDependencies": {
         "@fresha/code-morph-test-utils": "^0.1.1",
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.1",
+        "@fresha/openapi-codegen-test-utils": "^0.1.2",
         "@fresha/typescript-config": "^0.1.1",
         "@types/lodash.camelcase": "^4.3.7",
         "@types/lodash.get": "^4.4.7",
@@ -13906,13 +13906,13 @@
     },
     "packages/openapi-codegen-test-utils": {
       "name": "@fresha/openapi-codegen-test-utils",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@fresha/api-tools-core": "^0.4.2",
         "@fresha/code-morph-test-utils": "^0.1.1",
-        "@fresha/openapi-codegen-utils": "^0.1.2",
-        "@fresha/openapi-model": "^0.5.1",
+        "@fresha/openapi-codegen-utils": "^0.1.3",
+        "@fresha/openapi-model": "^0.6.0",
         "jest-matcher-utils": "^29.1.2",
         "ts-morph": "^16.0.0"
       },
@@ -13925,11 +13925,11 @@
     },
     "packages/openapi-codegen-utils": {
       "name": "@fresha/openapi-codegen-utils",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@fresha/api-tools-core": "^0.4.2",
-        "@fresha/openapi-model": "^0.5.1",
+        "@fresha/openapi-model": "^0.6.0",
         "pluralize": "^8.0.0",
         "ts-morph": "^16.0.0",
         "winston": "^3.8.2"
@@ -13955,10 +13955,10 @@
     },
     "packages/openapi-lint": {
       "name": "@fresha/openapi-lint",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
-        "@fresha/openapi-model": "^0.5.1",
+        "@fresha/openapi-model": "^0.6.0",
         "chalk": "^4.1.0",
         "glob": "^8.0.3",
         "yargs": "^17.6.2"
@@ -14011,7 +14011,7 @@
     },
     "packages/openapi-model": {
       "name": "@fresha/openapi-model",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@fresha/api-tools-core": "^0.4.2",
@@ -14888,7 +14888,7 @@
         "@fresha/api-tools-core": "^0.4.2",
         "@fresha/eslint-config": "^0.1.1",
         "@fresha/jest-config": "^0.1.1",
-        "@fresha/openapi-model": "^0.5.1",
+        "@fresha/openapi-model": "^0.6.0",
         "@fresha/typescript-config": "^0.1.1",
         "@types/pluralize": "^0.0.29",
         "pluralize": "^8.0.0",
@@ -14919,12 +14919,12 @@
       "requires": {
         "@fresha/eslint-config": "^0.1.1",
         "@fresha/jest-config": "^0.1.1",
-        "@fresha/openapi-codegen-client-fetch": "^0.2.3",
-        "@fresha/openapi-codegen-client-fresha": "^0.2.2",
-        "@fresha/openapi-codegen-docs-json-api": "^0.1.3",
-        "@fresha/openapi-codegen-server-elixir": "^0.2.2",
-        "@fresha/openapi-codegen-server-mock": "^0.1.2",
-        "@fresha/openapi-codegen-server-nestjs": "^0.2.2",
+        "@fresha/openapi-codegen-client-fetch": "^0.2.4",
+        "@fresha/openapi-codegen-client-fresha": "^0.2.3",
+        "@fresha/openapi-codegen-docs-json-api": "^0.1.4",
+        "@fresha/openapi-codegen-server-elixir": "^0.2.3",
+        "@fresha/openapi-codegen-server-mock": "^0.1.3",
+        "@fresha/openapi-codegen-server-nestjs": "^0.2.3",
         "@fresha/typescript-config": "^0.1.1",
         "@types/yargs": "^17.0.12",
         "typescript": "^4.7.2",
@@ -14937,9 +14937,9 @@
         "@fresha/api-tools-core": "^0.4.2",
         "@fresha/code-morph-ts": "^0.1.1",
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.1",
-        "@fresha/openapi-codegen-utils": "^0.1.2",
-        "@fresha/openapi-model": "^0.5.1",
+        "@fresha/openapi-codegen-test-utils": "^0.1.2",
+        "@fresha/openapi-codegen-utils": "^0.1.3",
+        "@fresha/openapi-model": "^0.6.0",
         "@fresha/typescript-config": "^0.1.1",
         "@types/pluralize": "^0.0.29",
         "pluralize": "^8.0.0",
@@ -14954,9 +14954,9 @@
         "@fresha/code-morph-test-utils": "^0.1.1",
         "@fresha/code-morph-ts": "^0.1.1",
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.1",
-        "@fresha/openapi-codegen-utils": "^0.1.2",
-        "@fresha/openapi-model": "^0.5.1",
+        "@fresha/openapi-codegen-test-utils": "^0.1.2",
+        "@fresha/openapi-codegen-utils": "^0.1.3",
+        "@fresha/openapi-model": "^0.6.0",
         "@fresha/typescript-config": "^0.1.1",
         "ts-morph": "^16.0.0",
         "typescript": "^4.7.2"
@@ -14967,9 +14967,9 @@
       "requires": {
         "@fresha/api-tools-core": "^0.4.2",
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.1",
-        "@fresha/openapi-codegen-utils": "^0.1.2",
-        "@fresha/openapi-model": "^0.5.1",
+        "@fresha/openapi-codegen-test-utils": "^0.1.2",
+        "@fresha/openapi-codegen-utils": "^0.1.3",
+        "@fresha/openapi-model": "^0.6.0",
         "@fresha/typescript-config": "^0.1.1",
         "typescript": "^4.7.2"
       }
@@ -14982,10 +14982,10 @@
         "@fresha/code-morph-ex": "^0.1.1",
         "@fresha/code-morph-test-utils": "^0.1.1",
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/json-api-model": "^0.2.2",
-        "@fresha/openapi-codegen-test-utils": "^0.1.1",
-        "@fresha/openapi-codegen-utils": "^0.1.2",
-        "@fresha/openapi-model": "^0.5.1",
+        "@fresha/json-api-model": "^0.2.3",
+        "@fresha/openapi-codegen-test-utils": "^0.1.2",
+        "@fresha/openapi-codegen-utils": "^0.1.3",
+        "@fresha/openapi-model": "^0.6.0",
         "@fresha/typescript-config": "^0.1.1",
         "memfs": "^3.4.7",
         "typescript": "^4.7.2"
@@ -14996,9 +14996,9 @@
       "requires": {
         "@fresha/code-morph-ts": "^0.1.1",
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.1",
-        "@fresha/openapi-codegen-utils": "^0.1.2",
-        "@fresha/openapi-model": "^0.5.1",
+        "@fresha/openapi-codegen-test-utils": "^0.1.2",
+        "@fresha/openapi-codegen-utils": "^0.1.3",
+        "@fresha/openapi-model": "^0.6.0",
         "@fresha/typescript-config": "^0.1.1",
         "ts-morph": "^16.0.0",
         "typescript": "^4.7.2"
@@ -15011,9 +15011,9 @@
         "@fresha/code-morph-test-utils": "^0.1.1",
         "@fresha/code-morph-ts": "^0.1.1",
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-test-utils": "^0.1.1",
-        "@fresha/openapi-codegen-utils": "^0.1.2",
-        "@fresha/openapi-model": "^0.5.1",
+        "@fresha/openapi-codegen-test-utils": "^0.1.2",
+        "@fresha/openapi-codegen-utils": "^0.1.3",
+        "@fresha/openapi-model": "^0.6.0",
         "@fresha/typescript-config": "^0.1.1",
         "@types/lodash.camelcase": "^4.3.7",
         "@types/lodash.get": "^4.4.7",
@@ -15038,8 +15038,8 @@
         "@fresha/api-tools-core": "^0.4.2",
         "@fresha/code-morph-test-utils": "^0.1.1",
         "@fresha/eslint-config": "^0.1.1",
-        "@fresha/openapi-codegen-utils": "^0.1.2",
-        "@fresha/openapi-model": "^0.5.1",
+        "@fresha/openapi-codegen-utils": "^0.1.3",
+        "@fresha/openapi-model": "^0.6.0",
         "@fresha/typescript-config": "^0.1.1",
         "@types/jest": "^29.1.2",
         "jest-matcher-utils": "^29.1.2",
@@ -15053,7 +15053,7 @@
         "@fresha/api-tools-core": "^0.4.2",
         "@fresha/eslint-config": "^0.1.1",
         "@fresha/jest-config": "^0.1.1",
-        "@fresha/openapi-model": "^0.5.1",
+        "@fresha/openapi-model": "^0.6.0",
         "@fresha/typescript-config": "^0.1.1",
         "@types/pluralize": "^0.0.29",
         "pluralize": "^8.0.0",
@@ -15076,7 +15076,7 @@
       "requires": {
         "@fresha/eslint-config": "^0.1.1",
         "@fresha/jest-config": "^0.1.1",
-        "@fresha/openapi-model": "^0.5.1",
+        "@fresha/openapi-model": "^0.6.0",
         "@fresha/typescript-config": "^0.1.1",
         "@types/chalk": "^2.2.0",
         "@types/glob": "^8.0.0",

--- a/packages/json-api-model/package.json
+++ b/packages/json-api-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/json-api-model",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "JSON:API object model",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -46,7 +46,7 @@
   "license": "MIT",
   "dependencies": {
     "@fresha/api-tools-core": "^0.4.2",
-    "@fresha/openapi-model": "^0.6.0",
+    "@fresha/openapi-model": "^0.6.1",
     "pluralize": "^8.0.0"
   },
   "devDependencies": {

--- a/packages/json-api-model/package.json
+++ b/packages/json-api-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/json-api-model",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "JSON:API object model",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -46,7 +46,7 @@
   "license": "MIT",
   "dependencies": {
     "@fresha/api-tools-core": "^0.4.2",
-    "@fresha/openapi-model": "^0.5.1",
+    "@fresha/openapi-model": "^0.6.0",
     "pluralize": "^8.0.0"
   },
   "devDependencies": {

--- a/packages/json-api-model/src/RelationshipSchema.ts
+++ b/packages/json-api-model/src/RelationshipSchema.ts
@@ -17,7 +17,7 @@ export const parseRelationshipSchema = (relSchema: SchemaModel): RelationshipInf
 
   let relDataSchema = relSchema.getPropertyOrThrow('data');
   if (relDataSchema.type === 'array') {
-    assert(relDataSchema.items);
+    assert(relDataSchema.items && !Array.isArray(relDataSchema.items));
     relDataSchema = relDataSchema.items;
     cardinality = 'many';
   } else if (relDataSchema.isNullish()) {

--- a/packages/openapi-codegen-cli/package.json
+++ b/packages/openapi-codegen-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-codegen-cli",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "CLI for OpenAPI code generators",
   "bin": {
     "fresha-openapi-codegen": "./bin/fresha-openapi-codegen.js"
@@ -54,12 +54,12 @@
     "typescript": "^4.7.2"
   },
   "dependencies": {
-    "@fresha/openapi-codegen-client-fetch": "^0.2.3",
-    "@fresha/openapi-codegen-client-fresha": "^0.2.2",
-    "@fresha/openapi-codegen-docs-json-api": "^0.1.3",
-    "@fresha/openapi-codegen-server-elixir": "^0.2.2",
-    "@fresha/openapi-codegen-server-mock": "^0.1.2",
-    "@fresha/openapi-codegen-server-nestjs": "^0.2.2",
+    "@fresha/openapi-codegen-client-fetch": "^0.2.4",
+    "@fresha/openapi-codegen-client-fresha": "^0.2.3",
+    "@fresha/openapi-codegen-docs-json-api": "^0.1.4",
+    "@fresha/openapi-codegen-server-elixir": "^0.2.3",
+    "@fresha/openapi-codegen-server-mock": "^0.1.3",
+    "@fresha/openapi-codegen-server-nestjs": "^0.2.3",
     "yargs": "^17.5.1"
   }
 }

--- a/packages/openapi-codegen-cli/package.json
+++ b/packages/openapi-codegen-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-codegen-cli",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "CLI for OpenAPI code generators",
   "bin": {
     "fresha-openapi-codegen": "./bin/fresha-openapi-codegen.js"
@@ -54,12 +54,12 @@
     "typescript": "^4.7.2"
   },
   "dependencies": {
-    "@fresha/openapi-codegen-client-fetch": "^0.2.4",
-    "@fresha/openapi-codegen-client-fresha": "^0.2.3",
-    "@fresha/openapi-codegen-docs-json-api": "^0.1.4",
-    "@fresha/openapi-codegen-server-elixir": "^0.2.3",
-    "@fresha/openapi-codegen-server-mock": "^0.1.3",
-    "@fresha/openapi-codegen-server-nestjs": "^0.2.3",
+    "@fresha/openapi-codegen-client-fetch": "^0.2.5",
+    "@fresha/openapi-codegen-client-fresha": "^0.2.4",
+    "@fresha/openapi-codegen-docs-json-api": "^0.1.5",
+    "@fresha/openapi-codegen-server-elixir": "^0.2.4",
+    "@fresha/openapi-codegen-server-mock": "^0.1.4",
+    "@fresha/openapi-codegen-server-nestjs": "^0.2.4",
     "yargs": "^17.5.1"
   }
 }

--- a/packages/openapi-codegen-client-fetch/package.json
+++ b/packages/openapi-codegen-client-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-codegen-client-fetch",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "OpenAPI code generation for Fetch API clients",
   "main": "build/index.js",
   "scripts": {
@@ -49,13 +49,13 @@
   "dependencies": {
     "@fresha/api-tools-core": "^0.4.2",
     "@fresha/code-morph-ts": "^0.1.1",
-    "@fresha/openapi-codegen-utils": "^0.1.2",
-    "@fresha/openapi-model": "^0.5.1",
+    "@fresha/openapi-codegen-utils": "^0.1.3",
+    "@fresha/openapi-model": "^0.6.0",
     "ts-morph": "^16.0.0"
   },
   "devDependencies": {
     "@fresha/eslint-config": "^0.1.1",
-    "@fresha/openapi-codegen-test-utils": "^0.1.1",
+    "@fresha/openapi-codegen-test-utils": "^0.1.2",
     "@fresha/typescript-config": "^0.1.1",
     "@types/pluralize": "^0.0.29",
     "pluralize": "^8.0.0",

--- a/packages/openapi-codegen-client-fetch/package.json
+++ b/packages/openapi-codegen-client-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-codegen-client-fetch",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "OpenAPI code generation for Fetch API clients",
   "main": "build/index.js",
   "scripts": {
@@ -49,13 +49,13 @@
   "dependencies": {
     "@fresha/api-tools-core": "^0.4.2",
     "@fresha/code-morph-ts": "^0.1.1",
-    "@fresha/openapi-codegen-utils": "^0.1.3",
-    "@fresha/openapi-model": "^0.6.0",
+    "@fresha/openapi-codegen-utils": "^0.1.4",
+    "@fresha/openapi-model": "^0.6.1",
     "ts-morph": "^16.0.0"
   },
   "devDependencies": {
     "@fresha/eslint-config": "^0.1.1",
-    "@fresha/openapi-codegen-test-utils": "^0.1.2",
+    "@fresha/openapi-codegen-test-utils": "^0.1.3",
     "@fresha/typescript-config": "^0.1.1",
     "@types/pluralize": "^0.0.29",
     "pluralize": "^8.0.0",

--- a/packages/openapi-codegen-client-fetch/src/parts/DocumentType.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/DocumentType.test.ts
@@ -157,6 +157,8 @@ describe('primary data', () => {
 
     responseSchema.setProperty('data', 'array').setItems(employee);
 
+    debugger;
+
     const documentType = createDocumentType(operation, 'SimpleResponseDocument');
 
     documentType.collectData(namedTypes);

--- a/packages/openapi-codegen-client-fetch/src/parts/ResourceType.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ResourceType.ts
@@ -119,6 +119,11 @@ export class ResourceType extends NamedType {
 
       let isArray = false;
       if (propDataSchema?.type === 'array') {
+        assert(
+          !Array.isArray(propDataSchema?.items),
+          'Relationship items subschema itself must not be an array',
+          this.context.operation,
+        );
         propDataSchema = propDataSchema?.items;
         isArray = true;
       }

--- a/packages/openapi-codegen-client-fetch/src/parts/utils.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/utils.ts
@@ -38,6 +38,10 @@ export const schemaToType = (schema: Nullable<SchemaModel>): string => {
       return elements.join(' | ');
     }
     case 'array': {
+      if (Array.isArray(schema.items)) {
+        const subtypes = schema.items.map(s => schemaToType(s));
+        return schema.nullable ? `[${subtypes.join(', ')}] | null` : `[${subtypes.join(', ')}]`;
+      }
       const subtype = schemaToType(schema.items);
       return schema.nullable ? `${subtype}[] | null` : `${subtype}[]`;
     }

--- a/packages/openapi-codegen-client-fresha/package.json
+++ b/packages/openapi-codegen-client-fresha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-codegen-client-fresha",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "OpenAPI code generation for Fresha clients",
   "main": "build/index.js",
   "scripts": {
@@ -49,14 +49,14 @@
   "dependencies": {
     "@fresha/api-tools-core": "^0.4.2",
     "@fresha/code-morph-ts": "^0.1.1",
-    "@fresha/openapi-codegen-utils": "^0.1.3",
-    "@fresha/openapi-model": "^0.6.0",
+    "@fresha/openapi-codegen-utils": "^0.1.4",
+    "@fresha/openapi-model": "^0.6.1",
     "ts-morph": "^16.0.0"
   },
   "devDependencies": {
     "@fresha/code-morph-test-utils": "^0.1.1",
     "@fresha/eslint-config": "^0.1.1",
-    "@fresha/openapi-codegen-test-utils": "^0.1.2",
+    "@fresha/openapi-codegen-test-utils": "^0.1.3",
     "@fresha/typescript-config": "^0.1.1",
     "typescript": "^4.7.2"
   }

--- a/packages/openapi-codegen-client-fresha/package.json
+++ b/packages/openapi-codegen-client-fresha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-codegen-client-fresha",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "OpenAPI code generation for Fresha clients",
   "main": "build/index.js",
   "scripts": {
@@ -49,14 +49,14 @@
   "dependencies": {
     "@fresha/api-tools-core": "^0.4.2",
     "@fresha/code-morph-ts": "^0.1.1",
-    "@fresha/openapi-codegen-utils": "^0.1.2",
-    "@fresha/openapi-model": "^0.5.1",
+    "@fresha/openapi-codegen-utils": "^0.1.3",
+    "@fresha/openapi-model": "^0.6.0",
     "ts-morph": "^16.0.0"
   },
   "devDependencies": {
     "@fresha/code-morph-test-utils": "^0.1.1",
     "@fresha/eslint-config": "^0.1.1",
-    "@fresha/openapi-codegen-test-utils": "^0.1.1",
+    "@fresha/openapi-codegen-test-utils": "^0.1.2",
     "@fresha/typescript-config": "^0.1.1",
     "typescript": "^4.7.2"
   }

--- a/packages/openapi-codegen-docs/package.json
+++ b/packages/openapi-codegen-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-codegen-docs-json-api",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Better OpenAPI documentation generator for JSON:API",
   "main": "build/index.js",
   "scripts": {
@@ -47,12 +47,12 @@
   "license": "MIT",
   "dependencies": {
     "@fresha/api-tools-core": "^0.4.2",
-    "@fresha/openapi-codegen-utils": "^0.1.3",
-    "@fresha/openapi-model": "^0.6.0"
+    "@fresha/openapi-codegen-utils": "^0.1.4",
+    "@fresha/openapi-model": "^0.6.1"
   },
   "devDependencies": {
     "@fresha/eslint-config": "^0.1.1",
-    "@fresha/openapi-codegen-test-utils": "^0.1.2",
+    "@fresha/openapi-codegen-test-utils": "^0.1.3",
     "@fresha/typescript-config": "^0.1.1",
     "typescript": "^4.7.2"
   }

--- a/packages/openapi-codegen-docs/package.json
+++ b/packages/openapi-codegen-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-codegen-docs-json-api",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Better OpenAPI documentation generator for JSON:API",
   "main": "build/index.js",
   "scripts": {
@@ -47,12 +47,12 @@
   "license": "MIT",
   "dependencies": {
     "@fresha/api-tools-core": "^0.4.2",
-    "@fresha/openapi-codegen-utils": "^0.1.2",
-    "@fresha/openapi-model": "^0.5.1"
+    "@fresha/openapi-codegen-utils": "^0.1.3",
+    "@fresha/openapi-model": "^0.6.0"
   },
   "devDependencies": {
     "@fresha/eslint-config": "^0.1.1",
-    "@fresha/openapi-codegen-test-utils": "^0.1.1",
+    "@fresha/openapi-codegen-test-utils": "^0.1.2",
     "@fresha/typescript-config": "^0.1.1",
     "typescript": "^4.7.2"
   }

--- a/packages/openapi-codegen-server-elixir/package.json
+++ b/packages/openapi-codegen-server-elixir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-codegen-server-elixir",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "OpenAPI code generation for Elixir/Phoenix servers",
   "main": "build/index.js",
   "scripts": {
@@ -49,15 +49,15 @@
     "@faker-js/faker": "^7.6.0",
     "@fresha/api-tools-core": "^0.4.2",
     "@fresha/code-morph-ex": "^0.1.1",
-    "@fresha/json-api-model": "^0.2.2",
-    "@fresha/openapi-codegen-utils": "^0.1.2",
-    "@fresha/openapi-model": "^0.5.1",
+    "@fresha/json-api-model": "^0.2.3",
+    "@fresha/openapi-codegen-utils": "^0.1.3",
+    "@fresha/openapi-model": "^0.6.0",
     "memfs": "^3.4.7"
   },
   "devDependencies": {
     "@fresha/code-morph-test-utils": "^0.1.1",
     "@fresha/eslint-config": "^0.1.1",
-    "@fresha/openapi-codegen-test-utils": "^0.1.1",
+    "@fresha/openapi-codegen-test-utils": "^0.1.2",
     "@fresha/typescript-config": "^0.1.1",
     "typescript": "^4.7.2"
   }

--- a/packages/openapi-codegen-server-elixir/package.json
+++ b/packages/openapi-codegen-server-elixir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-codegen-server-elixir",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "OpenAPI code generation for Elixir/Phoenix servers",
   "main": "build/index.js",
   "scripts": {
@@ -49,15 +49,15 @@
     "@faker-js/faker": "^7.6.0",
     "@fresha/api-tools-core": "^0.4.2",
     "@fresha/code-morph-ex": "^0.1.1",
-    "@fresha/json-api-model": "^0.2.3",
-    "@fresha/openapi-codegen-utils": "^0.1.3",
-    "@fresha/openapi-model": "^0.6.0",
+    "@fresha/json-api-model": "^0.2.4",
+    "@fresha/openapi-codegen-utils": "^0.1.4",
+    "@fresha/openapi-model": "^0.6.1",
     "memfs": "^3.4.7"
   },
   "devDependencies": {
     "@fresha/code-morph-test-utils": "^0.1.1",
     "@fresha/eslint-config": "^0.1.1",
-    "@fresha/openapi-codegen-test-utils": "^0.1.2",
+    "@fresha/openapi-codegen-test-utils": "^0.1.3",
     "@fresha/typescript-config": "^0.1.1",
     "typescript": "^4.7.2"
   }

--- a/packages/openapi-codegen-server-elixir/src/parts/Action.ts
+++ b/packages/openapi-codegen-server-elixir/src/parts/Action.ts
@@ -164,6 +164,12 @@ export class Action {
               break;
             }
             case 'array': {
+              assert(
+                !Array.isArray(param.schema.items),
+                `Unsupported tuple type "${String(param.schema?.type)}" for parameter "${
+                  param.name
+                }" from "${String(param.in)}"`,
+              );
               const itemSchemaType = param.schema.items?.type;
               if (
                 itemSchemaType === 'string' ||

--- a/packages/openapi-codegen-server-mock/package.json
+++ b/packages/openapi-codegen-server-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-codegen-server-mock",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "OpenAPI code generation for mock API servers",
   "main": "build/index.js",
   "scripts": {
@@ -47,13 +47,13 @@
   "license": "MIT",
   "dependencies": {
     "@fresha/code-morph-ts": "^0.1.1",
-    "@fresha/openapi-codegen-utils": "^0.1.2",
-    "@fresha/openapi-model": "^0.5.1",
+    "@fresha/openapi-codegen-utils": "^0.1.3",
+    "@fresha/openapi-model": "^0.6.0",
     "ts-morph": "^16.0.0"
   },
   "devDependencies": {
     "@fresha/eslint-config": "^0.1.1",
-    "@fresha/openapi-codegen-test-utils": "^0.1.1",
+    "@fresha/openapi-codegen-test-utils": "^0.1.2",
     "@fresha/typescript-config": "^0.1.1",
     "typescript": "^4.7.2"
   }

--- a/packages/openapi-codegen-server-mock/package.json
+++ b/packages/openapi-codegen-server-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-codegen-server-mock",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "OpenAPI code generation for mock API servers",
   "main": "build/index.js",
   "scripts": {
@@ -47,13 +47,13 @@
   "license": "MIT",
   "dependencies": {
     "@fresha/code-morph-ts": "^0.1.1",
-    "@fresha/openapi-codegen-utils": "^0.1.3",
-    "@fresha/openapi-model": "^0.6.0",
+    "@fresha/openapi-codegen-utils": "^0.1.4",
+    "@fresha/openapi-model": "^0.6.1",
     "ts-morph": "^16.0.0"
   },
   "devDependencies": {
     "@fresha/eslint-config": "^0.1.1",
-    "@fresha/openapi-codegen-test-utils": "^0.1.2",
+    "@fresha/openapi-codegen-test-utils": "^0.1.3",
     "@fresha/typescript-config": "^0.1.1",
     "typescript": "^4.7.2"
   }

--- a/packages/openapi-codegen-server-nestjs/package.json
+++ b/packages/openapi-codegen-server-nestjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-codegen-server-nestjs",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "OpenAPI code generation for NestJS servers",
   "main": "build/index.js",
   "scripts": {
@@ -49,8 +49,8 @@
   "dependencies": {
     "@fresha/api-tools-core": "^0.4.2",
     "@fresha/code-morph-ts": "^0.1.1",
-    "@fresha/openapi-codegen-utils": "^0.1.2",
-    "@fresha/openapi-model": "^0.5.1",
+    "@fresha/openapi-codegen-utils": "^0.1.3",
+    "@fresha/openapi-model": "^0.6.0",
     "lodash.camelcase": "^4.3.0",
     "lodash.get": "^4.4.2",
     "lodash.kebabcase": "^4.1.1",
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@fresha/code-morph-test-utils": "^0.1.1",
     "@fresha/eslint-config": "^0.1.1",
-    "@fresha/openapi-codegen-test-utils": "^0.1.1",
+    "@fresha/openapi-codegen-test-utils": "^0.1.2",
     "@fresha/typescript-config": "^0.1.1",
     "@types/lodash.camelcase": "^4.3.7",
     "@types/lodash.get": "^4.4.7",

--- a/packages/openapi-codegen-server-nestjs/package.json
+++ b/packages/openapi-codegen-server-nestjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-codegen-server-nestjs",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "OpenAPI code generation for NestJS servers",
   "main": "build/index.js",
   "scripts": {
@@ -49,8 +49,8 @@
   "dependencies": {
     "@fresha/api-tools-core": "^0.4.2",
     "@fresha/code-morph-ts": "^0.1.1",
-    "@fresha/openapi-codegen-utils": "^0.1.3",
-    "@fresha/openapi-model": "^0.6.0",
+    "@fresha/openapi-codegen-utils": "^0.1.4",
+    "@fresha/openapi-model": "^0.6.1",
     "lodash.camelcase": "^4.3.0",
     "lodash.get": "^4.4.2",
     "lodash.kebabcase": "^4.1.1",
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@fresha/code-morph-test-utils": "^0.1.1",
     "@fresha/eslint-config": "^0.1.1",
-    "@fresha/openapi-codegen-test-utils": "^0.1.2",
+    "@fresha/openapi-codegen-test-utils": "^0.1.3",
     "@fresha/typescript-config": "^0.1.1",
     "@types/lodash.camelcase": "^4.3.7",
     "@types/lodash.get": "^4.4.7",

--- a/packages/openapi-codegen-server-nestjs/src/DTO.ts
+++ b/packages/openapi-codegen-server-nestjs/src/DTO.ts
@@ -178,25 +178,27 @@ export class DTO {
     assert(this.schema);
 
     let itemTypeString = 'unknown[]';
-    switch (prop.schema.items?.type) {
-      case 'boolean':
-        itemTypeString = 'boolean[]';
-        break;
-      case 'integer':
-      case 'number':
-        itemTypeString = 'number[]';
-        break;
-      case 'string':
-        itemTypeString = 'string[]';
-        break;
-      case 'object':
-        itemTypeString = 'object[]';
-        break;
-      case undefined:
-      case null:
-        break;
-      default:
-        assert.fail(`Unsupported schema type ${String(prop.schema.items?.type)}`);
+    if (!Array.isArray(prop.schema.items)) {
+      switch (prop.schema.items?.type) {
+        case 'boolean':
+          itemTypeString = 'boolean[]';
+          break;
+        case 'integer':
+        case 'number':
+          itemTypeString = 'number[]';
+          break;
+        case 'string':
+          itemTypeString = 'string[]';
+          break;
+        case 'object':
+          itemTypeString = 'object[]';
+          break;
+        case undefined:
+        case null:
+          break;
+        default:
+          assert.fail(`Unsupported schema type ${String(prop.schema.items?.type)}`);
+      }
     }
 
     const propDef = classDecl.addProperty({

--- a/packages/openapi-codegen-test-utils/package.json
+++ b/packages/openapi-codegen-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-codegen-test-utils",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Testing utilites for OpenAPI codegens",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -47,8 +47,8 @@
   "dependencies": {
     "@fresha/api-tools-core": "^0.4.2",
     "@fresha/code-morph-test-utils": "^0.1.1",
-    "@fresha/openapi-codegen-utils": "^0.1.3",
-    "@fresha/openapi-model": "^0.6.0",
+    "@fresha/openapi-codegen-utils": "^0.1.4",
+    "@fresha/openapi-model": "^0.6.1",
     "jest-matcher-utils": "^29.1.2",
     "ts-morph": "^16.0.0"
   }

--- a/packages/openapi-codegen-test-utils/package.json
+++ b/packages/openapi-codegen-test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-codegen-test-utils",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Testing utilites for OpenAPI codegens",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -47,8 +47,8 @@
   "dependencies": {
     "@fresha/api-tools-core": "^0.4.2",
     "@fresha/code-morph-test-utils": "^0.1.1",
-    "@fresha/openapi-codegen-utils": "^0.1.2",
-    "@fresha/openapi-model": "^0.5.1",
+    "@fresha/openapi-codegen-utils": "^0.1.3",
+    "@fresha/openapi-model": "^0.6.0",
     "jest-matcher-utils": "^29.1.2",
     "ts-morph": "^16.0.0"
   }

--- a/packages/openapi-codegen-utils/package.json
+++ b/packages/openapi-codegen-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-codegen-utils",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Shared utilites for OpenAPI codegens",
   "main": "build/index.js",
   "scripts": {
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@fresha/api-tools-core": "^0.4.2",
-    "@fresha/openapi-model": "^0.5.1",
+    "@fresha/openapi-model": "^0.6.0",
     "pluralize": "^8.0.0",
     "ts-morph": "^16.0.0",
     "winston": "^3.8.2"

--- a/packages/openapi-codegen-utils/package.json
+++ b/packages/openapi-codegen-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-codegen-utils",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Shared utilites for OpenAPI codegens",
   "main": "build/index.js",
   "scripts": {
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@fresha/api-tools-core": "^0.4.2",
-    "@fresha/openapi-model": "^0.6.0",
+    "@fresha/openapi-model": "^0.6.1",
     "pluralize": "^8.0.0",
     "ts-morph": "^16.0.0",
     "winston": "^3.8.2"

--- a/packages/openapi-lint/package.json
+++ b/packages/openapi-lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-lint",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Linting tool for OpenAPI schemas",
   "main": "build/index.js",
   "bin": {
@@ -56,7 +56,7 @@
     "typescript": "^4.7.2"
   },
   "dependencies": {
-    "@fresha/openapi-model": "^0.6.0",
+    "@fresha/openapi-model": "^0.6.1",
     "chalk": "^4.1.0",
     "glob": "^8.0.3",
     "yargs": "^17.6.2"

--- a/packages/openapi-lint/package.json
+++ b/packages/openapi-lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-lint",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Linting tool for OpenAPI schemas",
   "main": "build/index.js",
   "bin": {
@@ -56,7 +56,7 @@
     "typescript": "^4.7.2"
   },
   "dependencies": {
-    "@fresha/openapi-model": "^0.5.1",
+    "@fresha/openapi-model": "^0.6.0",
     "chalk": "^4.1.0",
     "glob": "^8.0.3",
     "yargs": "^17.6.2"

--- a/packages/openapi-lint/src/rules/oas3/noUnusedSharedComponents.ts
+++ b/packages/openapi-lint/src/rules/oas3/noUnusedSharedComponents.ts
@@ -15,7 +15,13 @@ const removeReferenceSchema = (schema: SchemaModel, sharedSchemas: Set<SchemaMod
     removeReferenceSchema(schema.additionalProperties, sharedSchemas);
   }
   if (schema.items) {
-    removeReferenceSchema(schema.items, sharedSchemas);
+    if (Array.isArray(schema.items)) {
+      for (const item of schema.items) {
+        removeReferenceSchema(item, sharedSchemas);
+      }
+    } else {
+      removeReferenceSchema(schema.items, sharedSchemas);
+    }
   }
   if (schema.allOf?.length) {
     for (const alt of schema.allOf) {

--- a/packages/openapi-model/examples/json-api.yaml
+++ b/packages/openapi-model/examples/json-api.yaml
@@ -36,7 +36,23 @@ paths:
         $ref: "#/components/requestBodies/JSONAPIRequest"
       responses:
         default:
-          $ref: "#/components/responses/JSONAPIDataResponse"
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  - type: string
+                    nullable: true
+                  - type: number
+                    minimum: 0
+                    maximum: 100
+                  - type: object
+                    properties:
+                      one:
+                        type: boolean
+                      two:
+                        type: number
 components:
   schemas:
     JSONAPIVersion:

--- a/packages/openapi-model/package.json
+++ b/packages/openapi-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-model",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "OpenAPI object model",
   "main": "build/index.js",
   "scripts": {

--- a/packages/openapi-model/package.json
+++ b/packages/openapi-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fresha/openapi-model",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "OpenAPI object model",
   "main": "build/index.js",
   "scripts": {

--- a/packages/openapi-model/src/3.0.3/model/OpenAPIReader.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPIReader.ts
@@ -511,7 +511,13 @@ export class OpenAPIReader {
       model.not = this.parseSchema(json.not, model);
     }
     if (json.items) {
-      model.setItems(this.parseSchema(json.items, model));
+      if (Array.isArray(json.items)) {
+        for (const item of json.items) {
+          model.addTupleItem(this.parseSchema(item, model));
+        }
+      } else {
+        model.setItems(this.parseSchema(json.items, model));
+      }
     }
     if (json.properties) {
       for (const [key, value] of Object.entries(json.properties)) {

--- a/packages/openapi-model/src/3.0.3/model/OpenAPIWriter.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPIWriter.ts
@@ -389,7 +389,11 @@ export class OpenAPIWriter {
       result.not = this.writeSchema(schema.not, schema);
     }
     if (schema.items != null) {
-      result.items = this.writeSchema(schema.items, schema);
+      if (Array.isArray(schema.items)) {
+        result.items = schema.items.map(subschema => this.writeSchema(subschema, schema));
+      } else {
+        result.items = this.writeSchema(schema.items, schema);
+      }
     }
     if (schema.properties.size) {
       result.properties = {};

--- a/packages/openapi-model/src/3.0.3/model/Schema.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Schema.test.ts
@@ -139,7 +139,7 @@ describe('SchemaFactory', () => {
     expect(stringArraySchema.parent).toBe(openapi.components);
     expect(stringArraySchema.minItems).toBeNull();
     expect(stringArraySchema.maxItems).toBeNull();
-    expect(stringArraySchema.items?.type).toBe('string');
+    expect(!Array.isArray(stringArraySchema.items) && stringArraySchema.items?.type).toBe('string');
 
     const numberArraySchema = SchemaFactory.createArray(openapi.components, {
       itemsOptions: 'number',
@@ -676,6 +676,26 @@ describe('Schema', () => {
     expect(itemsSchema).toBe(schema.items);
     expect(itemsSchema.type).toBe('number');
     expect(itemsSchema.format).toBe('double');
+  });
+
+  test('addTupleItem, removeTupleItemAt, clearTupleItems', () => {
+    const schema = SchemaFactory.create(openapi.components, 'array');
+    const item1 = schema.addTupleItem('boolean');
+    const item2 = schema.addTupleItem('string');
+    const item3 = schema.addTupleItem('integer');
+    expect(schema.isTuple()).toBeTruthy();
+
+    expect(Array.isArray(schema.items)).toBe(true);
+
+    expect(schema.items).toHaveProperty('0', item1);
+    expect(schema.items).toHaveProperty('1', item2);
+    expect(schema.items).toHaveProperty('2', item3);
+
+    schema.deleteTupleItemAt(1);
+    expect(schema.items).toHaveProperty('1', item3);
+
+    schema.clearTupleItems();
+    expect(schema.items).toStrictEqual([]);
   });
 
   test('addAllOf', () => {

--- a/packages/openapi-model/src/3.0.3/model/Schema.ts
+++ b/packages/openapi-model/src/3.0.3/model/Schema.ts
@@ -443,7 +443,7 @@ export class Schema extends BasicNode<SchemaModelParent> implements SchemaModel 
       this.items = [];
     }
 
-    const subschema = SchemaFactory.createOrGet(this, options);
+    const subschema = Schema.createOrGet(this, options);
     this.items.push(subschema);
 
     return subschema;

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -176,7 +176,7 @@ export interface SchemaModel extends TreeNode<SchemaModelParent>, SpecificationE
   oneOf: Nullable<SchemaModel[]>;
   anyOf: Nullable<SchemaModel[]>;
   not: Nullable<SchemaModel>;
-  items: Nullable<SchemaModel>;
+  items: Nullable<SchemaModel | SchemaModel[]>;
   readonly properties: ReadonlyMap<string, SchemaModel>;
   additionalProperties: Nullable<SchemaModel | boolean>;
   description: Nullable<CommonMarkString>;
@@ -209,6 +209,12 @@ export interface SchemaModel extends TreeNode<SchemaModelParent>, SpecificationE
    * null schemas or nullable (i.e. have nullable attribute set to true).
    */
   isNullish(): boolean;
+
+  /**
+   * Returns true is this schema represents a tuple, i.e. an array of fixed size those
+   * elements may have different types.
+   */
+  isTuple(): boolean;
 
   // /**
   //  * Returns type of this schema, deduced from own type and types of allOf subschemas.
@@ -258,6 +264,28 @@ export interface SchemaModel extends TreeNode<SchemaModelParent>, SpecificationE
    * @return this.items
    */
   setItems(options: CreateOrSetSchemaOptions): SchemaModel;
+
+  /**
+   * Utility function to handle tuple-like schemas. It adds a new subschema at the end of
+   * `items` schema array. If items is not an array, it makes it one.
+   *
+   * @see https://json-schema.org/understanding-json-schema/reference/array.html#tuple-validation
+   */
+  addTupleItem(options: CreateOrSetSchemaOptions): SchemaModel;
+
+  /**
+   * Utility function to handle tuple-like schemas. It removes a tuple subschema from given
+   * index in the `items` schema array. It `items` is not an array, it does nothing.
+   *
+   * @param index subschema index
+   */
+  deleteTupleItemAt(index: number): void;
+
+  /**
+   * Utility function to handle tuple-like schemas. It removes all subschemas from `items`
+   * array, but does not change the `items` itself.
+   */
+  clearTupleItems(): void;
 
   addAllOf(options: CreateOrSetSchemaOptions): SchemaModel;
   deleteAllOfAt(index: number): void;

--- a/packages/openapi-model/src/3.0.3/types.ts
+++ b/packages/openapi-model/src/3.0.3/types.ts
@@ -161,7 +161,7 @@ export type SchemaObject = {
   oneOf?: ObjectOrRef<SchemaObject>[];
   anyOf?: ObjectOrRef<SchemaObject>[];
   not?: ObjectOrRef<SchemaObject>;
-  items?: ObjectOrRef<SchemaObject>;
+  items?: ObjectOrRef<SchemaObject> | ObjectOrRef<SchemaObject>[];
   properties?: Record<string, ObjectOrRef<SchemaObject>>;
   additionalProperties?: ObjectOrRef<SchemaObject> | boolean;
   description?: CommonMarkString;


### PR DESCRIPTION
## Motivation and Context

This PR extends `SchemaModel` with support for tuple-like schemas, like:

```yaml
SomeSchema:
  type: array
  items:
    - type: boolean
    - type: string
```

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

More information on things that require more attention while reviewing.
