### PR TITLE
Implement model for OpenAPI 3.1

### DIFF
--- a/packages/openapi-model/src/3.1.0/model/Callback.ts
+++ b/packages/openapi-model/src/3.1.0/model/Callback.ts
@@ -1,0 +1,9 @@
+import { Node } from './Node';
+
+import type { Components } from './Components';
+import type { Operation } from './Operation';
+import type { CallbackModel } from './types';
+
+type CallbackParent = Components | Operation;
+
+export class Callback extends Node<CallbackParent> implements CallbackModel {}

--- a/packages/openapi-model/src/3.1.0/model/Components.ts
+++ b/packages/openapi-model/src/3.1.0/model/Components.ts
@@ -1,0 +1,490 @@
+import assert from 'assert';
+
+import { CommonMarkString, URLString } from '@fresha/api-tools-core';
+
+import { Callback } from './Callback';
+import { Example } from './Example';
+import { Header } from './Header';
+import { Link } from './Link';
+import { Node } from './Node';
+import {
+  CookieParameter,
+  HeaderParameter,
+  Parameter,
+  PathParameter,
+  QueryParameter,
+} from './Parameter';
+import { PathItem } from './PathItem';
+import { RequestBody } from './RequestBody';
+import { Response } from './Response';
+import { Schema } from './Schema';
+import {
+  APIKeySecuritySchema,
+  HTTPSecuritySchema,
+  MutualTLSSecuritySchema,
+  OAuth2SecuritySchema,
+  OpenIDConnectSecuritySchema,
+  SecuritySchema,
+} from './SecuritySchema';
+
+import type { OpenAPI } from './OpenAPI';
+import type {
+  APIKeySecuritySchemaLocation,
+  ComponentsModel,
+  ParameterLocation,
+  SecuritySchemaType,
+} from './types';
+
+type ComponentsParent = OpenAPI;
+
+export class Components extends Node<ComponentsParent> implements ComponentsModel {
+  #schemas: Map<string, Schema>;
+  #responses: Map<string, Response>;
+  #parameters: Map<string, Parameter>;
+  #examples: Map<string, Example>;
+  #requestBodies: Map<string, RequestBody>;
+  #headers: Map<string, Header>;
+  #securitySchemas: Map<string, SecuritySchema>;
+  #links: Map<string, Link>;
+  #callbacks: Map<string, Callback>;
+  #pathItems: Map<string, PathItem>;
+
+  constructor(parent: ComponentsParent) {
+    super(parent);
+    this.#schemas = new Map<string, Schema>();
+    this.#responses = new Map<string, Response>();
+    this.#parameters = new Map<string, Parameter>();
+    this.#examples = new Map<string, Example>();
+    this.#requestBodies = new Map<string, RequestBody>();
+    this.#headers = new Map<string, Header>();
+    this.#securitySchemas = new Map<string, SecuritySchema>();
+    this.#links = new Map<string, Link>();
+    this.#callbacks = new Map<string, Callback>();
+    this.#pathItems = new Map<string, PathItem>();
+  }
+
+  get schemaCount(): number {
+    return this.#schemas.size;
+  }
+
+  schemaKeys(): IterableIterator<string> {
+    return this.#schemas.keys();
+  }
+
+  schemas(): IterableIterator<[string, Schema]> {
+    return this.#schemas.entries();
+  }
+
+  hasSchema(key: string): boolean {
+    return this.#schemas.has(key);
+  }
+
+  addSchema(key: string): Schema {
+    assert(!this.hasSchema(key), `Schema for key '${key}' already exists`);
+    const schema = new Schema(this);
+    this.#schemas.set(key, schema);
+    return schema;
+  }
+
+  deleteSchema(key: string): void {
+    const schema = this.#schemas.get(key);
+    if (schema) {
+      schema.dispose();
+      this.#schemas.delete(key);
+    }
+  }
+
+  clearSchemas(): void {
+    this.#schemas.forEach(s => s.dispose());
+    this.#schemas.clear();
+  }
+
+  get responseCount(): number {
+    return this.#responses.size;
+  }
+
+  responseKeys(): IterableIterator<string> {
+    return this.#responses.keys();
+  }
+
+  responses(): IterableIterator<[string, Response]> {
+    return this.#responses.entries();
+  }
+
+  hasResponse(key: string): boolean {
+    return this.#responses.has(key);
+  }
+
+  addResponse(key: string, description: CommonMarkString): Response {
+    assert(!this.hasResponse(key), `Response for key '${key}' already exists`);
+    const response = new Response(this, description);
+    this.#responses.set(key, response);
+    return response;
+  }
+
+  deleteResponse(key: string): void {
+    const response = this.#responses.get(key);
+    if (response) {
+      response.dispose();
+      this.#responses.delete(key);
+    }
+  }
+
+  clearResponse(): void {
+    this.#responses.forEach(r => r.dispose());
+    this.#responses.clear();
+  }
+
+  get parameterCount(): number {
+    return this.#parameters.size;
+  }
+
+  parameterKeys(): IterableIterator<string> {
+    return this.#parameters.keys();
+  }
+
+  parameters(): IterableIterator<[string, Parameter]> {
+    return this.#parameters.entries();
+  }
+
+  hasParameter(key: string): boolean {
+    return this.#parameters.has(key);
+  }
+
+  addParameter(key: string, name: string, location: 'path'): PathParameter;
+  addParameter(key: string, name: string, location: 'query'): QueryParameter;
+  addParameter(key: string, name: string, location: 'header'): HeaderParameter;
+  addParameter(key: string, name: string, location: 'cookie'): CookieParameter;
+  addParameter(key: string, name: string, location: ParameterLocation): Parameter {
+    assert(!this.hasParameter(key), `Parameter for key '${key}' already exists`);
+    let result: Parameter;
+    switch (location) {
+      case 'path':
+        result = new PathParameter(this, name);
+        break;
+      case 'query':
+        result = new QueryParameter(this, name);
+        break;
+      case 'header':
+        result = new HeaderParameter(this, name);
+        break;
+      case 'cookie':
+        result = new CookieParameter(this, name);
+        break;
+      default:
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        assert.fail(`Invalid parameter location '${location}'`);
+    }
+    this.#parameters.set(key, result);
+    return result;
+  }
+
+  deleteParameter(key: string): void {
+    const parameter = this.#parameters.get(key);
+    if (parameter) {
+      parameter.dispose();
+      this.#parameters.delete(key);
+    }
+  }
+
+  clearParameters(): void {
+    this.#parameters.forEach(p => p.dispose());
+    this.#parameters.clear();
+  }
+
+  get exampleCount(): number {
+    return this.#examples.size;
+  }
+
+  exampleKeys(): IterableIterator<string> {
+    return this.#examples.keys();
+  }
+
+  examples(): IterableIterator<[string, Example]> {
+    return this.#examples.entries();
+  }
+
+  hasExample(key: string): boolean {
+    return this.#examples.has(key);
+  }
+
+  addExample(key: string): Example {
+    assert(!this.hasExample(key), `Example for key '${key}' already exists`);
+    const result = new Example(this);
+    this.#examples.set(key, result);
+    return result;
+  }
+
+  deleteExample(key: string): void {
+    const example = this.#examples.get(key);
+    if (example) {
+      example.dispose();
+      this.#examples.delete(key);
+    }
+  }
+
+  clearExamples(): void {
+    this.#examples.forEach(e => e.dispose());
+    this.#examples.clear();
+  }
+
+  get requestBodyCount(): number {
+    return this.#requestBodies.size;
+  }
+
+  requestBodyKeys(): IterableIterator<string> {
+    return this.#requestBodies.keys();
+  }
+
+  requestBodies(): IterableIterator<[string, RequestBody]> {
+    return this.#requestBodies.entries();
+  }
+
+  hasRequestBody(key: string): boolean {
+    return this.#requestBodies.has(key);
+  }
+
+  addRequestBody(key: string): RequestBody {
+    assert(!this.hasRequestBody(key), `Request body for key '${key}' already exists`);
+    const result = new RequestBody(this);
+    this.#requestBodies.set(key, result);
+    return result;
+  }
+
+  deleteRequestBody(key: string): void {
+    const requestBody = this.#requestBodies.get(key);
+    if (requestBody) {
+      requestBody.dispose();
+      this.#requestBodies.delete(key);
+    }
+  }
+
+  clearRequestBodies(): void {
+    this.#requestBodies.forEach(rb => rb.dispose());
+    this.#requestBodies.clear();
+  }
+
+  get headerCount(): number {
+    return this.#headers.size;
+  }
+
+  headerKeys(): IterableIterator<string> {
+    return this.#headers.keys();
+  }
+
+  headers(): IterableIterator<[string, Header]> {
+    return this.#headers.entries();
+  }
+
+  hasHeader(key: string): boolean {
+    return this.#headers.has(key);
+  }
+
+  addHeader(key: string): Header {
+    assert(!this.hasHeader(key), `Header for the key '${key}' already exists`);
+    const result = new Header(this);
+    this.#headers.set(key, result);
+    return result;
+  }
+
+  deleteHeader(key: string): void {
+    const header = this.#headers.get(key);
+    if (header) {
+      header.dispose();
+      this.#headers.delete(key);
+    }
+  }
+
+  clearHeaders(): void {
+    this.#headers.forEach(h => h.dispose());
+    this.#headers.clear();
+  }
+
+  get securitySchemaCount(): number {
+    return this.#securitySchemas.size;
+  }
+
+  securitySchemaKeys(): IterableIterator<string> {
+    return this.#securitySchemas.keys();
+  }
+
+  securitySchemas(): IterableIterator<[string, SecuritySchema]> {
+    return this.#securitySchemas.entries();
+  }
+
+  hasSecuritySchema(key: string): boolean {
+    return this.#securitySchemas.has(key);
+  }
+
+  addSecuritySchema(
+    key: string,
+    type: 'apiKey',
+    name: string,
+    location: APIKeySecuritySchemaLocation,
+  ): APIKeySecuritySchema;
+
+  addSecuritySchema(key: string, type: 'http'): HTTPSecuritySchema;
+  addSecuritySchema(key: string, type: 'mutualTLS'): MutualTLSSecuritySchema;
+  addSecuritySchema(key: string, type: 'oauth2'): OAuth2SecuritySchema;
+  addSecuritySchema(
+    key: string,
+    type: 'openIdConnect',
+    connectUrl: URLString,
+  ): OpenIDConnectSecuritySchema;
+
+  addSecuritySchema(
+    key: string,
+    type: SecuritySchemaType,
+    nameOrConnectUrl?: string,
+    location?: APIKeySecuritySchemaLocation,
+  ): SecuritySchema {
+    assert(!this.hasSecuritySchema(key), `Security schema for key '${key}' already exists`);
+    let result: SecuritySchema;
+    switch (type) {
+      case 'apiKey':
+        assert(nameOrConnectUrl, 'Name of an API Key schema cannot be empty');
+        assert(location, 'Location of an API key schema cannot be empty');
+        result = new APIKeySecuritySchema(this, nameOrConnectUrl, location);
+        break;
+      case 'http':
+        result = new HTTPSecuritySchema(this);
+        break;
+      case 'mutualTLS':
+        result = new MutualTLSSecuritySchema(this);
+        break;
+      case 'oauth2':
+        result = new OAuth2SecuritySchema(this);
+        break;
+      case 'openIdConnect':
+        assert(nameOrConnectUrl, 'Connect URL of an OpenIDConnect schema cannot be empty');
+        result = new OpenIDConnectSecuritySchema(this, nameOrConnectUrl);
+        break;
+      default:
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        assert.fail(`Unsupported security schema type '${type}'`);
+    }
+    this.#securitySchemas.set(key, result);
+    return result;
+  }
+
+  deleteSecuritySchema(key: string): void {
+    const securitySchema = this.#securitySchemas.get(key);
+    if (securitySchema) {
+      securitySchema.dispose();
+      this.#securitySchemas.delete(key);
+    }
+  }
+
+  clearSecuritySchemas(): void {
+    this.#securitySchemas.forEach(s => s.dispose());
+    this.#securitySchemas.clear();
+  }
+
+  get linkCount(): number {
+    return this.#links.size;
+  }
+
+  linkKeys(): IterableIterator<string> {
+    return this.#links.keys();
+  }
+
+  links(): IterableIterator<[string, Link]> {
+    return this.#links.entries();
+  }
+
+  hasLink(key: string): boolean {
+    return this.#links.has(key);
+  }
+
+  addLink(key: string): Link {
+    assert(!this.hasLink(key), `Link for key '${key}' already exists`);
+    const result = new Link(this);
+    this.#links.set(key, result);
+    return result;
+  }
+
+  deleteLink(key: string): void {
+    const result = this.#links.get(key);
+    if (result) {
+      result.dispose();
+      this.#links.delete(key);
+    }
+  }
+
+  clearLinks(): void {
+    this.#links.forEach(l => l.dispose());
+    this.#links.clear();
+  }
+
+  get callbackCount(): number {
+    return this.#callbacks.size;
+  }
+
+  callbackKeys(): IterableIterator<string> {
+    return this.#callbacks.keys();
+  }
+
+  callbacks(): IterableIterator<[string, Callback]> {
+    return this.#callbacks.entries();
+  }
+
+  hasCallback(key: string): boolean {
+    return this.#callbacks.has(key);
+  }
+
+  addCallback(key: string): Callback {
+    assert(!this.hasCallback(key), `Callback for key '${key}' already exists`);
+    const result = new Callback(this);
+    this.#callbacks.set(key, result);
+    return result;
+  }
+
+  deleteCallback(key: string): void {
+    const callback = this.#callbacks.get(key);
+    if (callback) {
+      callback.dispose();
+      this.#callbacks.delete(key);
+    }
+  }
+
+  clearCallbacks(): void {
+    this.#callbacks.forEach(c => c.dispose());
+    this.#callbacks.clear();
+  }
+
+  get pathItemCount(): number {
+    return this.#pathItems.size;
+  }
+
+  pathItemKeys(): IterableIterator<string> {
+    return this.#pathItems.keys();
+  }
+
+  pathItems(): IterableIterator<[string, PathItem]> {
+    return this.#pathItems.entries();
+  }
+
+  hasPathItem(key: string): boolean {
+    return this.#pathItems.has(key);
+  }
+
+  addPathItem(key: string): PathItem {
+    assert(!this.hasPathItem(key), `Path item for key '${key}' already exists`);
+    const result = new PathItem(this);
+    this.#pathItems.set(key, result);
+    return result;
+  }
+
+  deletePathItem(key: string): void {
+    const pathItem = this.#pathItems.get(key);
+    if (pathItem) {
+      pathItem.dispose();
+      this.#pathItems.delete(key);
+    }
+  }
+
+  clearPathItems(): void {
+    this.#pathItems.forEach(p => p.dispose());
+    this.#pathItems.clear();
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/Contact.ts
+++ b/packages/openapi-model/src/3.1.0/model/Contact.ts
@@ -1,0 +1,30 @@
+import { Info } from './Info';
+import { Node } from './Node';
+
+import type { ContactModel } from './types';
+import type { Nullable } from '@fresha/api-tools-core';
+
+export class Contact extends Node<Info> implements ContactModel {
+  #name: Nullable<string>;
+  #url: Nullable<string>;
+  #email: Nullable<string>;
+
+  constructor(parent: Info) {
+    super(parent);
+    this.#name = null;
+    this.#url = null;
+    this.#email = null;
+  }
+
+  get name(): Nullable<string> {
+    return this.#name;
+  }
+
+  get url(): Nullable<string> {
+    return this.#url;
+  }
+
+  get email(): Nullable<string> {
+    return this.#email;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/Discriminator.ts
+++ b/packages/openapi-model/src/3.1.0/model/Discriminator.ts
@@ -1,0 +1,45 @@
+import { Node } from './Node';
+
+import type { Schema } from './Schema';
+import type { DiscriminatorModel } from './types';
+
+export type DiscriminatorParent = Schema;
+
+export class Discriminator extends Node<DiscriminatorParent> implements DiscriminatorModel {
+  #propertyName: string;
+  readonly #mappings: Map<string, string>;
+
+  constructor(parent: DiscriminatorParent, propertyName: string) {
+    super(parent);
+    this.#propertyName = propertyName;
+    this.#mappings = new Map<string, string>();
+  }
+
+  get propertyName(): string {
+    return this.#propertyName;
+  }
+
+  get mappingCount(): number {
+    return this.#mappings.size;
+  }
+
+  mapping(): IterableIterator<[string, string]> {
+    return this.#mappings.entries();
+  }
+
+  hasMapping(key: string): boolean {
+    return this.#mappings.has(key);
+  }
+
+  addMapping(key: string, value: string): void {
+    this.#mappings.set(key, value);
+  }
+
+  deleteMapping(key: string): void {
+    this.#mappings.delete(key);
+  }
+
+  clearMappings(): void {
+    this.#mappings.clear();
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/Encoding.ts
+++ b/packages/openapi-model/src/3.1.0/model/Encoding.ts
@@ -1,0 +1,97 @@
+import assert from 'assert';
+
+import { Header } from './Header';
+import { Node } from './Node';
+
+import type { MediaType } from './MediaType';
+import type { EncodingModel, EncodingSerializationStyle } from './types';
+import type { Nullable } from '@fresha/api-tools-core';
+
+type EncodingParent = MediaType;
+
+export class Encoding extends Node<EncodingParent> implements EncodingModel {
+  #contentType: Nullable<string>;
+  #headers: Map<string, Header>;
+  #style: EncodingSerializationStyle;
+  #explode: boolean;
+  #allowReserved: boolean;
+
+  constructor(parent: EncodingParent) {
+    super(parent);
+    this.#contentType = null;
+    this.#headers = new Map<string, Header>();
+    this.#style = 'form';
+    this.#explode = true;
+    this.#allowReserved = false;
+  }
+
+  get contentType(): Nullable<string> {
+    return this.#contentType;
+  }
+
+  set contentType(value: Nullable<string>) {
+    this.#contentType = value;
+  }
+
+  get headerCount(): number {
+    return this.#headers.size;
+  }
+
+  headerNames(): IterableIterator<string> {
+    return this.#headers.keys();
+  }
+
+  headers(): IterableIterator<[string, Header]> {
+    return this.#headers.entries();
+  }
+
+  hasHeader(name: string): boolean {
+    return this.#headers.has(name);
+  }
+
+  addHeader(name: string): Header {
+    assert(!this.hasHeader(name), `Header '${name}' already exists`);
+    const result = new Header(this);
+    this.#headers.set(name, result);
+    return result;
+  }
+
+  deleteHeader(name: string): void {
+    const header = this.#headers.get(name);
+    if (header) {
+      if (header.parent === this) {
+        header.dispose();
+      }
+      this.#headers.delete(name);
+    }
+  }
+
+  clearHeaders(): void {
+    this.#headers.forEach(h => h.dispose());
+    this.#headers.clear();
+  }
+
+  get style(): EncodingSerializationStyle {
+    return this.#style;
+  }
+
+  set style(value: EncodingSerializationStyle) {
+    this.#style = value;
+  }
+
+  get explode(): boolean {
+    return this.#explode;
+  }
+
+  set explode(value: boolean) {
+    this.#explode = value;
+  }
+
+  get allowReserved(): boolean {
+    return this.#allowReserved;
+  }
+
+  set allowReserved(value: boolean) {
+    this.#allowReserved = value;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/Example.ts
+++ b/packages/openapi-model/src/3.1.0/model/Example.ts
@@ -1,0 +1,57 @@
+import { Node } from './Node';
+
+import type { Components } from './Components';
+import type { Header } from './Header';
+import type { MediaType } from './MediaType';
+import type { ParameterBase } from './Parameter';
+import type { ExampleModel } from './types';
+import type { Nullable, JSONValue, CommonMarkString, URLString } from '@fresha/api-tools-core';
+
+type ExampleParent = Components | ParameterBase | Header | MediaType;
+
+export class Example extends Node<ExampleParent> implements ExampleModel {
+  #summary: Nullable<string>;
+  #description: Nullable<CommonMarkString>;
+  #value: JSONValue;
+  #externalValue: Nullable<URLString>;
+
+  constructor(parent: ExampleParent) {
+    super(parent);
+    this.#summary = null;
+    this.#description = null;
+    this.#value = null;
+    this.#externalValue = null;
+  }
+
+  get summary(): Nullable<string> {
+    return this.#summary;
+  }
+
+  set summary(value: Nullable<string>) {
+    this.#summary = value;
+  }
+
+  get description(): Nullable<CommonMarkString> {
+    return this.#description;
+  }
+
+  set description(value: Nullable<CommonMarkString>) {
+    this.#description = value;
+  }
+
+  get value(): JSONValue {
+    return this.#value;
+  }
+
+  set value(value: JSONValue) {
+    this.#value = value;
+  }
+
+  get externalValue(): Nullable<URLString> {
+    return this.#externalValue;
+  }
+
+  set externalValue(value: Nullable<URLString>) {
+    this.#externalValue = value;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/ExternalDocumentation.ts
+++ b/packages/openapi-model/src/3.1.0/model/ExternalDocumentation.ts
@@ -1,0 +1,43 @@
+import assert from 'assert';
+
+import { Node } from './Node';
+
+import type { OpenAPI } from './OpenAPI';
+import type { Operation } from './Operation';
+import type { Schema } from './Schema';
+import type { Tag } from './Tag';
+import type { ExternalDocumentationModel } from './types';
+import type { CommonMarkString, Nullable, URLString } from '@fresha/api-tools-core';
+
+type ExternalDocumentationParent = OpenAPI | Operation | Tag | Schema;
+
+export class ExternalDocumentation
+  extends Node<ExternalDocumentationParent>
+  implements ExternalDocumentationModel
+{
+  #url: URLString;
+  #description: Nullable<CommonMarkString>;
+
+  constructor(parent: ExternalDocumentationParent, url: string) {
+    super(parent);
+    this.#url = url;
+    this.#description = null;
+  }
+
+  get url(): URLString {
+    return this.#url;
+  }
+
+  set url(value: URLString) {
+    assert(!!value, `URL must not be an empty string`);
+    this.#url = value;
+  }
+
+  get description(): Nullable<CommonMarkString> {
+    return this.#description;
+  }
+
+  set description(value: Nullable<CommonMarkString>) {
+    this.#description = value;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/Header.ts
+++ b/packages/openapi-model/src/3.1.0/model/Header.ts
@@ -1,0 +1,168 @@
+import assert from 'assert';
+
+import { HeaderParameterSerializationStyle } from '../../baseTypes';
+
+import { Example } from './Example';
+import { MediaType } from './MediaType';
+import { Node } from './Node';
+import { Schema } from './Schema';
+
+import type { Components } from './Components';
+import type { Encoding } from './Encoding';
+import type { Response } from './Response';
+import type { HeaderModel } from './types';
+import type { CommonMarkString, MIMETypeString, Nullable } from '@fresha/api-tools-core';
+
+type HeaderParent = Components | Response | Encoding;
+
+export class Header extends Node<HeaderParent> implements HeaderModel {
+  #description: Nullable<CommonMarkString>;
+  #required: boolean;
+  #deprecated: boolean;
+  #style: HeaderParameterSerializationStyle;
+  #explode: boolean;
+  #schema: Nullable<Schema>;
+  readonly #examples: Map<string, Example>;
+  readonly #content: Map<MIMETypeString, MediaType>;
+
+  constructor(parent: HeaderParent) {
+    super(parent);
+    this.#description = null;
+    this.#required = false;
+    this.#deprecated = false;
+    this.#style = 'simple';
+    this.#explode = false;
+    this.#schema = null;
+    this.#examples = new Map<string, Example>();
+    this.#content = new Map<MIMETypeString, MediaType>();
+  }
+
+  get description(): Nullable<CommonMarkString> {
+    return this.#description;
+  }
+
+  set description(value: Nullable<CommonMarkString>) {
+    this.#description = value;
+  }
+
+  get required(): boolean {
+    return this.#required;
+  }
+
+  set required(value: boolean) {
+    this.#required = value;
+  }
+
+  get deprecated(): boolean {
+    return this.#deprecated;
+  }
+
+  set deprecated(value: boolean) {
+    this.#deprecated = value;
+  }
+
+  get style(): HeaderParameterSerializationStyle {
+    return this.#style;
+  }
+
+  set style(value: HeaderParameterSerializationStyle) {
+    this.#style = value;
+  }
+
+  get explode(): boolean {
+    return this.#explode;
+  }
+
+  set explode(value: boolean) {
+    this.#explode = value;
+  }
+
+  get schema(): Nullable<Schema> {
+    return this.#schema;
+  }
+
+  addSchema(): Schema {
+    assert(!this.#schema, 'Schema is already set');
+    this.#schema = new Schema(this);
+    return this.#schema;
+  }
+
+  deleteSchema(): void {
+    if (this.#schema) {
+      this.#schema.dispose();
+      this.#schema = null;
+    }
+  }
+
+  get exampleCount(): number {
+    return this.#examples.size;
+  }
+
+  exampleKeys(): IterableIterator<string> {
+    return this.#examples.keys();
+  }
+
+  examples(): IterableIterator<[string, Example]> {
+    return this.#examples.entries();
+  }
+
+  hasExample(key: string): boolean {
+    return this.#examples.has(key);
+  }
+
+  addExample(key: string): Example {
+    assert(!this.hasExample(key), `Example for key '${key}' already exists`);
+    const result = new Example(this);
+    this.#examples.set(key, result);
+    return result;
+  }
+
+  deleteExample(key: string): void {
+    const example = this.#examples.get(key);
+    if (example) {
+      example.dispose();
+      this.#examples.delete(key);
+    }
+  }
+
+  clearExamples(): void {
+    this.#examples.forEach(ex => ex.dispose());
+    this.#examples.clear();
+  }
+
+  get mediaTypeCount(): number {
+    return this.#content.size;
+  }
+
+  mediaTypeKeys(): IterableIterator<MIMETypeString> {
+    return this.#content.keys();
+  }
+
+  mediaTypes(): IterableIterator<[MIMETypeString, MediaType]> {
+    return this.#content.entries();
+  }
+
+  hasMediaType(mediaType: MIMETypeString): boolean {
+    return this.#content.has(mediaType);
+  }
+
+  addMediaType(mediaType: MIMETypeString): MediaType {
+    assert(!this.hasMediaType(mediaType), `Content for '${mediaType}' already set`);
+    const result = new MediaType(this);
+    this.#content.set(mediaType, result);
+    return result;
+  }
+
+  deleteMediaType(mediaType: MIMETypeString): void {
+    const item = this.#content.get(mediaType);
+    if (item) {
+      item.dispose();
+      this.#content.delete(mediaType);
+    }
+  }
+
+  clearMediaTypes(): void {
+    this.#content.forEach(item => item.dispose());
+    this.#content.clear();
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/Info.ts
+++ b/packages/openapi-model/src/3.1.0/model/Info.ts
@@ -1,0 +1,50 @@
+import { Contact } from './Contact';
+import { License } from './License';
+import { Node } from './Node';
+import { OpenAPI } from './OpenAPI';
+
+import type { InfoModel } from './types';
+import type { Nullable } from '@fresha/api-tools-core';
+
+export class Info extends Node<OpenAPI> implements InfoModel {
+  #title: string;
+  #description: Nullable<string>;
+  #termsOfService: Nullable<string>;
+  readonly #contact: Contact;
+  readonly #license: License;
+  #version: string;
+
+  constructor(parent: OpenAPI, title: string, version: string) {
+    super(parent);
+    this.#title = title;
+    this.#description = null;
+    this.#termsOfService = null;
+    this.#contact = new Contact(this);
+    this.#license = new License(this);
+    this.#version = version;
+  }
+
+  get title(): string {
+    return this.#title;
+  }
+
+  get description(): Nullable<string> {
+    return this.#description;
+  }
+
+  get termsOfService(): Nullable<string> {
+    return this.#termsOfService;
+  }
+
+  get contact(): Contact {
+    return this.#contact;
+  }
+
+  get license(): License {
+    return this.#license;
+  }
+
+  get version(): string {
+    return this.#version;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/License.ts
+++ b/packages/openapi-model/src/3.1.0/model/License.ts
@@ -1,0 +1,24 @@
+import { Info } from './Info';
+import { Node } from './Node';
+
+import type { LicenseModel } from './types';
+import type { Nullable } from '@fresha/api-tools-core';
+
+export class License extends Node<Info> implements LicenseModel {
+  #name: string;
+  #url: Nullable<string>;
+
+  constructor(parent: Info) {
+    super(parent);
+    this.#name = '';
+    this.#url = null;
+  }
+
+  get name(): string {
+    return this.#name;
+  }
+
+  get url(): Nullable<string> {
+    return this.#url;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/Link.ts
+++ b/packages/openapi-model/src/3.1.0/model/Link.ts
@@ -1,0 +1,96 @@
+import assert from 'assert';
+
+import { CommonMarkString, JSONValue, Nullable } from '@fresha/api-tools-core';
+
+import { Node } from './Node';
+import { Operation } from './Operation';
+import { Server } from './Server';
+
+import type { Components } from './Components';
+import type { Response } from './Response';
+import type { LinkModel } from './types';
+
+type LinkParent = Components | Response;
+
+export class Link extends Node<LinkParent> implements LinkModel {
+  #operation: Nullable<Operation>;
+  readonly #parameters: Map<string, JSONValue>;
+  #requestBody: JSONValue;
+  #description: Nullable<CommonMarkString>;
+  #server: Nullable<Server>;
+
+  constructor(parent: LinkParent) {
+    super(parent);
+    this.#operation = null;
+    this.#parameters = new Map<string, JSONValue>();
+    this.#requestBody = null;
+    this.#description = null;
+    this.#server = null;
+  }
+
+  get operation(): Nullable<Operation> {
+    return this.#operation;
+  }
+
+  set operation(value: Nullable<Operation>) {
+    this.#operation = value;
+  }
+
+  get parameterCount(): number {
+    return this.#parameters.size;
+  }
+
+  parameterNames(): IterableIterator<string> {
+    return this.#parameters.keys();
+  }
+
+  parameters(): IterableIterator<[string, JSONValue]> {
+    return this.#parameters.entries();
+  }
+
+  hasParameter(name: string): boolean {
+    return this.#parameters.has(name);
+  }
+
+  getParameterValue(name: string): JSONValue {
+    const result = this.#parameters.get(name);
+    assert(result !== undefined, `Missing value for parameter '${name}'`);
+    return result;
+  }
+
+  setParameterValue(name: string, value: JSONValue): void {
+    this.#parameters.set(name, value);
+  }
+
+  deleteParameter(name: string): void {
+    this.#parameters.delete(name);
+  }
+
+  clearParameter(): void {
+    this.#parameters.clear();
+  }
+
+  get requestBody(): JSONValue {
+    return this.#requestBody;
+  }
+
+  set requestBody(value: JSONValue) {
+    this.#requestBody = value;
+  }
+
+  get description(): Nullable<CommonMarkString> {
+    return this.#description;
+  }
+
+  set description(value: Nullable<CommonMarkString>) {
+    this.#description = value;
+  }
+
+  get server(): Nullable<Server> {
+    return this.#server;
+  }
+
+  set server(value: Nullable<Server>) {
+    this.#server = value;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/MediaType.ts
+++ b/packages/openapi-model/src/3.1.0/model/MediaType.ts
@@ -1,0 +1,119 @@
+import { assert } from 'console';
+
+import { Encoding } from './Encoding';
+import { Example } from './Example';
+import { Node } from './Node';
+import { Schema } from './Schema';
+
+import type { Header } from './Header';
+import type { ParameterBase } from './Parameter';
+import type { RequestBody } from './RequestBody';
+import type { Response } from './Response';
+import type { MediaTypeModel } from './types';
+import type { Nullable } from '@fresha/api-tools-core';
+
+type MediaTypeParent = ParameterBase | RequestBody | Response | Header;
+
+export class MediaType extends Node<MediaTypeParent> implements MediaTypeModel {
+  #schema: Nullable<Schema>;
+  #examples: Map<string, Example>;
+  #encodings: Map<string, Encoding>;
+
+  constructor(parent: MediaTypeParent) {
+    super(parent);
+    this.#schema = null;
+    this.#examples = new Map<string, Example>();
+    this.#encodings = new Map<string, Encoding>();
+  }
+
+  get schema(): Nullable<Schema> {
+    return this.#schema;
+  }
+
+  addSchema(): Schema {
+    assert(!this.#schema, `Schema already exists`);
+    this.#schema = new Schema(this);
+    return this.#schema;
+  }
+
+  deleteSchema(): void {
+    if (this.#schema) {
+      if (this.#schema.parent === this) {
+        this.#schema.dispose();
+      }
+      this.#schema = null;
+    }
+  }
+
+  get exampleCount(): number {
+    return this.#examples.size;
+  }
+
+  exampleKeys(): IterableIterator<string> {
+    return this.#examples.keys();
+  }
+
+  examples(): IterableIterator<[string, Example]> {
+    return this.#examples.entries();
+  }
+
+  hasExample(key: string): boolean {
+    return this.#examples.has(key);
+  }
+
+  addExample(key: string): Example {
+    assert(!this.hasExample(key), `Example for key '${key}' already exists`);
+    const result = new Example(this);
+    this.#examples.set(key, result);
+    return result;
+  }
+
+  deleteExample(key: string): void {
+    const example = this.#examples.get(key);
+    if (example) {
+      example.dispose();
+      this.#examples.delete(key);
+    }
+  }
+
+  clearExamples(): void {
+    this.#examples.forEach(e => e.dispose());
+    this.#examples.clear();
+  }
+
+  get encodingCount(): number {
+    return this.#encodings.size;
+  }
+
+  encodingKeys(): IterableIterator<string> {
+    return this.#encodings.keys();
+  }
+
+  encodings(): IterableIterator<[string, Encoding]> {
+    return this.#encodings.entries();
+  }
+
+  hasEncoding(key: string): boolean {
+    return this.#encodings.has(key);
+  }
+
+  addEncoding(key: string): Encoding {
+    assert(!this.hasEncoding(key), `Encoding '${key}' already exists`);
+    const result = new Encoding(this);
+    this.#encodings.set(key, result);
+    return result;
+  }
+
+  deleteEncoding(key: string): void {
+    const encoding = this.#encodings.get(key);
+    if (encoding) {
+      encoding.dispose();
+      this.#encodings.delete(key);
+    }
+  }
+
+  clearEncodings(): void {
+    this.#encodings.forEach(e => e.dispose());
+    this.#encodings.clear();
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/Node.ts
+++ b/packages/openapi-model/src/3.1.0/model/Node.ts
@@ -1,0 +1,55 @@
+import assert from 'assert';
+
+import type { SpecificationExtensionsModel } from './types';
+import type { Disposable, JSONValue } from '@fresha/api-tools-core';
+
+export class Node<TParent> implements Disposable, SpecificationExtensionsModel {
+  #parent: TParent;
+  readonly #extensions: Map<string, JSONValue>;
+
+  constructor(parent: TParent) {
+    this.#parent = parent;
+    this.#extensions = new Map<string, JSONValue>();
+  }
+
+  get parent(): TParent {
+    return this.#parent;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  dispose(): void {}
+
+  get extensionCount(): number {
+    return this.#extensions.size;
+  }
+
+  extensions(): IterableIterator<[string, JSONValue]> {
+    return this.#extensions.entries();
+  }
+
+  extensionKeys(): IterableIterator<string> {
+    return this.#extensions.keys();
+  }
+
+  hasExtension(key: string): boolean {
+    return this.#extensions.has(key);
+  }
+
+  getExtension(key: string): JSONValue {
+    const result = this.#extensions.get(key);
+    assert(result !== undefined, `Expected to have extension key ${key}`);
+    return result;
+  }
+
+  setExtension(key: string, value: JSONValue): void {
+    this.#extensions.set(key, value);
+  }
+
+  deleteExtension(key: string): void {
+    this.#extensions.delete(key);
+  }
+
+  clearExtensions(): void {
+    this.#extensions.clear();
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/OpenAPI.ts
+++ b/packages/openapi-model/src/3.1.0/model/OpenAPI.ts
@@ -1,0 +1,227 @@
+import assert from 'assert';
+
+import { Nullable } from '@fresha/api-tools-core';
+
+import { Components } from './Components';
+import { ExternalDocumentation } from './ExternalDocumentation';
+import { Info } from './Info';
+import { Node } from './Node';
+import { PathItem } from './PathItem';
+import { Paths } from './Paths';
+import { SecurityRequirement } from './SecurityRequirement';
+import { Server } from './Server';
+import { Tag } from './Tag';
+
+import type { OpenAPIModel, OpenAPIModelFactory, OpenAPIVersion } from './types';
+
+export class OpenAPI extends Node<null> implements OpenAPIModel {
+  static create(): OpenAPI;
+  static create(title: string, version: string): OpenAPI;
+  static create(title?: string, version?: string): OpenAPI {
+    return new OpenAPI(title ?? 'New OpenAPI 3.1', version ?? '0.1.0');
+  }
+
+  readonly #info: Info;
+  #jsonSchemaDialect: string;
+  readonly #servers: Server[];
+  readonly #paths: Paths;
+  readonly #webhooks: Map<string, PathItem>;
+  readonly #components: Components;
+  readonly #securityRequirements: SecurityRequirement[];
+  readonly #tags: Tag[];
+  #externalDocs: Nullable<ExternalDocumentation>;
+
+  constructor(title: string, version: string) {
+    super(null);
+    this.#info = new Info(this, title, version);
+    this.#jsonSchemaDialect = '';
+    this.#servers = [];
+    this.#paths = new Paths(this);
+    this.#webhooks = new Map<string, PathItem>();
+    this.#components = new Components(this);
+    this.#securityRequirements = [];
+    this.#tags = [];
+    this.#externalDocs = null;
+  }
+
+  get root(): OpenAPI {
+    return this;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  get openapi(): OpenAPIVersion {
+    return '3.1.0';
+  }
+
+  get info(): Info {
+    return this.#info;
+  }
+
+  get jsonSchemaDialect(): string {
+    return this.#jsonSchemaDialect;
+  }
+
+  get serverCount(): number {
+    return this.#servers.length;
+  }
+
+  servers(): IterableIterator<Server> {
+    return this.#servers.values();
+  }
+
+  serverAt(index: number): Server {
+    return this.#servers[index];
+  }
+
+  addServer(url: string): Server {
+    const server = new Server(this, url);
+    this.#servers.push(server);
+    return server;
+  }
+
+  removeServerAt(index: number): void {
+    this.#servers[index].dispose();
+    this.#servers.splice(index, 1);
+  }
+
+  clearServers(): void {
+    this.#servers.forEach(s => s.dispose());
+    this.#servers.splice(0, this.#servers.length);
+  }
+
+  get paths(): Paths {
+    return this.#paths;
+  }
+
+  get webhookCount(): number {
+    return this.#webhooks.size;
+  }
+
+  webhookKeys(): IterableIterator<string> {
+    return this.#webhooks.keys();
+  }
+
+  webhooks(): IterableIterator<[string, PathItem]> {
+    return this.#webhooks.entries();
+  }
+
+  hasWebhook(key: string): boolean {
+    return this.#webhooks.has(key);
+  }
+
+  getWebhook(key: string): PathItem {
+    const result = this.#webhooks.get(key);
+    assert(result, `Missing webhook '${key}'`);
+    return result;
+  }
+
+  addWebhook(key: string): PathItem {
+    assert(!this.#webhooks.has(key), `Webhook named '${key}' already exists`);
+    const result = new PathItem(this);
+    this.#webhooks.set(key, result);
+    return result;
+  }
+
+  removeWebhook(key: string): void {
+    const webhook = this.#webhooks.get(key);
+    if (webhook) {
+      webhook.dispose();
+      this.#webhooks.delete(key);
+    }
+  }
+
+  clearWebhooks(): void {
+    this.#webhooks.forEach(w => w.dispose());
+    this.#webhooks.clear();
+  }
+
+  get components(): Components {
+    return this.#components;
+  }
+
+  get securityRequirementCount(): number {
+    return this.#securityRequirements.length;
+  }
+
+  securityRequirements(): IterableIterator<SecurityRequirement> {
+    return this.#securityRequirements.values();
+  }
+
+  securityRequirementAt(index: number): SecurityRequirement {
+    return this.#securityRequirements[index];
+  }
+
+  addSecurityRequirement(): SecurityRequirement {
+    const result = new SecurityRequirement(this);
+    this.#securityRequirements.push(result);
+    return result;
+  }
+
+  deleteSecurityRequirementAt(index: number): void {
+    const securityRequirement = this.#securityRequirements[index];
+    if (securityRequirement) {
+      securityRequirement.dispose();
+      this.#securityRequirements.splice(index, 1);
+    }
+  }
+
+  clearSecurityRequirements(): void {
+    this.#securityRequirements.forEach(s => s.dispose());
+    this.#securityRequirements.splice(0, this.#securityRequirements.length);
+  }
+
+  get tagCount(): number {
+    return this.#tags.length;
+  }
+
+  tags(): IterableIterator<Tag> {
+    return this.#tags.values();
+  }
+
+  tagAt(index: number): Tag {
+    return this.#tags[index];
+  }
+
+  hasTag(name: string): boolean {
+    return this.#tags.some(t => t.name === name);
+  }
+
+  addTag(name: string): Tag {
+    assert(!this.hasTag(name), `Tag named '${name}' already exists`);
+    const result = new Tag(this, name);
+    this.#tags.push(result);
+    return result;
+  }
+
+  deleteTagAt(index: number): void {
+    const tag = this.#tags[index];
+    if (tag) {
+      tag.dispose();
+      this.#tags.splice(index, 1);
+    }
+  }
+
+  clearTags(): void {
+    this.#tags.forEach(t => t.dispose());
+    this.#tags.splice(0, this.#tags.length);
+  }
+
+  get externalDocs(): Nullable<ExternalDocumentation> {
+    return this.#externalDocs;
+  }
+
+  addExternalDocs(url: string): ExternalDocumentation {
+    assert(!this.#externalDocs, 'External documentation is already set');
+    this.#externalDocs = new ExternalDocumentation(this, url);
+    return this.#externalDocs;
+  }
+
+  deleteExternalDocs(): void {
+    if (this.#externalDocs) {
+      this.#externalDocs.dispose();
+      this.#externalDocs = null;
+    }
+  }
+}
+
+export const OpenAPIFactory: OpenAPIModelFactory = OpenAPI;

--- a/packages/openapi-model/src/3.1.0/model/OpenAPIReader.ts
+++ b/packages/openapi-model/src/3.1.0/model/OpenAPIReader.ts
@@ -1,0 +1,9 @@
+import { OpenAPI } from './OpenAPI';
+
+export class OpenAPIReader {
+  // eslint-disable-next-line class-methods-use-this
+  parse(): OpenAPI {
+    const result = new OpenAPI('la', 'la');
+    return result;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/OpenAPIWriter.ts
+++ b/packages/openapi-model/src/3.1.0/model/OpenAPIWriter.ts
@@ -1,0 +1,66 @@
+import fs from 'fs';
+
+import { JSONValue, Nullable } from '@fresha/api-tools-core';
+import yaml from 'yaml';
+
+import type { ContactModel, InfoModel, LicenseModel, OpenAPIModel } from './types';
+import type { ContactObject, InfoObject, LicenseObject, OpenAPIObject } from '../types';
+
+export class OpenAPIWriter {
+  writeToFile(model: OpenAPIModel, path: string): void {
+    const data = this.write(model);
+    const text = yaml.stringify(data);
+    fs.writeFileSync(path, text, 'utf-8');
+  }
+
+  write(model: OpenAPIModel): JSONValue {
+    const result: OpenAPIObject = {
+      openapi: '3.1.0',
+      info: this.writeInfo(model.info),
+    };
+    return result;
+  }
+
+  writeInfo(model: InfoModel): InfoObject {
+    const result: InfoObject = {
+      title: model.title,
+      version: model.version,
+    };
+    const contact = this.writeContact(model.contact);
+    if (contact) {
+      result.contact = contact;
+    }
+    const license = this.writeLicense(model.license);
+    if (license) {
+      result.license = license;
+    }
+    return result;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  writeContact(model: ContactModel): Nullable<ContactObject> {
+    let result: Nullable<ContactObject> = null;
+    if (model.name || model.url || model.email) {
+      result = {};
+      if (model.name) {
+        result.name = model.name;
+      }
+      if (model.url) {
+        result.url = model.url;
+      }
+      if (model.email) {
+        result.email = model.email;
+      }
+    }
+    return result;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  writeLicense(model: LicenseModel): Nullable<LicenseObject> {
+    const result: Nullable<LicenseObject> = { name: model.name };
+    if (model.url) {
+      result.url = model.url;
+    }
+    return result;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/Operation.ts
+++ b/packages/openapi-model/src/3.1.0/model/Operation.ts
@@ -1,0 +1,362 @@
+import assert from 'assert';
+
+import { Callback } from './Callback';
+import { ExternalDocumentation } from './ExternalDocumentation';
+import { Node } from './Node';
+import {
+  CookieParameter,
+  HeaderParameter,
+  Parameter,
+  PathParameter,
+  QueryParameter,
+} from './Parameter';
+import { PathItem } from './PathItem';
+import { RequestBody } from './RequestBody';
+import { Responses } from './Responses';
+import { SecurityRequirement } from './SecurityRequirement';
+import { Server } from './Server';
+import { Tag } from './Tag';
+
+import type { OperationModel, ParameterLocation } from './types';
+import type { CommonMarkString, Nullable, URLString } from '@fresha/api-tools-core';
+
+type OperationParent = PathItem;
+
+export class Operation extends Node<OperationParent> implements OperationModel {
+  readonly #tags: Tag[];
+  #summary: Nullable<string>;
+  #description: Nullable<CommonMarkString>;
+  #externalDocs: Nullable<ExternalDocumentation>;
+  #operationId: Nullable<string>;
+  readonly #parameters: Parameter[];
+  #requestBody: Nullable<RequestBody>;
+  readonly #responses: Responses;
+  readonly #callbacks: Map<string, Callback>;
+  #deprecated: boolean;
+  readonly #securityRequirements: SecurityRequirement[];
+  readonly #servers: Server[];
+
+  constructor(parent: OperationParent) {
+    super(parent);
+    this.#tags = [];
+    this.#summary = null;
+    this.#description = null;
+    this.#externalDocs = null;
+    this.#operationId = null;
+    this.#parameters = [];
+    this.#requestBody = null;
+    this.#responses = new Responses(this);
+    this.#callbacks = new Map<string, Callback>();
+    this.#deprecated = false;
+    this.#securityRequirements = [];
+    this.#servers = [];
+  }
+
+  get tagCount(): number {
+    return this.#tags.length;
+  }
+
+  *tagNames(): IterableIterator<string> {
+    for (const tag of this.#tags) {
+      yield tag.name;
+    }
+  }
+
+  tags(): IterableIterator<Tag> {
+    return this.#tags.values();
+  }
+
+  tagAt(index: number): Tag {
+    return this.#tags[index];
+  }
+
+  removeTagAt(index: number): void {
+    this.#tags.splice(index, 1);
+  }
+
+  hasTag(name: string): boolean {
+    return this.#tags.some(t => t.name === name);
+  }
+
+  addTag(name: string): void {
+    assert(!this.hasTag(name), `Duplicate tag '${name}'`);
+  }
+
+  removeTag(name: string): void {
+    const index = this.#tags.findIndex(t => t.name === name);
+    if (index >= 0) {
+      this.#tags.splice(index, 1);
+    }
+  }
+
+  clearTags(): void {
+    this.#tags.splice(0, this.#tags.length);
+  }
+
+  get summary(): Nullable<string> {
+    return this.#summary;
+  }
+
+  set summary(value: Nullable<string>) {
+    this.#summary = value;
+  }
+
+  get description(): Nullable<CommonMarkString> {
+    return this.#description;
+  }
+
+  set description(value: Nullable<CommonMarkString>) {
+    this.#description = value;
+  }
+
+  get externalDocs(): Nullable<ExternalDocumentation> {
+    return this.#externalDocs;
+  }
+
+  addExternalDocs(url: URLString): ExternalDocumentation {
+    assert(!this.#externalDocs, 'External documentation already set');
+    this.#externalDocs = new ExternalDocumentation(this, url);
+    return this.#externalDocs;
+  }
+
+  deleteExternalDocs(): void {
+    if (this.#externalDocs) {
+      this.#externalDocs.dispose();
+      this.#externalDocs = null;
+    }
+  }
+
+  get operationId(): Nullable<string> {
+    return this.#operationId;
+  }
+
+  set operationId(value: Nullable<string>) {
+    if (this.#operationId !== value) {
+      this.#operationId = value;
+    }
+  }
+
+  get parameterCount(): number {
+    return this.#parameters.length;
+  }
+
+  parameters(): IterableIterator<Parameter> {
+    return this.#parameters.values();
+  }
+
+  parameterAt(index: number): Parameter {
+    return this.#parameters[index];
+  }
+
+  removeParameterAt(index: number): void {
+    const parameter = this.#parameters[index];
+    if (parameter) {
+      this.dispose();
+      this.#parameters.splice(index, 1);
+    }
+  }
+
+  hasParameter(name: string, location?: ParameterLocation): boolean {
+    return location
+      ? this.#parameters.some(p => p.name === name && p.in === location)
+      : this.#parameters.some(p => p.name === name);
+  }
+
+  getParameter(name: string, location?: ParameterLocation): Parameter {
+    let result: Parameter | undefined;
+    if (location) {
+      result = this.#parameters.find(p => p.in === location && p.name === name);
+      assert(result, `Expected to find parameter '${name}' of type '${location}'`);
+    } else {
+      result = this.#parameters.find(p => p.name === name);
+      assert(result, `Expected to find parameter '${name}'`);
+    }
+    return result;
+  }
+
+  addParameter(name: string, location: 'path'): PathParameter;
+  addParameter(name: string, location: 'query'): QueryParameter;
+  addParameter(name: string, location: 'header'): HeaderParameter;
+  addParameter(name: string, location: 'cookie'): CookieParameter;
+  addParameter(name: string, location: ParameterLocation): Parameter {
+    assert(
+      !this.hasParameter(name, location),
+      `Duplicate paramter '${name}' and type '${location}'`,
+    );
+    let result: Parameter;
+    switch (location) {
+      case 'path':
+        result = new PathParameter(this, name);
+        break;
+      case 'query':
+        result = new QueryParameter(this, name);
+        break;
+      case 'header':
+        result = new HeaderParameter(this, name);
+        break;
+      case 'cookie':
+        result = new CookieParameter(this, name);
+        break;
+      default:
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        assert.fail(`Invalid parameter location '${location}'`);
+    }
+    this.#parameters.push(result);
+    return result;
+  }
+
+  removeParameter(name: string, location?: ParameterLocation): void {
+    for (let i = this.#parameters.length - 1; i >= 0; i -= 1) {
+      const parameter = this.#parameters[i];
+      if (parameter.name === name && (!location || parameter.in === location)) {
+        parameter.dispose();
+        this.#parameters.splice(i, 1);
+      }
+    }
+  }
+
+  clearParameters(): void {
+    this.#parameters.forEach(p => p.dispose());
+    this.#parameters.splice(0, this.#parameters.length);
+  }
+
+  get requestBody(): Nullable<RequestBody> {
+    return this.#requestBody;
+  }
+
+  addRequestBody(): RequestBody {
+    assert(!this.#requestBody, 'Request body is already set');
+    this.#requestBody = new RequestBody(this);
+    return this.#requestBody;
+  }
+
+  deleteRequestBody(): void {
+    if (this.#requestBody) {
+      this.#requestBody.dispose();
+      this.#requestBody = null;
+    }
+  }
+
+  get responses(): Responses {
+    return this.#responses;
+  }
+
+  get callbackCount(): number {
+    return this.#callbacks.size;
+  }
+
+  callbackKeys(): IterableIterator<string> {
+    return this.#callbacks.keys();
+  }
+
+  callbacks(): IterableIterator<[string, Callback]> {
+    return this.#callbacks.entries();
+  }
+
+  hasCallback(key: string): boolean {
+    return this.#callbacks.has(key);
+  }
+
+  getCallback(key: string): Callback {
+    const result = this.#callbacks.get(key);
+    assert(result, `Missing callback for key '${key}'`);
+    return result;
+  }
+
+  addCallback(key: string): Callback {
+    assert(!this.hasCallback(key), `Callback for key '${key}' already exists`);
+    const result = new Callback(this);
+    this.#callbacks.set(key, result);
+    return result;
+  }
+
+  deleteCallback(key: string): void {
+    const callback = this.#callbacks.get(key);
+    if (callback) {
+      callback.dispose();
+      this.#callbacks.delete(key);
+    }
+  }
+
+  clearCallbacks(): void {
+    this.#callbacks.forEach(c => c.dispose());
+    this.#callbacks.clear();
+  }
+
+  get deprecated(): boolean {
+    return this.#deprecated;
+  }
+
+  set deprecated(value: boolean) {
+    if (this.#deprecated !== value) {
+      this.#deprecated = value;
+    }
+  }
+
+  get securityRequirementCount(): number {
+    return this.#securityRequirements.length;
+  }
+
+  securityRequirements(): IterableIterator<SecurityRequirement> {
+    return this.#securityRequirements.values();
+  }
+
+  securityRequirementAt(index: number): SecurityRequirement {
+    return this.#securityRequirements[index];
+  }
+
+  addSecurityRequirement(): SecurityRequirement {
+    const result = new SecurityRequirement(this);
+    this.#securityRequirements.push(result);
+    return result;
+  }
+
+  deleteSecurityRequirementAt(index: number): void {
+    const securityRequirement = this.#securityRequirements[index];
+    if (securityRequirement) {
+      securityRequirement.dispose();
+      this.#securityRequirements.splice(index, 1);
+    }
+  }
+
+  clearSecurityRequirements(): void {
+    this.#securityRequirements.forEach(sr => sr.dispose());
+    this.#securityRequirements.splice(0, this.#securityRequirements.length);
+  }
+
+  get serverCount(): number {
+    return this.#servers.length;
+  }
+
+  servers(): IterableIterator<Server> {
+    return this.#servers.values();
+  }
+
+  serverAt(index: number): Server {
+    return this.#servers[index];
+  }
+
+  hasServer(url: string): boolean {
+    return this.#servers.some(server => server.url === url);
+  }
+
+  addServer(url: string): Server {
+    assert(!this.hasServer(url), `Server for '${url}' URL already exists`);
+    const result = new Server(this, url);
+    this.#servers.push(result);
+    return result;
+  }
+
+  removeServerAt(index: number): void {
+    const server = this.#servers[index];
+    if (server) {
+      server.dispose();
+      this.#servers.splice(index, 1);
+    }
+  }
+
+  clearServers(): void {
+    this.#servers.forEach(s => s.dispose());
+    this.#servers.splice(0, this.#servers.length);
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/Parameter/CookieParameter.ts
+++ b/packages/openapi-model/src/3.1.0/model/Parameter/CookieParameter.ts
@@ -1,0 +1,36 @@
+import { ParameterBase, ParameterParent } from './ParameterBase';
+
+import type { CookieParameterSerializationStyle } from '../../../baseTypes';
+import type { CookieParameterModel } from '../types';
+
+export class CookieParameter extends ParameterBase implements CookieParameterModel {
+  #required: boolean;
+  #style: CookieParameterSerializationStyle;
+
+  constructor(parent: ParameterParent, name: string) {
+    super(parent, name);
+    this.#required = false;
+    this.#style = 'form';
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  get in(): 'cookie' {
+    return 'cookie';
+  }
+
+  get required(): boolean {
+    return this.#required;
+  }
+
+  set required(value: boolean) {
+    this.#required = value;
+  }
+
+  get style(): CookieParameterSerializationStyle {
+    return this.#style;
+  }
+
+  set style(value: CookieParameterSerializationStyle) {
+    this.#style = value;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/Parameter/HeaderParameter.ts
+++ b/packages/openapi-model/src/3.1.0/model/Parameter/HeaderParameter.ts
@@ -1,0 +1,36 @@
+import { ParameterBase, ParameterParent } from './ParameterBase';
+
+import type { HeaderParameterSerializationStyle } from '../../../baseTypes';
+import type { HeaderParameterModel } from '../types';
+
+export class HeaderParameter extends ParameterBase implements HeaderParameterModel {
+  #required: boolean;
+  #style: HeaderParameterSerializationStyle;
+
+  constructor(parent: ParameterParent, name: string) {
+    super(parent, name);
+    this.#required = false;
+    this.#style = 'simple';
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  get in(): 'header' {
+    return 'header';
+  }
+
+  get required(): boolean {
+    return this.#required;
+  }
+
+  set required(value: boolean) {
+    this.#required = value;
+  }
+
+  get style(): HeaderParameterSerializationStyle {
+    return this.#style;
+  }
+
+  set style(value: HeaderParameterSerializationStyle) {
+    this.#style = value;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/Parameter/ParameterBase.ts
+++ b/packages/openapi-model/src/3.1.0/model/Parameter/ParameterBase.ts
@@ -1,0 +1,144 @@
+import assert from 'assert';
+
+import { Example } from '../Example';
+import { MediaType } from '../MediaType';
+import { Node } from '../Node';
+import { Schema } from '../Schema';
+
+import type { Components } from '../Components';
+import type { Operation } from '../Operation';
+import type { PathItem } from '../PathItem';
+import type { ParameterModelBase } from '../types';
+import type { CommonMarkString, MIMETypeString, Nullable } from '@fresha/api-tools-core';
+
+export type ParameterParent = Components | PathItem | Operation;
+
+export class ParameterBase extends Node<ParameterParent> implements ParameterModelBase {
+  #name: string;
+  #description: Nullable<CommonMarkString>;
+  #deprecated: boolean;
+  #explode: boolean;
+  #schema: Nullable<Schema>;
+  #examples: Map<string, Example>;
+  #content: Map<MIMETypeString, MediaType>;
+
+  constructor(parent: ParameterParent, name: string) {
+    super(parent);
+    this.#name = name;
+    this.#description = null;
+    this.#deprecated = false;
+    this.#explode = false;
+    this.#schema = null;
+    this.#examples = new Map<string, Example>();
+    this.#content = new Map<MIMETypeString, MediaType>();
+  }
+
+  get name(): string {
+    return this.#name;
+  }
+
+  set name(value: string) {
+    this.#name = value;
+  }
+
+  get description(): Nullable<CommonMarkString> {
+    return this.#description;
+  }
+
+  get deprecated(): boolean {
+    return this.#deprecated;
+  }
+
+  get explode(): boolean {
+    return this.#explode;
+  }
+
+  get schema(): Nullable<Schema> {
+    return this.#schema;
+  }
+
+  addSchema(): Schema {
+    assert(!this.#schema, 'Schema already exists');
+    this.#schema = new Schema(this);
+    return this.#schema;
+  }
+
+  deleteSchema(): void {
+    if (this.#schema) {
+      this.#schema.dispose();
+      this.#schema = null;
+    }
+  }
+
+  get exampleCount(): number {
+    return this.#examples.size;
+  }
+
+  exampleKeys(): IterableIterator<string> {
+    return this.#examples.keys();
+  }
+
+  examples(): IterableIterator<[string, Example]> {
+    return this.#examples.entries();
+  }
+
+  hasExample(key: string): boolean {
+    return this.#examples.has(key);
+  }
+
+  addExample(key: string): Example {
+    assert(!this.hasExample(key), `Example for key '${key}' already exists`);
+    const result = new Example(this);
+    this.#examples.set(key, result);
+    return result;
+  }
+
+  deleteExample(key: string): void {
+    const example = this.#examples.get(key);
+    if (example) {
+      example.dispose();
+      this.#examples.delete(key);
+    }
+  }
+
+  clearExamples(): void {
+    this.#examples.forEach(e => e.dispose());
+    this.#examples.clear();
+  }
+
+  get mediaTypeCount(): number {
+    return this.#content.size;
+  }
+
+  mediaTypeKeys(): IterableIterator<MIMETypeString> {
+    return this.#content.keys();
+  }
+
+  mediaTypes(): IterableIterator<[MIMETypeString, MediaType]> {
+    return this.#content.entries();
+  }
+
+  hasMediaType(mediaType: MIMETypeString): boolean {
+    return this.#content.has(mediaType);
+  }
+
+  addMediaType(key: MIMETypeString): MediaType {
+    assert(!this.hasMediaType(key), `Media type for key '${key}' already exists`);
+    const result = new MediaType(this);
+    this.#content.set(key, result);
+    return result;
+  }
+
+  deleteMediaType(key: MIMETypeString): void {
+    const mediaType = this.#content.get(key);
+    if (mediaType) {
+      mediaType.dispose();
+      this.#content.delete(key);
+    }
+  }
+
+  clearMediaTypes(): void {
+    this.#content.forEach(m => m.dispose());
+    this.#content.clear();
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/Parameter/PathParameter.ts
+++ b/packages/openapi-model/src/3.1.0/model/Parameter/PathParameter.ts
@@ -1,0 +1,32 @@
+import { PathParameterSerializationStyle } from '../../../baseTypes';
+
+import { ParameterBase, ParameterParent } from './ParameterBase';
+
+import type { PathParameterModel } from '../types';
+
+export class PathParameter extends ParameterBase implements PathParameterModel {
+  #style: PathParameterSerializationStyle;
+
+  constructor(parent: ParameterParent, name: string) {
+    super(parent, name);
+    this.#style = 'simple';
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  get in(): 'path' {
+    return 'path';
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  get required(): true {
+    return true;
+  }
+
+  get style(): PathParameterSerializationStyle {
+    return this.#style;
+  }
+
+  set style(value: PathParameterSerializationStyle) {
+    this.#style = value;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/Parameter/QueryParameter.ts
+++ b/packages/openapi-model/src/3.1.0/model/Parameter/QueryParameter.ts
@@ -1,0 +1,56 @@
+import { ParameterBase, ParameterParent } from './ParameterBase';
+
+import type { QueryParameterSerializationStyle } from '../../../baseTypes';
+import type { QueryParameterModel } from '../types';
+
+export class QueryParameter extends ParameterBase implements QueryParameterModel {
+  #required: boolean;
+  #allowEmptyValue: boolean;
+  #style: QueryParameterSerializationStyle;
+  #allowReserved: boolean;
+
+  constructor(parent: ParameterParent, name: string) {
+    super(parent, name);
+    this.#required = false;
+    this.#allowEmptyValue = false;
+    this.#style = 'form';
+    this.#allowReserved = false;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  get in(): 'query' {
+    return 'query';
+  }
+
+  get required(): boolean {
+    return this.#required;
+  }
+
+  set required(value: boolean) {
+    this.#required = value;
+  }
+
+  get allowEmptyValue(): boolean {
+    return this.#allowEmptyValue;
+  }
+
+  set allowEmptyValue(value: boolean) {
+    this.#allowEmptyValue = value;
+  }
+
+  get style(): QueryParameterSerializationStyle {
+    return this.#style;
+  }
+
+  set style(value: QueryParameterSerializationStyle) {
+    this.#style = value;
+  }
+
+  get allowReserved(): boolean {
+    return this.#allowReserved;
+  }
+
+  set allowReserved(value: boolean) {
+    this.#allowReserved = value;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/Parameter/index.ts
+++ b/packages/openapi-model/src/3.1.0/model/Parameter/index.ts
@@ -1,0 +1,10 @@
+import { CookieParameter } from './CookieParameter';
+import { HeaderParameter } from './HeaderParameter';
+import { PathParameter } from './PathParameter';
+import { QueryParameter } from './QueryParameter';
+
+export type { ParameterBase } from './ParameterBase';
+
+export type Parameter = PathParameter | QueryParameter | HeaderParameter | CookieParameter;
+
+export { PathParameter, QueryParameter, HeaderParameter, CookieParameter };

--- a/packages/openapi-model/src/3.1.0/model/PathItem.ts
+++ b/packages/openapi-model/src/3.1.0/model/PathItem.ts
@@ -1,0 +1,210 @@
+import assert from 'assert';
+
+import { Node } from './Node';
+import { Operation } from './Operation';
+import {
+  CookieParameter,
+  HeaderParameter,
+  Parameter,
+  PathParameter,
+  QueryParameter,
+} from './Parameter';
+import { Server } from './Server';
+
+import type { Components } from './Components';
+import type { OpenAPI } from './OpenAPI';
+import type { Paths } from './Paths';
+import type {
+  OperationModel,
+  ParameterLocation,
+  PathItemModel,
+  PathItemOperationMethod,
+} from './types';
+import type { CommonMarkString, Nullable } from '@fresha/api-tools-core';
+
+type PathItemParent = OpenAPI | Components | Paths;
+
+export class PathItem extends Node<PathItemParent> implements PathItemModel {
+  #summary: Nullable<string>;
+  #description: Nullable<CommonMarkString>;
+  readonly #operations: Map<PathItemOperationMethod, Operation>;
+  readonly #servers: Server[];
+  readonly #parameters: Parameter[];
+
+  constructor(parent: PathItemParent) {
+    super(parent);
+    this.#summary = null;
+    this.#description = null;
+    this.#operations = new Map<PathItemOperationMethod, Operation>();
+    this.#servers = [];
+    this.#parameters = [];
+  }
+
+  get summary(): Nullable<string> {
+    return this.#summary;
+  }
+
+  set summary(value: Nullable<string>) {
+    this.#summary = value;
+  }
+
+  get description(): Nullable<CommonMarkString> {
+    return this.#description;
+  }
+
+  set description(value: Nullable<CommonMarkString>) {
+    this.#description = value;
+  }
+
+  get operationCount(): number {
+    return this.#operations.size;
+  }
+
+  operationMethods(): IterableIterator<PathItemOperationMethod> {
+    return this.#operations.keys();
+  }
+
+  operations(): IterableIterator<[PathItemOperationMethod, OperationModel]> {
+    return this.#operations.entries();
+  }
+
+  hasOperation(method: PathItemOperationMethod): boolean {
+    return this.#operations.has(method);
+  }
+
+  getOperation(method: PathItemOperationMethod): Operation {
+    const result = this.#operations.get(method);
+    assert(result, `Expect operation for method '${method}' to exist`);
+    return result;
+  }
+
+  addOperation(method: PathItemOperationMethod): Operation {
+    assert(!this.#operations.has(method), `Operation for method '${method}' already exists`);
+    const result = new Operation(this);
+    this.#operations.set(method, result);
+    return result;
+  }
+
+  removeOperation(method: PathItemOperationMethod): void {
+    const operation = this.#operations.get(method);
+    if (operation) {
+      operation.dispose();
+    }
+    this.#operations.delete(method);
+  }
+
+  clearOperations(): void {
+    this.#operations.forEach(o => o.dispose());
+    this.#operations.clear();
+  }
+
+  get serverCount(): number {
+    return this.#servers.length;
+  }
+
+  servers(): IterableIterator<Server> {
+    return this.#servers.values();
+  }
+
+  serverAt(index: number): Server {
+    return this.#servers[index];
+  }
+
+  addServer(url: string): Server {
+    assert(!this.#servers.some(s => s.url === url), `Duplicate server for URL '${url}'`);
+    const result = new Server(this, url);
+    this.#servers.push(result);
+    return result;
+  }
+
+  removeServerAt(index: number): void {
+    this.#servers[index].dispose();
+    this.#servers.splice(index, 1);
+  }
+
+  clearServers(): void {
+    this.#servers.forEach(s => s.dispose());
+    this.#servers.splice(0, this.#servers.length);
+  }
+
+  get parameterCount(): number {
+    return this.#parameters.length;
+  }
+
+  parameters(): IterableIterator<Parameter> {
+    return this.#parameters.values();
+  }
+
+  parameterAt(index: number): Parameter {
+    return this.#parameters[index];
+  }
+
+  removeParameterAt(index: number): void {
+    this.#parameters[index].dispose();
+    this.#parameters.splice(index, 1);
+  }
+
+  hasParameter(name: string, location?: ParameterLocation): boolean {
+    return location
+      ? this.#parameters.some(p => p.name === name && p.in === location)
+      : this.#parameters.some(p => p.name === name);
+  }
+
+  getParameter(name: string, location?: ParameterLocation): Parameter {
+    let result: Parameter | undefined;
+    if (location) {
+      result = this.#parameters.find(p => p.in === location && p.name === name);
+      assert(result, `Expected to find parameter '${name}' of type '${location}'`);
+    } else {
+      result = this.#parameters.find(p => p.name === name);
+      assert(result, `Expected to find parameter '${name}'`);
+    }
+    return result;
+  }
+
+  addParameter(name: string, location: 'path'): PathParameter;
+  addParameter(name: string, location: 'query'): QueryParameter;
+  addParameter(name: string, location: 'header'): HeaderParameter;
+  addParameter(name: string, location: 'cookie'): CookieParameter;
+  addParameter(name: string, location: ParameterLocation): Parameter {
+    assert(
+      !this.hasParameter(name, location),
+      `Duplicate paramter '${name}' and type '${location}'`,
+    );
+    let result: Parameter;
+    switch (location) {
+      case 'path':
+        result = new PathParameter(this, name);
+        break;
+      case 'query':
+        result = new QueryParameter(this, name);
+        break;
+      case 'header':
+        result = new HeaderParameter(this, name);
+        break;
+      case 'cookie':
+        result = new CookieParameter(this, name);
+        break;
+      default:
+        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+        assert.fail(`Invalid parameter location '${location}'`);
+    }
+    this.#parameters.push(result);
+    return result;
+  }
+
+  removeParameter(name: string, location?: ParameterLocation): void {
+    for (let i = this.#parameters.length - 1; i >= 0; i -= 1) {
+      const parameter = this.#parameters[i];
+      if (parameter.name === name && (!location || parameter.in === location)) {
+        parameter.dispose();
+        this.#parameters.splice(i, 1);
+      }
+    }
+  }
+
+  clearParameters(): void {
+    this.#parameters.forEach(p => p.dispose());
+    this.#parameters.splice(0, this.#parameters.length);
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/Paths.ts
+++ b/packages/openapi-model/src/3.1.0/model/Paths.ts
@@ -1,0 +1,54 @@
+import assert from 'assert';
+
+import { ParametrisedURLString } from '@fresha/api-tools-core';
+
+import { Node } from './Node';
+import { OpenAPI } from './OpenAPI';
+import { PathItem } from './PathItem';
+
+import type { PathsModel } from './types';
+
+export class Paths extends Node<OpenAPI> implements PathsModel {
+  readonly #items: Map<ParametrisedURLString, PathItem>;
+
+  constructor(parent: OpenAPI) {
+    super(parent);
+    this.#items = new Map<ParametrisedURLString, PathItem>();
+  }
+
+  get itemCount(): number {
+    return this.#items.size;
+  }
+
+  itemUrls(): IterableIterator<ParametrisedURLString> {
+    return this.#items.keys();
+  }
+
+  items(): IterableIterator<[ParametrisedURLString, PathItem]> {
+    return this.#items.entries();
+  }
+
+  hasItem(url: ParametrisedURLString): boolean {
+    return this.#items.has(url);
+  }
+
+  addItem(url: ParametrisedURLString): PathItem {
+    assert(!this.#items.has(url), `Path item '${url}' already exists`);
+    const result = new PathItem(this);
+    this.#items.set(url, result);
+    return result;
+  }
+
+  removeItem(url: ParametrisedURLString): void {
+    const item = this.#items.get(url);
+    if (item) {
+      item.dispose();
+      this.#items.delete(url);
+    }
+  }
+
+  clearItems(): void {
+    this.#items.forEach(it => it.dispose());
+    this.#items.clear();
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/RequestBody.ts
+++ b/packages/openapi-model/src/3.1.0/model/RequestBody.ts
@@ -1,0 +1,77 @@
+import assert from 'assert';
+
+import { CommonMarkString, MIMETypeString, Nullable } from '@fresha/api-tools-core';
+
+import { MediaType } from './MediaType';
+import { Node } from './Node';
+
+import type { Components } from './Components';
+import type { Operation } from './Operation';
+import type { RequestBodyModel } from './types';
+
+type RequestBodyParent = Components | Operation;
+
+export class RequestBody extends Node<RequestBodyParent> implements RequestBodyModel {
+  #description: Nullable<CommonMarkString>;
+  readonly #content: Map<MIMETypeString, MediaType>;
+  #required: boolean;
+
+  constructor(parent: RequestBodyParent) {
+    super(parent);
+    this.#description = null;
+    this.#content = new Map<MIMETypeString, MediaType>();
+    this.#required = false;
+  }
+
+  get description(): Nullable<CommonMarkString> {
+    return this.#description;
+  }
+
+  set description(value: Nullable<CommonMarkString>) {
+    this.#description = value;
+  }
+
+  get mediaTypeCount(): number {
+    return this.#content.size;
+  }
+
+  mediaTypeKeys(): IterableIterator<MIMETypeString> {
+    return this.#content.keys();
+  }
+
+  mediaTypes(): IterableIterator<[MIMETypeString, MediaType]> {
+    return this.#content.entries();
+  }
+
+  hasMediaType(mediaType: MIMETypeString): boolean {
+    return this.#content.has(mediaType);
+  }
+
+  addMediaType(mediaType: MIMETypeString): MediaType {
+    assert(!this.hasMediaType(mediaType), `Media type for '${mediaType}' already exists`);
+    const result = new MediaType(this);
+    this.#content.set(mediaType, result);
+    return result;
+  }
+
+  deleteMediaType(key: MIMETypeString): void {
+    const mediaType = this.#content.get(key);
+    if (mediaType) {
+      mediaType.dispose();
+      this.#content.delete(key);
+    }
+  }
+
+  clearMediaTypes(): void {
+    this.#content.forEach(c => c.dispose());
+    this.#content.clear();
+  }
+
+  get required(): boolean {
+    return this.#required;
+  }
+
+  set required(value: boolean) {
+    this.#required = value;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/Response.ts
+++ b/packages/openapi-model/src/3.1.0/model/Response.ts
@@ -1,0 +1,161 @@
+import assert from 'assert';
+
+import { Header } from './Header';
+import { Link } from './Link';
+import { MediaType } from './MediaType';
+import { Node } from './Node';
+
+import type { Components } from './Components';
+import type { Operation } from './Operation';
+import type { Responses } from './Responses';
+import type { ResponseModel } from './types';
+import type { CommonMarkString, MIMETypeString } from '@fresha/api-tools-core';
+
+type ResposeParent = Components | Operation | Responses;
+
+export class Response extends Node<ResposeParent> implements ResponseModel {
+  #description: CommonMarkString;
+  readonly #headers: Map<string, Header>;
+  readonly #content: Map<MIMETypeString, MediaType>;
+  readonly #links: Map<string, Link>;
+
+  constructor(parent: ResposeParent, description: CommonMarkString) {
+    super(parent);
+    assert(!!description, 'Response description cannot be empty');
+    this.#description = description;
+    this.#headers = new Map<string, Header>();
+    this.#content = new Map<MIMETypeString, MediaType>();
+    this.#links = new Map<string, Link>();
+  }
+
+  get description(): CommonMarkString {
+    return this.#description;
+  }
+
+  set description(value: CommonMarkString) {
+    if (this.#description !== value) {
+      assert(!!value, 'Response description cannot be empty');
+      this.#description = value;
+    }
+  }
+
+  get headerCount(): number {
+    return this.#headers.size;
+  }
+
+  headerNames(): IterableIterator<string> {
+    return this.#headers.keys();
+  }
+
+  headers(): IterableIterator<[string, Header]> {
+    return this.#headers.entries();
+  }
+
+  hasHeader(name: string): boolean {
+    return this.#headers.has(name);
+  }
+
+  getHeader(name: string): Header {
+    const result = this.#headers.get(name);
+    assert(result, `Header ${name} is missing`);
+    return result;
+  }
+
+  addHeader(name: string): Header {
+    assert(!this.hasHeader(name), `Header ${name} is already set`);
+    const result = new Header(this);
+    this.#headers.set(name, result);
+    return result;
+  }
+
+  deleteHeader(name: string): void {
+    const header = this.#headers.get(name);
+    if (header) {
+      header.dispose();
+      this.#headers.delete(name);
+    }
+  }
+
+  clearHeaders(): void {
+    this.#headers.forEach(h => h.dispose());
+    this.#headers.clear();
+  }
+
+  get mediaTypeCount(): number {
+    return this.#content.size;
+  }
+
+  mediaTypeKeys(): IterableIterator<MIMETypeString> {
+    return this.#content.keys();
+  }
+
+  mediaTypes(): IterableIterator<[MIMETypeString, MediaType]> {
+    return this.#content.entries();
+  }
+
+  hasMediaType(mediaType: MIMETypeString): boolean {
+    return this.#content.has(mediaType);
+  }
+
+  addMediaType(key: MIMETypeString): MediaType {
+    assert(!this.hasMediaType(key), `Media type for key '${key}' already exists`);
+    const result = new MediaType(this);
+    this.#content.set(key, result);
+    return result;
+  }
+
+  deleteMediaType(key: MIMETypeString): void {
+    const mediaType = this.#content.get(key);
+    if (mediaType) {
+      mediaType.dispose();
+      this.#content.delete(key);
+    }
+  }
+
+  clearMediaTypes(): void {
+    this.#content.forEach(m => m.dispose());
+    this.#content.clear();
+  }
+
+  get linkCount(): number {
+    return this.#links.size;
+  }
+
+  linkKeys(): IterableIterator<string> {
+    return this.#links.keys();
+  }
+
+  links(): IterableIterator<[string, Link]> {
+    return this.#links.entries();
+  }
+
+  hasLink(key: string): boolean {
+    return this.#links.has(key);
+  }
+
+  getLink(key: string): Link {
+    const result = this.#links.get(key);
+    assert(result, `Link for key ${key} is missing`);
+    return result;
+  }
+
+  addLink(key: string): Link {
+    assert(!this.hasLink(key), `Link for key ${key} already exists`);
+    const result = new Link(this);
+    this.#links.set(key, result);
+    return result;
+  }
+
+  deleteLink(key: string): void {
+    const link = this.#links.get(key);
+    if (link) {
+      link.dispose();
+      this.#links.delete(key);
+    }
+  }
+
+  clearLinks(): void {
+    this.#links.forEach(l => l.dispose());
+    this.#links.clear();
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/Responses.ts
+++ b/packages/openapi-model/src/3.1.0/model/Responses.ts
@@ -1,0 +1,81 @@
+import assert from 'assert';
+
+import { Node } from './Node';
+import { Response } from './Response';
+
+import type { Operation } from './Operation';
+import type { ResponsesModel } from './types';
+import type { CommonMarkString, HTTPStatusCode, Nullable } from '@fresha/api-tools-core';
+
+type ResponsesParent = Operation;
+
+export class Responses extends Node<ResponsesParent> implements ResponsesModel {
+  #defaultResponse: Nullable<Response>;
+  readonly #codes: Map<HTTPStatusCode, Response>;
+
+  constructor(parent: ResponsesParent) {
+    super(parent);
+    this.#defaultResponse = null;
+    this.#codes = new Map<HTTPStatusCode, Response>();
+  }
+
+  get defaultResponse(): Nullable<Response> {
+    return this.#defaultResponse;
+  }
+
+  addDefaultResponse(description: CommonMarkString): Response {
+    assert(!this.#defaultResponse, 'Default response is already set');
+    const result = new Response(this, description);
+    this.#defaultResponse = result;
+    return result;
+  }
+
+  deleteDefaultResponse(): void {
+    if (this.#defaultResponse) {
+      this.#defaultResponse.dispose();
+      this.#defaultResponse = null;
+    }
+  }
+
+  get responseCount(): number {
+    return this.#codes.size;
+  }
+
+  responseCodes(): IterableIterator<HTTPStatusCode> {
+    return this.#codes.keys();
+  }
+
+  responses(): IterableIterator<[HTTPStatusCode, Response]> {
+    return this.#codes.entries();
+  }
+
+  hasResponse(code: HTTPStatusCode): boolean {
+    return this.#codes.has(code);
+  }
+
+  getResponse(code: HTTPStatusCode): Response {
+    const result = this.#codes.get(code);
+    assert(result, `Response for HTTP code ${code} is missing`);
+    return result;
+  }
+
+  addResponse(code: HTTPStatusCode, description: CommonMarkString): Response {
+    assert(!this.hasResponse(code), `Response for code ${code} is already set`);
+    const result = new Response(this, description);
+    this.#codes.set(code, result);
+    return result;
+  }
+
+  deleteResponse(code: HTTPStatusCode): void {
+    const response = this.#codes.get(code);
+    if (response) {
+      response.dispose();
+      this.#codes.delete(code);
+    }
+  }
+
+  clearResponses(): void {
+    this.#codes.forEach(r => r.dispose());
+    this.#codes.clear();
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/Schema.ts
+++ b/packages/openapi-model/src/3.1.0/model/Schema.ts
@@ -1,0 +1,686 @@
+import assert from 'assert';
+
+import { Discriminator } from './Discriminator';
+import { ExternalDocumentation } from './ExternalDocumentation';
+import { Node } from './Node';
+import { XML } from './XML';
+
+import type { Components } from './Components';
+import type { Header } from './Header';
+import type { MediaType } from './MediaType';
+import type { Operation } from './Operation';
+import type { ParameterBase } from './Parameter';
+import type { SchemaFormat, SchemaModel, SchemaType } from './types';
+import type { CommonMarkString, JSONValue, Nullable, URLString } from '@fresha/api-tools-core';
+
+type SchemaParent = Components | Operation | ParameterBase | Header | MediaType | Schema;
+
+export class Schema extends Node<SchemaParent> implements SchemaModel {
+  #title: Nullable<string>;
+  #description: Nullable<CommonMarkString>;
+  #defaultValue: JSONValue | undefined;
+  #examples: JSONValue[];
+  #types: Set<SchemaType>;
+  #format: Nullable<SchemaFormat>;
+  #allowedValues: Set<JSONValue>;
+  #minLength: Nullable<number>;
+  #maxLength: Nullable<number>;
+  #pattern: Nullable<string>;
+  #minimum: Nullable<number>;
+  #exclusiveMinimum: Nullable<number>;
+  #maximum: Nullable<number>;
+  #exclusiveMaximum: Nullable<number>;
+  #multipleOf: Nullable<number>;
+  #properties: Map<string, Schema>;
+  #minProperties: Nullable<number>;
+  #maxProperties: Nullable<number>;
+  #patternProperties: Map<string, Schema>;
+  #additionalProperties: Schema | false;
+  #requiredProperties: Set<string>;
+  #propertyNamesSchema: Nullable<Schema>;
+  #items: Nullable<Schema>;
+  #minItems: Nullable<number>;
+  #maxItems: Nullable<number>;
+  #uniqueItems: boolean;
+  #containsSchema: Nullable<Schema>;
+  #minContains: Nullable<number>;
+  #maxContains: Nullable<number>;
+  #prefixItems: Schema[];
+  #allOf: Schema[];
+  #anyOf: Schema[];
+  #oneOf: Schema[];
+  #not: Nullable<Schema>;
+  #discriminator: Nullable<Discriminator>;
+  #xml: Nullable<XML>;
+  #extenalDocs: Nullable<ExternalDocumentation>;
+
+  constructor(parent: SchemaParent) {
+    super(parent);
+    this.#title = null;
+    this.#description = null;
+    this.#defaultValue = undefined;
+    this.#examples = [];
+    this.#types = new Set<SchemaType>();
+    this.#format = null;
+    this.#allowedValues = new Set<JSONValue>();
+    this.#minLength = null;
+    this.#maxLength = null;
+    this.#pattern = null;
+    this.#minimum = null;
+    this.#exclusiveMinimum = null;
+    this.#maximum = null;
+    this.#exclusiveMaximum = null;
+    this.#multipleOf = null;
+    this.#properties = new Map<string, Schema>();
+    this.#minProperties = null;
+    this.#maxProperties = null;
+    this.#patternProperties = new Map<string, Schema>();
+    this.#additionalProperties = false;
+    this.#requiredProperties = new Set<string>();
+    this.#propertyNamesSchema = null;
+    this.#items = null;
+    this.#minItems = null;
+    this.#maxItems = null;
+    this.#uniqueItems = false;
+    this.#containsSchema = null;
+    this.#minContains = null;
+    this.#maxContains = null;
+    this.#prefixItems = [];
+    this.#allOf = [];
+    this.#anyOf = [];
+    this.#oneOf = [];
+    this.#not = null;
+    this.#discriminator = null;
+    this.#extenalDocs = null;
+    this.#xml = null;
+  }
+
+  get title(): Nullable<string> {
+    return this.#title;
+  }
+
+  set title(value: Nullable<string>) {
+    this.#title = value;
+  }
+
+  get description(): Nullable<CommonMarkString> {
+    return this.#description;
+  }
+
+  set description(value: Nullable<CommonMarkString>) {
+    this.#description = value;
+  }
+
+  get defaultValue(): JSONValue | undefined {
+    return this.#defaultValue;
+  }
+
+  set defaultValue(value: JSONValue | undefined) {
+    this.#defaultValue = value;
+  }
+
+  get exampleCount(): number {
+    return this.#examples.length;
+  }
+
+  examples(): IterableIterator<JSONValue> {
+    return this.#examples.values();
+  }
+
+  exampleAt(index: number): JSONValue {
+    return this.#examples[index];
+  }
+
+  deleteExampleAt(index: number): void {
+    this.#examples.splice(index, 1);
+  }
+
+  clearExamples(): void {
+    this.#examples.splice(0, this.#examples.length);
+  }
+
+  get typeCount(): number {
+    return this.#types.size;
+  }
+
+  types(): IterableIterator<SchemaType> {
+    return this.#types.values();
+  }
+
+  hasType(value: SchemaType): boolean {
+    return this.#types.has(value);
+  }
+
+  addType(value: SchemaType): void {
+    this.#types.add(value);
+  }
+
+  deleteType(value: SchemaType): void {
+    // TODO clean properties relevant to the type which is removed
+    this.#types.delete(value);
+  }
+
+  clearTypes(): void {
+    this.#types.clear();
+  }
+
+  get format(): Nullable<SchemaFormat> {
+    return this.#format;
+  }
+
+  set format(value: Nullable<SchemaFormat>) {
+    this.#format = value;
+  }
+
+  get allowedValueCount(): number {
+    return this.#allowedValues.size;
+  }
+
+  allowedValues(): IterableIterator<JSONValue> {
+    return this.#allowedValues.values();
+  }
+
+  hasAllowedValue(value: JSONValue): boolean {
+    return this.#allowedValues.has(value);
+  }
+
+  addAllowedValue(value: JSONValue): void {
+    this.#allowedValues.add(value);
+  }
+
+  removeAllowedValue(value: JSONValue): void {
+    this.#allowedValues.delete(value);
+  }
+
+  clearAllowedValues(): void {
+    this.#allowedValues.clear();
+  }
+
+  get minLength(): Nullable<number> {
+    return this.#minLength;
+  }
+
+  set minLength(value: Nullable<number>) {
+    this.#minLength = value;
+  }
+
+  get maxLength(): Nullable<number> {
+    return this.#maxLength;
+  }
+
+  set maxLength(value: Nullable<number>) {
+    this.#maxLength = value;
+  }
+
+  get pattern(): Nullable<string> {
+    return this.#pattern;
+  }
+
+  set pattern(value: Nullable<string>) {
+    this.#pattern = value;
+  }
+
+  get minimum(): Nullable<number> {
+    return this.#minimum;
+  }
+
+  set minimum(value: Nullable<number>) {
+    this.#minimum = value;
+  }
+
+  get exclusiveMinimum(): Nullable<number> {
+    return this.#exclusiveMinimum;
+  }
+
+  set exclusiveMinimum(value: Nullable<number>) {
+    this.#exclusiveMinimum = value;
+  }
+
+  get maximum(): Nullable<number> {
+    return this.#maximum;
+  }
+
+  set maximum(value: Nullable<number>) {
+    this.#maximum = value;
+  }
+
+  get exclusiveMaximum(): Nullable<number> {
+    return this.#exclusiveMaximum;
+  }
+
+  set exclusiveMaximum(value: Nullable<number>) {
+    this.#exclusiveMaximum = value;
+  }
+
+  get multipleOf(): Nullable<number> {
+    return this.#multipleOf;
+  }
+
+  set multipleOf(value: Nullable<number>) {
+    this.#multipleOf = value;
+  }
+
+  get propertyCount(): number {
+    return this.#properties.size;
+  }
+
+  propertyNames(): IterableIterator<string> {
+    return this.#properties.keys();
+  }
+
+  properties(): IterableIterator<[string, Schema]> {
+    return this.#properties.entries();
+  }
+
+  hasProperty(name: string): boolean {
+    return this.#properties.has(name);
+  }
+
+  getProperty(name: string): Schema {
+    const result = this.#properties.get(name);
+    assert(result, `Property '${name}' does not exist`);
+    return result;
+  }
+
+  addProperty(name: string): Schema {
+    assert(!this.hasProperty(name), `Property '${name}' already exists`);
+    const result = new Schema(this);
+    this.#properties.set(name, result);
+    return result;
+  }
+
+  deleteProperty(name: string): void {
+    const prop = this.#properties.get(name);
+    if (prop) {
+      prop.dispose();
+      this.#properties.delete(name);
+    }
+  }
+
+  clearProperties(): void {
+    this.#properties.forEach(p => p.dispose());
+    this.#properties.clear();
+  }
+
+  get minProperties(): Nullable<number> {
+    return this.#minProperties;
+  }
+
+  set minProperties(value: Nullable<number>) {
+    this.#minProperties = value;
+  }
+
+  get maxProperties(): Nullable<number> {
+    return this.#maxProperties;
+  }
+
+  set maxProperties(value: Nullable<number>) {
+    this.#maxProperties = value;
+  }
+
+  get patternPropertyCount(): number {
+    return this.#patternProperties.size;
+  }
+
+  patternPropertyNames(): IterableIterator<string> {
+    return this.#patternProperties.keys();
+  }
+
+  patternProperties(): IterableIterator<[string, Schema]> {
+    return this.#patternProperties.entries();
+  }
+
+  hasPatternProperty(name: string): boolean {
+    return this.#patternProperties.has(name);
+  }
+
+  getPatternProperty(name: string): Schema {
+    const result = this.#patternProperties.get(name);
+    assert(result, `Missing pattern property '${name}'`);
+    return result;
+  }
+
+  addPatternProperty(name: string): Schema {
+    assert(!this.hasPatternProperty(name), `Pattern property '${name}' already exists`);
+    const result = new Schema(this);
+    this.#patternProperties.set(name, result);
+    return result;
+  }
+
+  deletePatternProperty(name: string): void {
+    const prop = this.#patternProperties.get(name);
+    if (prop) {
+      prop.dispose();
+      this.#patternProperties.delete(name);
+    }
+  }
+
+  clearPatternProperties(): void {
+    this.#properties.forEach(p => p.dispose());
+    this.#properties.clear();
+  }
+
+  get additionalProperties(): Schema | false {
+    return this.#additionalProperties;
+  }
+
+  set(value: false) {
+    this.#additionalProperties = value;
+  }
+
+  addAdditionalProperties(): Schema {
+    assert(!this.#additionalProperties, 'Additional properties schema is already set');
+    this.#additionalProperties = new Schema(this);
+    return this.#additionalProperties;
+  }
+
+  disableAdditionalProperties(): void {
+    if (this.#additionalProperties) {
+      this.#additionalProperties.dispose();
+    }
+    this.#additionalProperties = false;
+  }
+
+  requiredPropertyNames(): IterableIterator<string> {
+    return this.#requiredProperties.keys();
+  }
+
+  *requiredProperties(): IterableIterator<[string, Schema]> {
+    for (const name of this.#requiredProperties) {
+      yield [name, this.getProperty(name)];
+    }
+  }
+
+  isPropertyRequired(name: string): boolean {
+    return this.#requiredProperties.has(name);
+  }
+
+  setPropertyRequired(name: string, value: boolean): void {
+    if (value) {
+      this.#requiredProperties.add(name);
+    } else {
+      this.#requiredProperties.delete(name);
+    }
+  }
+
+  get propertyNamesSchema(): Nullable<Schema> {
+    return this.#propertyNamesSchema;
+  }
+
+  addPropertyNamesSchema(): Schema {
+    assert(!this.#propertyNamesSchema, 'Property names schema is already set');
+    this.#propertyNamesSchema = new Schema(this);
+    return this.#propertyNamesSchema;
+  }
+
+  deletePropertyNamesSchema(): void {
+    if (this.#propertyNamesSchema) {
+      this.#propertyNamesSchema.dispose();
+      this.#propertyNamesSchema = null;
+    }
+  }
+
+  get items(): Nullable<Schema> {
+    return this.#items;
+  }
+
+  addItems(): Schema {
+    assert(!this.#items, 'Items schema is already set');
+    this.#items = new Schema(this);
+    return this.#items;
+  }
+
+  deleteItems(): void {
+    if (this.#items) {
+      this.#items.dispose();
+      this.#items = null;
+    }
+  }
+
+  get minItems(): Nullable<number> {
+    return this.#minItems;
+  }
+
+  set minItems(value: Nullable<number>) {
+    assert(value == null || value >= 0, `minItems cannot be negative`);
+    this.#minItems = value;
+  }
+
+  get maxItems(): Nullable<number> {
+    return this.#maxItems;
+  }
+
+  set maxItems(value: Nullable<number>) {
+    assert(value == null || value >= 0, `maxItems cannot be negative`);
+    this.#maxItems = value;
+  }
+
+  get uniqueItems(): boolean {
+    return this.#uniqueItems;
+  }
+
+  set uniqueItems(value: boolean) {
+    this.#uniqueItems = value;
+  }
+
+  get containsSchema(): Nullable<Schema> {
+    return this.#containsSchema;
+  }
+
+  addContainsSchema(): Schema {
+    assert(!this.#containsSchema, 'contains schema is set');
+    this.#containsSchema = new Schema(this);
+    return this.#containsSchema;
+  }
+
+  deleteContainsSchema(): void {
+    if (this.#containsSchema) {
+      this.#containsSchema.dispose();
+      this.#containsSchema = null;
+    }
+  }
+
+  get minContains(): Nullable<number> {
+    return this.#minContains;
+  }
+
+  set minContains(value: Nullable<number>) {
+    this.#minContains = value;
+  }
+
+  get maxContains(): Nullable<number> {
+    return this.#maxContains;
+  }
+
+  set maxContains(value: Nullable<number>) {
+    this.#maxContains = value;
+  }
+
+  get prefixItemsCount(): number {
+    return this.#prefixItems.length;
+  }
+
+  prefixItemsAt(index: number): Schema {
+    return this.#prefixItems[index];
+  }
+
+  addPrefixItem(): Schema {
+    const result = new Schema(this);
+    this.#prefixItems.push(result);
+    return result;
+  }
+
+  deletePrefixItemAt(index: number): void {
+    const item = this.#prefixItems[index];
+    if (item) {
+      item.dispose();
+      this.#prefixItems.splice(index, 1);
+    }
+  }
+
+  clearPrefixItems(): void {
+    this.#prefixItems.forEach(s => s.dispose());
+    this.#prefixItems.splice(0, this.#prefixItems.length);
+  }
+
+  get allOfCount(): number {
+    return this.#allOf.length;
+  }
+
+  allOf(): IterableIterator<Schema> {
+    return this.#allOf.values();
+  }
+
+  allOfAt(index: number): Schema {
+    return this.#allOf[index];
+  }
+
+  addAllOf(): Schema {
+    const result = new Schema(this);
+    this.#allOf.push(result);
+    return result;
+  }
+
+  deleteAllOfAt(index: number): void {
+    const item = this.#allOf[index];
+    if (item) {
+      item.dispose();
+      this.#allOf.splice(index, 1);
+    }
+  }
+
+  clearAllOf(): void {
+    this.#allOf.forEach(s => s.dispose());
+    this.#allOf.splice(0, this.#allOf.length);
+  }
+
+  get anyOfCount(): number {
+    return this.#anyOf.length;
+  }
+
+  anyOf(): IterableIterator<Schema> {
+    return this.#anyOf.values();
+  }
+
+  anyOfAt(index: number): Schema {
+    return this.#anyOf[index];
+  }
+
+  addAnyOf(): Schema {
+    const result = new Schema(this);
+    this.#anyOf.push(result);
+    return result;
+  }
+
+  deleteAnyOfAt(index: number): void {
+    const item = this.#anyOf[index];
+    if (item) {
+      item.dispose();
+      this.#anyOf.splice(index, 1);
+    }
+  }
+
+  clearAnyOf(): void {
+    this.#anyOf.forEach(s => s.dispose());
+    this.#anyOf.splice(0, this.#anyOf.length);
+  }
+
+  get oneOfCount(): number {
+    return this.#oneOf.length;
+  }
+
+  oneOf(): IterableIterator<Schema> {
+    return this.#oneOf.values();
+  }
+
+  oneOfAt(index: number): Schema {
+    return this.#oneOf[index];
+  }
+
+  addOneOf(): Schema {
+    const result = new Schema(this);
+    this.#oneOf.push(result);
+    return result;
+  }
+
+  deleteOneOfAt(index: number): void {
+    const item = this.#oneOf[index];
+    if (item) {
+      item.dispose();
+      this.#oneOf.splice(index, 1);
+    }
+  }
+
+  clearOneOf(): void {
+    this.#oneOf.forEach(s => s.dispose());
+    this.#oneOf.splice(0, this.#oneOf.length);
+  }
+
+  get not(): Nullable<Schema> {
+    return this.#not;
+  }
+
+  addNot(): Schema {
+    assert(!this.#not, 'Not schema is already set');
+    this.#not = new Schema(this);
+    return this.#not;
+  }
+
+  deleteNot(): void {
+    if (this.#not) {
+      this.#not.dispose();
+      this.#not = null;
+    }
+  }
+
+  get externalDocs(): Nullable<ExternalDocumentation> {
+    return this.#extenalDocs;
+  }
+
+  addExternalDocs(url: URLString): ExternalDocumentation {
+    assert(!this.#extenalDocs, 'externalDocs is already set');
+    this.#extenalDocs = new ExternalDocumentation(this, url);
+    return this.#extenalDocs;
+  }
+
+  deleteExternalDocs(): void {
+    if (this.#extenalDocs) {
+      this.#extenalDocs.dispose();
+      this.#extenalDocs = null;
+    }
+  }
+
+  get xml(): Nullable<XML> {
+    return this.#xml;
+  }
+
+  addXML(): XML {
+    assert(!this.#xml, 'xml is already set');
+    this.#xml = new XML(this);
+    return this.#xml;
+  }
+
+  deleteXML(): void {
+    if (this.#xml) {
+      this.#xml.dispose();
+      this.#xml = null;
+    }
+  }
+
+  get discriminator(): Nullable<Discriminator> {
+    return this.#discriminator;
+  }
+
+  addDiscriminator(propertyName: string): Discriminator {
+    assert(!this.#discriminator, 'Discriminator is already set');
+    this.#discriminator = new Discriminator(this, propertyName);
+    return this.#discriminator;
+  }
+
+  deleteDiscriminator(): void {
+    if (this.#discriminator) {
+      this.#discriminator.dispose();
+      this.#discriminator = null;
+    }
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/SecurityRequirement.ts
+++ b/packages/openapi-model/src/3.1.0/model/SecurityRequirement.ts
@@ -1,0 +1,66 @@
+import { Node } from './Node';
+
+import type { OpenAPI } from './OpenAPI';
+import type { Operation } from './Operation';
+import type { SecuritySchema } from './SecuritySchema';
+import type { SecurityRequirementModel } from './types';
+
+type SecurityRequirementParent = OpenAPI | Operation;
+
+export class SecurityRequirement
+  extends Node<SecurityRequirementParent>
+  implements SecurityRequirementModel
+{
+  readonly #scopes: Map<SecuritySchema, Set<string>>;
+
+  constructor(parent: SecurityRequirementParent) {
+    super(parent);
+    this.#scopes = new Map<SecuritySchema, Set<string>>();
+  }
+
+  get schemaCount(): number {
+    return this.#scopes.size;
+  }
+
+  schemas(): IterableIterator<SecuritySchema> {
+    return this.#scopes.keys();
+  }
+
+  scopeCount(schema: SecuritySchema): number {
+    return this.#scopes.get(schema)?.size ?? 0;
+  }
+
+  *scopes(schema: SecuritySchema): IterableIterator<string> {
+    const scopes = this.#scopes.get(schema);
+    if (scopes) {
+      for (const scope of scopes) {
+        yield scope;
+      }
+    }
+  }
+
+  hasScope(schema: SecuritySchema): boolean {
+    return this.#scopes.has(schema);
+  }
+
+  addScope(schema: SecuritySchema, scope: string): void {
+    let scopes = this.#scopes.get(schema);
+    if (!scopes) {
+      scopes = new Set<string>();
+      this.#scopes.set(schema, scopes);
+    }
+    scopes.add(scope);
+  }
+
+  deleteScope(schema: SecuritySchema, scope: string): void {
+    this.#scopes.get(schema)?.delete(scope);
+  }
+
+  clearScopes(schema: SecuritySchema): void {
+    this.#scopes.delete(schema);
+  }
+
+  clearAllScopes(): void {
+    this.#scopes.clear();
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/SecuritySchema/APIKeySecuritySchema.ts
+++ b/packages/openapi-model/src/3.1.0/model/SecuritySchema/APIKeySecuritySchema.ts
@@ -1,0 +1,39 @@
+import assert from 'assert';
+
+import { SecuritySchemaBase, SecuritySchemaParent } from './SecuritySchemaBase';
+
+import type { APIKeySecuritySchemaLocation, APIKeySecuritySchemaModel } from '../types';
+
+export class APIKeySecuritySchema extends SecuritySchemaBase implements APIKeySecuritySchemaModel {
+  #name: string;
+  #in: APIKeySecuritySchemaLocation;
+
+  constructor(parent: SecuritySchemaParent, name: string, location: APIKeySecuritySchemaLocation) {
+    super(parent);
+    assert(name, 'Name of an APIKey security scheme cannot be empty');
+    this.#name = name;
+    this.#in = location;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  get type(): 'apiKey' {
+    return 'apiKey';
+  }
+
+  get name(): string {
+    return this.#name;
+  }
+
+  set name(value: string) {
+    assert(value, 'Name of an APIKey security scheme cannot be empty');
+    this.#name = value;
+  }
+
+  get in(): APIKeySecuritySchemaLocation {
+    return this.#in;
+  }
+
+  set in(value: APIKeySecuritySchemaLocation) {
+    this.#in = value;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/SecuritySchema/HTTPSecuritySchema.ts
+++ b/packages/openapi-model/src/3.1.0/model/SecuritySchema/HTTPSecuritySchema.ts
@@ -1,0 +1,36 @@
+import { SecuritySchemaBase, SecuritySchemaParent } from './SecuritySchemaBase';
+
+import type { HTTPSecuritySchemaAuthentication, HTTPSecuritySchemaModel } from '../types';
+import type { Nullable } from '@fresha/api-tools-core';
+
+export class HTTPSecuritySchema extends SecuritySchemaBase implements HTTPSecuritySchemaModel {
+  #scheme: HTTPSecuritySchemaAuthentication;
+  #bearerFormat: Nullable<string>;
+
+  constructor(parent: SecuritySchemaParent) {
+    super(parent);
+    this.#scheme = 'Basic';
+    this.#bearerFormat = null;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  get type(): 'http' {
+    return 'http';
+  }
+
+  get scheme(): HTTPSecuritySchemaAuthentication {
+    return this.#scheme;
+  }
+
+  set scheme(value: HTTPSecuritySchemaAuthentication) {
+    this.#scheme = value;
+  }
+
+  get bearerFormat(): Nullable<string> {
+    return this.#bearerFormat;
+  }
+
+  set bearerFormat(value: Nullable<string>) {
+    this.#bearerFormat = value;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/SecuritySchema/MutualTLSSecuritySchema.ts
+++ b/packages/openapi-model/src/3.1.0/model/SecuritySchema/MutualTLSSecuritySchema.ts
@@ -1,0 +1,13 @@
+import { SecuritySchemaBase } from './SecuritySchemaBase';
+
+import type { MutualTLSSecuritySchemaModel } from '../types';
+
+export class MutualTLSSecuritySchema
+  extends SecuritySchemaBase
+  implements MutualTLSSecuritySchemaModel
+{
+  // eslint-disable-next-line class-methods-use-this
+  get type(): 'mutualTLS' {
+    return 'mutualTLS';
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/SecuritySchema/OAuth2SecuritySchema.ts
+++ b/packages/openapi-model/src/3.1.0/model/SecuritySchema/OAuth2SecuritySchema.ts
@@ -1,0 +1,22 @@
+import { OAuthFlows } from './OAuthFlow/OAuthFlows';
+import { SecuritySchemaBase, SecuritySchemaParent } from './SecuritySchemaBase';
+
+import type { OAuth2SecuritySchemaModel } from '../types';
+
+export class OAuth2SecuritySchema extends SecuritySchemaBase implements OAuth2SecuritySchemaModel {
+  #flows: OAuthFlows;
+
+  constructor(parent: SecuritySchemaParent) {
+    super(parent);
+    this.#flows = new OAuthFlows(this);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  get type(): 'oauth2' {
+    return 'oauth2';
+  }
+
+  get flows(): OAuthFlows {
+    return this.#flows;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/SecuritySchema/OAuthFlow/OAuthAuthorizationFlow.ts
+++ b/packages/openapi-model/src/3.1.0/model/SecuritySchema/OAuthFlow/OAuthAuthorizationFlow.ts
@@ -1,0 +1,55 @@
+import assert from 'assert';
+
+import { OAuthFlowBase, OAuthFlowParent } from './OAuthFlowBase';
+
+import type { OAuthAuthorizationCodeFlowModel } from '../../types';
+import type { URLString } from '@fresha/api-tools-core';
+
+export class OAuthAuthorizationCodeFlow
+  extends OAuthFlowBase
+  implements OAuthAuthorizationCodeFlowModel
+{
+  #authorizationUrl: URLString;
+  #tokenUrl: URLString;
+
+  constructor(
+    parent: OAuthFlowParent,
+    authorizationUrl: URLString,
+    tokenUrl: URLString,
+    refreshUrl: URLString,
+  ) {
+    super(parent, refreshUrl);
+    this.#validateAuthorizationUrl(authorizationUrl);
+    this.#authorizationUrl = authorizationUrl;
+    this.#validateTokenUrl(tokenUrl);
+    this.#tokenUrl = tokenUrl;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  #validateAuthorizationUrl(value: URLString) {
+    assert(value, 'Authorisation URL cannot be empty');
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  #validateTokenUrl(value: URLString) {
+    assert(value, 'Token URL cannot be empty');
+  }
+
+  get authorizationUrl(): URLString {
+    return this.#authorizationUrl;
+  }
+
+  set authorizationUrl(value: URLString) {
+    this.#validateAuthorizationUrl(value);
+    this.#authorizationUrl = value;
+  }
+
+  get tokenUrl(): URLString {
+    return this.#tokenUrl;
+  }
+
+  set tokenUrl(value: URLString) {
+    this.#validateTokenUrl(value);
+    this.#tokenUrl = value;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/SecuritySchema/OAuthFlow/OAuthClientCredentialsFlow.ts
+++ b/packages/openapi-model/src/3.1.0/model/SecuritySchema/OAuthFlow/OAuthClientCredentialsFlow.ts
@@ -1,0 +1,33 @@
+import assert from 'assert';
+
+import { OAuthFlowBase, OAuthFlowParent } from './OAuthFlowBase';
+
+import type { OAuthClientCredentialsFlowModel } from '../../types';
+import type { URLString } from '@fresha/api-tools-core';
+
+export class OAuthClientCredentialsFlow
+  extends OAuthFlowBase
+  implements OAuthClientCredentialsFlowModel
+{
+  #tokenUrl: URLString;
+
+  constructor(parent: OAuthFlowParent, tokenUrl: URLString, refreshUrl: URLString) {
+    super(parent, refreshUrl);
+    this.#validateTokenUrl(tokenUrl);
+    this.#tokenUrl = tokenUrl;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  #validateTokenUrl(value: URLString) {
+    assert(value, 'Token URL cannot be empty');
+  }
+
+  get tokenUrl(): URLString {
+    return this.#tokenUrl;
+  }
+
+  set tokenUrl(value: URLString) {
+    this.#validateTokenUrl(value);
+    this.#tokenUrl = value;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/SecuritySchema/OAuthFlow/OAuthFlowBase.ts
+++ b/packages/openapi-model/src/3.1.0/model/SecuritySchema/OAuthFlow/OAuthFlowBase.ts
@@ -1,0 +1,64 @@
+import assert from 'assert';
+
+import { Node } from '../../Node';
+
+import type { OAuthFlows } from './OAuthFlows';
+import type { OAuthFlowModelBase } from '../../types';
+import type { URLString } from '@fresha/api-tools-core';
+
+export type OAuthFlowParent = OAuthFlows;
+
+export class OAuthFlowBase extends Node<OAuthFlowParent> implements OAuthFlowModelBase {
+  #refreshUrl: URLString;
+  readonly #scopes: Map<string, string>;
+
+  constructor(parent: OAuthFlowParent, refreshUrl: URLString) {
+    super(parent);
+    assert(refreshUrl, `refreshUrl must not be empty`);
+    this.#refreshUrl = refreshUrl;
+    this.#scopes = new Map<string, string>();
+  }
+
+  get refreshUrl(): URLString {
+    return this.#refreshUrl;
+  }
+
+  set refreshUrl(value: URLString) {
+    this.#refreshUrl = value;
+  }
+
+  get scopeCount(): number {
+    return this.#scopes.size;
+  }
+
+  scopeNames(): IterableIterator<string> {
+    return this.#scopes.keys();
+  }
+
+  scopes(): IterableIterator<[string, string]> {
+    return this.#scopes.entries();
+  }
+
+  hasScope(name: string): boolean {
+    return this.#scopes.has(name);
+  }
+
+  getScopeDescription(name: string): string {
+    const result = this.#scopes.get(name);
+    assert(result !== undefined, `There is no scope named '${name}'`);
+    return result;
+  }
+
+  addScope(name: string, description: string): void {
+    assert(!this.hasScope(name), `Scope '${name}' already exists`);
+    this.#scopes.set(name, description);
+  }
+
+  deleteScope(name: string): void {
+    this.#scopes.delete(name);
+  }
+
+  clearScopes(): void {
+    this.#scopes.clear();
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/SecuritySchema/OAuthFlow/OAuthFlows.ts
+++ b/packages/openapi-model/src/3.1.0/model/SecuritySchema/OAuthFlow/OAuthFlows.ts
@@ -1,0 +1,106 @@
+import assert from 'assert';
+
+import { Node } from '../../Node';
+
+import { OAuthAuthorizationCodeFlow } from './OAuthAuthorizationFlow';
+import { OAuthClientCredentialsFlow } from './OAuthClientCredentialsFlow';
+import { OAuthImplicitFlow } from './OAuthImplicitFlow';
+import { OAuthPasswordFlow } from './OAuthPasswordFlow';
+
+import type { OAuthFlowsModel } from '../../types';
+import type { OAuth2SecuritySchema } from '../OAuth2SecuritySchema';
+import type { Nullable, URLString } from '@fresha/api-tools-core';
+
+export type OAuthFlowsParent = OAuth2SecuritySchema;
+
+export class OAuthFlows extends Node<OAuthFlowsParent> implements OAuthFlowsModel {
+  #implicit: Nullable<OAuthImplicitFlow>;
+  #password: Nullable<OAuthPasswordFlow>;
+  #clientCredentials: Nullable<OAuthClientCredentialsFlow>;
+  #authorizationCode: Nullable<OAuthAuthorizationCodeFlow>;
+
+  constructor(parent: OAuthFlowsParent) {
+    super(parent);
+    this.#implicit = null;
+    this.#password = null;
+    this.#clientCredentials = null;
+    this.#authorizationCode = null;
+  }
+
+  get implicit(): Nullable<OAuthImplicitFlow> {
+    return this.#implicit;
+  }
+
+  addImplicitFlow(authorizationUrl: URLString, refreshUrl: URLString): OAuthImplicitFlow {
+    assert(!this.#implicit, 'Implicit flow is already set');
+    this.#implicit = new OAuthImplicitFlow(this, authorizationUrl, refreshUrl);
+    return this.#implicit;
+  }
+
+  deleteImplicitFlow(): void {
+    if (this.#implicit) {
+      this.#implicit.dispose();
+      this.#implicit = null;
+    }
+  }
+
+  get password(): Nullable<OAuthPasswordFlow> {
+    return this.#password;
+  }
+
+  addPasswordFlow(tokenUrl: URLString, refreshUrl: URLString): OAuthPasswordFlow {
+    assert(!this.#password, 'Password flow is already set');
+    this.#password = new OAuthPasswordFlow(this, tokenUrl, refreshUrl);
+    return this.#password;
+  }
+
+  deletePasswordFlow(): void {
+    if (this.#password) {
+      this.#password.dispose();
+      this.#password = null;
+    }
+  }
+
+  get clientCredentials(): Nullable<OAuthClientCredentialsFlow> {
+    return this.#clientCredentials;
+  }
+
+  addClientCredentialsFlow(tokenUrl: URLString, refreshUrl: URLString): OAuthClientCredentialsFlow {
+    assert(!this.#clientCredentials, 'Client credentials flow is already set');
+    this.#clientCredentials = new OAuthClientCredentialsFlow(this, tokenUrl, refreshUrl);
+    return this.#clientCredentials;
+  }
+
+  deleteClientCredentialsFlow(): void {
+    if (this.#clientCredentials) {
+      this.#clientCredentials.dispose();
+      this.#clientCredentials = null;
+    }
+  }
+
+  get authorizationCode(): Nullable<OAuthAuthorizationCodeFlow> {
+    return this.#authorizationCode;
+  }
+
+  addAuthorizationCodeFlow(
+    authorizationUrl: URLString,
+    tokenUrl: URLString,
+    refreshUrl: URLString,
+  ): OAuthAuthorizationCodeFlow {
+    assert(!this.#authorizationCode, 'Authorisation code flow is already set');
+    this.#authorizationCode = new OAuthAuthorizationCodeFlow(
+      this,
+      authorizationUrl,
+      tokenUrl,
+      refreshUrl,
+    );
+    return this.#authorizationCode;
+  }
+
+  deleteAuthorizationCodeFlow(): void {
+    if (this.#authorizationCode) {
+      this.#authorizationCode.dispose();
+      this.#authorizationCode = null;
+    }
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/SecuritySchema/OAuthFlow/OAuthImplicitFlow.ts
+++ b/packages/openapi-model/src/3.1.0/model/SecuritySchema/OAuthFlow/OAuthImplicitFlow.ts
@@ -1,0 +1,30 @@
+import assert from 'assert';
+
+import { OAuthFlowBase, OAuthFlowParent } from './OAuthFlowBase';
+
+import type { OAuthImplicitFlowModel } from '../../types';
+import type { URLString } from '@fresha/api-tools-core';
+
+export class OAuthImplicitFlow extends OAuthFlowBase implements OAuthImplicitFlowModel {
+  #authorizationUrl: URLString;
+
+  constructor(parent: OAuthFlowParent, authorizationUrl: URLString, refreshUrl: URLString) {
+    super(parent, refreshUrl);
+    this.#validateAuthorizationUrl(authorizationUrl);
+    this.#authorizationUrl = authorizationUrl;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  #validateAuthorizationUrl(value: URLString) {
+    assert(value, 'Authorisation URL cannot be empty');
+  }
+
+  get authorizationUrl(): URLString {
+    return this.#authorizationUrl;
+  }
+
+  set authorizationUrl(value: URLString) {
+    this.#validateAuthorizationUrl(value);
+    this.#authorizationUrl = value;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/SecuritySchema/OAuthFlow/OAuthPasswordFlow.ts
+++ b/packages/openapi-model/src/3.1.0/model/SecuritySchema/OAuthFlow/OAuthPasswordFlow.ts
@@ -1,0 +1,30 @@
+import assert from 'assert';
+
+import { OAuthFlowBase, OAuthFlowParent } from './OAuthFlowBase';
+
+import type { OAuthPasswordFlowModel } from '../../types';
+import type { URLString } from '@fresha/api-tools-core';
+
+export class OAuthPasswordFlow extends OAuthFlowBase implements OAuthPasswordFlowModel {
+  #tokenUrl: URLString;
+
+  constructor(parent: OAuthFlowParent, tokenUrl: URLString, refreshUrl: URLString) {
+    super(parent, refreshUrl);
+    this.#validateTokenUrl(tokenUrl);
+    this.#tokenUrl = tokenUrl;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  #validateTokenUrl(value: URLString) {
+    assert(value, 'Token URL cannot be empty');
+  }
+
+  get tokenUrl(): URLString {
+    return this.#tokenUrl;
+  }
+
+  set tokenUrl(value: URLString) {
+    this.#validateTokenUrl(value);
+    this.#tokenUrl = value;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/SecuritySchema/OpenIDConnectSecuritySchema.ts
+++ b/packages/openapi-model/src/3.1.0/model/SecuritySchema/OpenIDConnectSecuritySchema.ts
@@ -1,0 +1,32 @@
+import assert from 'assert';
+
+import { SecuritySchemaBase, SecuritySchemaParent } from './SecuritySchemaBase';
+
+import type { OpenIDConnectSecuritySchemaModel } from '../types';
+import type { URLString } from '@fresha/api-tools-core';
+
+export class OpenIDConnectSecuritySchema
+  extends SecuritySchemaBase
+  implements OpenIDConnectSecuritySchemaModel
+{
+  #connectUrl: URLString;
+
+  constructor(parent: SecuritySchemaParent, connectUrl: URLString) {
+    super(parent);
+    this.#connectUrl = connectUrl;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  get type(): 'openIdConnect' {
+    return 'openIdConnect';
+  }
+
+  get connectUrl(): URLString {
+    return this.#connectUrl;
+  }
+
+  set connectUrl(value: URLString) {
+    assert(value, 'Connect URL for an OpenIDConnect schema cannot be empty');
+    this.#connectUrl = value;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/SecuritySchema/SecuritySchemaBase.ts
+++ b/packages/openapi-model/src/3.1.0/model/SecuritySchema/SecuritySchemaBase.ts
@@ -1,0 +1,27 @@
+import { Node } from '../Node';
+
+import type { Components } from '../Components';
+import type { SecuritySchemaModelBase } from '../types';
+import type { CommonMarkString, Nullable } from '@fresha/api-tools-core';
+
+export type SecuritySchemaParent = Components;
+
+export class SecuritySchemaBase
+  extends Node<SecuritySchemaParent>
+  implements SecuritySchemaModelBase
+{
+  #description: Nullable<CommonMarkString>;
+
+  constructor(parent: SecuritySchemaParent) {
+    super(parent);
+    this.#description = null;
+  }
+
+  get description(): Nullable<CommonMarkString> {
+    return this.#description;
+  }
+
+  set description(value: Nullable<CommonMarkString>) {
+    this.#description = value;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/SecuritySchema/index.ts
+++ b/packages/openapi-model/src/3.1.0/model/SecuritySchema/index.ts
@@ -1,0 +1,20 @@
+import { APIKeySecuritySchema } from './APIKeySecuritySchema';
+import { HTTPSecuritySchema } from './HTTPSecuritySchema';
+import { MutualTLSSecuritySchema } from './MutualTLSSecuritySchema';
+import { OAuth2SecuritySchema } from './OAuth2SecuritySchema';
+import { OpenIDConnectSecuritySchema } from './OpenIDConnectSecuritySchema';
+
+export type SecuritySchema =
+  | APIKeySecuritySchema
+  | HTTPSecuritySchema
+  | MutualTLSSecuritySchema
+  | OAuth2SecuritySchema
+  | OpenIDConnectSecuritySchema;
+
+export {
+  APIKeySecuritySchema,
+  HTTPSecuritySchema,
+  MutualTLSSecuritySchema,
+  OAuth2SecuritySchema,
+  OpenIDConnectSecuritySchema,
+};

--- a/packages/openapi-model/src/3.1.0/model/Server.ts
+++ b/packages/openapi-model/src/3.1.0/model/Server.ts
@@ -1,0 +1,87 @@
+import assert from 'assert';
+
+import { Node } from './Node';
+import { OpenAPI } from './OpenAPI';
+import { PathItem } from './PathItem';
+import { ServerVariable } from './ServerVariable';
+
+import type { Operation } from './Operation';
+import type { ServerModel } from './types';
+import type { CommonMarkString, Nullable } from '@fresha/api-tools-core';
+
+type ServerParent = OpenAPI | PathItem | Operation;
+
+export class Server extends Node<ServerParent> implements ServerModel {
+  #url: string;
+  #description: Nullable<CommonMarkString>;
+  readonly #variables: Map<string, ServerVariable>;
+
+  constructor(parent: ServerParent, url: string) {
+    super(parent);
+    this.#url = url;
+    this.#description = null;
+    this.#variables = new Map<string, ServerVariable>();
+    this.#syncVariables();
+  }
+
+  get url(): string {
+    return this.#url;
+  }
+
+  set url(value: string) {
+    if (this.#url !== value) {
+      this.#url = value;
+      this.#syncVariables();
+    }
+  }
+
+  #syncVariables(): void {
+    const newVarNames = (this.#url.match(/\{.+?\}/g) || []).map(elem => elem.slice(1, -1));
+    assert(
+      newVarNames.every(s => !!s),
+      `Server URL has empty variable names ${this.#url}`,
+    );
+
+    for (const [name, variable] of this.#variables) {
+      if (!newVarNames.includes(name)) {
+        variable.dispose();
+        this.#variables.delete(name);
+      }
+    }
+    for (const newName of newVarNames) {
+      if (!this.#variables.has(newName)) {
+        this.#variables.set(newName, new ServerVariable(this));
+      }
+    }
+  }
+
+  get description(): Nullable<CommonMarkString> {
+    return this.#description;
+  }
+
+  set description(value: Nullable<CommonMarkString>) {
+    this.#description = value;
+  }
+
+  get variableCount(): number {
+    return this.#variables.size;
+  }
+
+  variables(): IterableIterator<ServerVariable> {
+    return this.#variables.values();
+  }
+
+  variableNames(): IterableIterator<string> {
+    return this.#variables.keys();
+  }
+
+  hasVariable(name: string): boolean {
+    return this.#variables.has(name);
+  }
+
+  getVariable(name: string): ServerVariable {
+    const result = this.#variables.get(name);
+    assert(result, `Cannot find variable '${name}'`);
+    return result;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/ServerVariable.ts
+++ b/packages/openapi-model/src/3.1.0/model/ServerVariable.ts
@@ -1,0 +1,67 @@
+import assert from 'assert';
+
+import { Node } from './Node';
+import { Server } from './Server';
+
+import type { ServerVariableModel } from './types';
+import type { CommonMarkString, Nullable } from '@fresha/api-tools-core';
+
+export class ServerVariable extends Node<Server> implements ServerVariableModel {
+  readonly #allowedValues: Set<string>;
+  #defaultValue: string;
+  #description: Nullable<CommonMarkString>;
+
+  constructor(parent: Server) {
+    super(parent);
+    this.#allowedValues = new Set<string>();
+    this.#defaultValue = '';
+    this.#description = null;
+  }
+
+  get allowedValueCount(): number {
+    return this.#allowedValues.size;
+  }
+
+  allowedValues(): IterableIterator<string> {
+    return this.#allowedValues.values();
+  }
+
+  hasAllowedValue(value: string): boolean {
+    return this.#allowedValues.has(value);
+  }
+
+  addAllowedValue(value: string): void {
+    this.#allowedValues.add(value);
+  }
+
+  removeAllowedValue(value: string): void {
+    this.#allowedValues.delete(value);
+    if (this.#allowedValues.size && this.#defaultValue === value) {
+      this.#defaultValue = '';
+    }
+  }
+
+  clearAllowedValues(): void {
+    this.#allowedValues.clear();
+  }
+
+  get defaultValue(): string {
+    return this.#defaultValue;
+  }
+
+  set defaultValue(value: string) {
+    assert(
+      !this.#allowedValues.size || this.#allowedValues.has(value),
+      'Default value must also be among allowed values',
+    );
+    this.#defaultValue = value;
+  }
+
+  get description(): Nullable<CommonMarkString> {
+    return this.#description;
+  }
+
+  set description(value: Nullable<CommonMarkString>) {
+    this.#description = value;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/Tag.ts
+++ b/packages/openapi-model/src/3.1.0/model/Tag.ts
@@ -1,0 +1,56 @@
+import assert from 'assert';
+
+import { ExternalDocumentation } from './ExternalDocumentation';
+import { Node } from './Node';
+
+import type { OpenAPI } from './OpenAPI';
+import type { TagModel } from './types';
+import type { CommonMarkString, Nullable, URLString } from '@fresha/api-tools-core';
+
+type TagParent = OpenAPI;
+
+export class Tag extends Node<TagParent> implements TagModel {
+  #name: string;
+  #description: Nullable<CommonMarkString>;
+  #externalDocs: Nullable<ExternalDocumentation>;
+
+  constructor(parent: TagParent, name: string) {
+    super(parent);
+    this.#name = name;
+    this.#description = null;
+    this.#externalDocs = null;
+  }
+
+  get name(): string {
+    return this.#name;
+  }
+
+  set name(value: string) {
+    this.#name = value;
+  }
+
+  get description(): Nullable<CommonMarkString> {
+    return this.#description;
+  }
+
+  set description(value: Nullable<CommonMarkString>) {
+    this.#description = value;
+  }
+
+  get externalDocs(): Nullable<ExternalDocumentation> {
+    return this.#externalDocs;
+  }
+
+  addExternalDocs(url: URLString): ExternalDocumentation {
+    assert(!this.#externalDocs, 'External documentation is already set');
+    this.#externalDocs = new ExternalDocumentation(this, url);
+    return this.#externalDocs;
+  }
+
+  deleteExternalDocs(): void {
+    if (this.#externalDocs) {
+      this.#externalDocs.dispose();
+      this.#externalDocs = null;
+    }
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/XML.ts
+++ b/packages/openapi-model/src/3.1.0/model/XML.ts
@@ -1,0 +1,65 @@
+import { Nullable } from '@fresha/api-tools-core';
+
+import { Node } from './Node';
+
+import type { Schema } from './Schema';
+import type { XMLModel } from './types';
+
+export type XMLParent = Schema;
+
+export class XML extends Node<XMLParent> implements XMLModel {
+  #name: Nullable<string>;
+  #namespace: Nullable<string>;
+  #prefix: Nullable<string>;
+  #attribute: boolean;
+  #wrapped: boolean;
+
+  constructor(parent: XMLParent) {
+    super(parent);
+    this.#name = null;
+    this.#namespace = null;
+    this.#prefix = null;
+    this.#attribute = false;
+    this.#wrapped = false;
+  }
+
+  get name(): Nullable<string> {
+    return this.#name;
+  }
+
+  set name(value: Nullable<string>) {
+    this.#name = value;
+  }
+
+  get namespace(): Nullable<string> {
+    return this.#namespace;
+  }
+
+  set namespace(value: Nullable<string>) {
+    this.#namespace = value;
+  }
+
+  get prefix(): Nullable<string> {
+    return this.#prefix;
+  }
+
+  set prefix(value: Nullable<string>) {
+    this.#prefix = value;
+  }
+
+  get attribute(): boolean {
+    return this.#attribute;
+  }
+
+  set attribute(value: boolean) {
+    this.#attribute = value;
+  }
+
+  get wrapped(): boolean {
+    return this.#wrapped;
+  }
+
+  set wrapped(value: boolean) {
+    this.#wrapped = value;
+  }
+}

--- a/packages/openapi-model/src/3.1.0/model/index.ts
+++ b/packages/openapi-model/src/3.1.0/model/index.ts
@@ -1,0 +1,4 @@
+export * from './types';
+export { OpenAPIFactory } from './OpenAPI';
+export { OpenAPIReader } from './OpenAPIReader';
+export { OpenAPIWriter } from './OpenAPIWriter';

--- a/packages/openapi-model/src/3.1.0/model/types.ts
+++ b/packages/openapi-model/src/3.1.0/model/types.ts
@@ -1,0 +1,1028 @@
+import {
+  CookieParameterSerializationStyle,
+  HeaderParameterSerializationStyle,
+  PathParameterSerializationStyle,
+  QueryParameterSerializationStyle,
+} from '../../baseTypes';
+
+import type {
+  CommonMarkString,
+  HTTPStatusCode,
+  JSONValue,
+  MIMETypeString,
+  Nullable,
+  ParametrisedURLString,
+  URLString,
+} from '@fresha/api-tools-core';
+
+export type ExtensionFields = ReadonlyMap<string, JSONValue>;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#specification-extensions
+ */
+export interface SpecificationExtensionsModel {
+  readonly extensionCount: number;
+  extensions(): IterableIterator<[string, JSONValue]>;
+  extensionKeys(): IterableIterator<string>;
+  hasExtension(key: string): boolean;
+  getExtension(key: string): JSONValue;
+  setExtension(key: string, value: JSONValue): void;
+  deleteExtension(key: string): void;
+  clearExtensions(): void;
+}
+
+export interface OpenAPIModelFactory {
+  create(): OpenAPIModel;
+  create(title: string, version: string): OpenAPIModel;
+}
+
+export type OpenAPIVersion = '3.1.0';
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#openapi-object
+ */
+export interface OpenAPIModel extends SpecificationExtensionsModel {
+  readonly root: OpenAPIModel;
+  readonly openapi: OpenAPIVersion;
+  readonly info: InfoModel;
+  readonly jsonSchemaDialect: string;
+
+  readonly serverCount: number;
+  servers(): IterableIterator<ServerModel>;
+  serverAt(index: number): ServerModel;
+  addServer(url: string): ServerModel;
+  removeServerAt(index: number): void;
+  clearServers(): void;
+
+  readonly paths: PathsModel;
+
+  readonly webhookCount: number;
+  webhookKeys(): IterableIterator<string>;
+  webhooks(): IterableIterator<[string, PathItemModel]>;
+  hasWebhook(key: string): boolean;
+  getWebhook(key: string): PathItemModel;
+  addWebhook(key: string): PathItemModel;
+  removeWebhook(key: string): void;
+  clearWebhooks(): void;
+
+  readonly components: ComponentsModel;
+
+  readonly securityRequirementCount: number;
+  securityRequirements(): IterableIterator<SecurityRequirementModel>;
+  securityRequirementAt(index: number): SecurityRequirementModel;
+  addSecurityRequirement(): SecurityRequirementModel;
+  deleteSecurityRequirementAt(index: number): void;
+  clearSecurityRequirements(): void;
+
+  readonly tagCount: number;
+  tags(): IterableIterator<TagModel>;
+  tagAt(index: number): TagModel;
+  hasTag(name: string): boolean;
+  addTag(name: string): TagModel;
+  deleteTagAt(index: number): void;
+  clearTags(): void;
+
+  readonly externalDocs: Nullable<ExternalDocumentationModel>;
+  addExternalDocs(url: string): ExternalDocumentationModel;
+  deleteExternalDocs(): void;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#info-object
+ */
+export interface InfoModel extends SpecificationExtensionsModel {
+  title: string;
+  description: Nullable<CommonMarkString>;
+  termsOfService: Nullable<string>;
+  readonly contact: ContactModel;
+  readonly license: LicenseModel;
+  version: string;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#contact-object
+ */
+export interface ContactModel extends SpecificationExtensionsModel {
+  name: Nullable<string>;
+  url: Nullable<string>;
+  email: Nullable<string>;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#license-object
+ */
+export interface LicenseModel extends SpecificationExtensionsModel {
+  name: string;
+  url: Nullable<string>;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#server-object
+ */
+export interface ServerModel extends SpecificationExtensionsModel {
+  url: string;
+  description: Nullable<CommonMarkString>;
+
+  readonly variableCount: number;
+  variables(): IterableIterator<ServerVariableModel>;
+  variableNames(): IterableIterator<string>;
+  hasVariable(name: string): boolean;
+  getVariable(name: string): ServerVariableModel;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#server-variable-object
+ */
+export interface ServerVariableModel extends SpecificationExtensionsModel {
+  readonly allowedValueCount: number;
+  allowedValues(): IterableIterator<string>;
+  hasAllowedValue(value: string): boolean;
+  addAllowedValue(value: string): void;
+  removeAllowedValue(value: string): void;
+  clearAllowedValues(): void;
+
+  defaultValue: string;
+  description: Nullable<CommonMarkString>;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#paths-object
+ */
+export interface PathsModel extends SpecificationExtensionsModel {
+  readonly itemCount: number;
+  itemUrls(): IterableIterator<ParametrisedURLString>;
+  items(): IterableIterator<[ParametrisedURLString, PathItemModel]>;
+  hasItem(url: ParametrisedURLString): boolean;
+  addItem(url: ParametrisedURLString): PathItemModel;
+  removeItem(url: ParametrisedURLString): void;
+  clearItems(): void;
+}
+
+export type PathItemOperationMethod =
+  | 'get'
+  | 'put'
+  | 'post'
+  | 'delete'
+  | 'options'
+  | 'head'
+  | 'patch'
+  | 'trace';
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#path-item-object
+ */
+export interface PathItemModel extends SpecificationExtensionsModel {
+  summary: Nullable<string>;
+  description: Nullable<CommonMarkString>;
+
+  readonly operationCount: number;
+  operationMethods(): IterableIterator<PathItemOperationMethod>;
+  operations(): IterableIterator<[PathItemOperationMethod, OperationModel]>;
+  hasOperation(method: PathItemOperationMethod): boolean;
+  getOperation(method: PathItemOperationMethod): OperationModel;
+  addOperation(method: PathItemOperationMethod): OperationModel;
+  removeOperation(method: PathItemOperationMethod): void;
+  clearOperations(): void;
+
+  readonly serverCount: number;
+  servers(): IterableIterator<ServerModel>;
+  serverAt(index: number): ServerModel;
+  addServer(url: string): ServerModel;
+  removeServerAt(index: number): void;
+  clearServers(): void;
+
+  readonly parameterCount: number;
+  parameters(): IterableIterator<ParameterModel>;
+  parameterAt(index: number): ParameterModel;
+  removeParameterAt(index: number): void;
+  hasParameter(name: string, location?: ParameterLocation): boolean;
+  getParameter(name: string, location?: ParameterLocation): ParameterModel;
+  addParameter(name: string, location: 'path'): PathParameterModel;
+  addParameter(name: string, location: 'query'): QueryParameterModel;
+  addParameter(name: string, location: 'header'): HeaderParameterModel;
+  addParameter(name: string, location: 'cookie'): CookieParameterModel;
+  removeParameter(name: string, location?: ParameterLocation): void;
+  clearParameters(): void;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#parameter-object
+ */
+export interface ParameterModelBase extends SpecificationExtensionsModel {
+  description: Nullable<CommonMarkString>;
+  deprecated: boolean;
+  explode: boolean;
+
+  readonly schema: Nullable<SchemaModel>;
+  addSchema(): SchemaModel;
+  deleteSchema(): void;
+
+  readonly exampleCount: number;
+  exampleKeys(): IterableIterator<string>;
+  examples(): IterableIterator<[string, ExampleModel]>;
+  hasExample(key: string): boolean;
+  addExample(key: string): ExampleModel;
+  deleteExample(key: string): void;
+  clearExamples(): void;
+
+  readonly mediaTypeCount: number;
+  mediaTypeKeys(): IterableIterator<MIMETypeString>;
+  mediaTypes(): IterableIterator<[MIMETypeString, MediaTypeModel]>;
+  hasMediaType(mediaType: MIMETypeString): boolean;
+  addMediaType(mediaType: MIMETypeString): MediaTypeModel;
+  deleteMediaType(mediaType: MIMETypeString): void;
+  clearMediaTypes(): void;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#parameter-object
+ */
+export interface PathParameterModel extends ParameterModelBase {
+  readonly in: 'path';
+  readonly name: string;
+  readonly required: true;
+  style: PathParameterSerializationStyle;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#parameter-object
+ */
+export interface QueryParameterModel extends ParameterModelBase {
+  readonly in: 'query';
+  name: string;
+  required: boolean;
+  allowEmptyValue: boolean;
+  style: QueryParameterSerializationStyle;
+  allowReserved: boolean;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#parameter-object
+ */
+export interface HeaderParameterModel extends ParameterModelBase {
+  readonly in: 'header';
+  name: string;
+  required: boolean;
+  style: HeaderParameterSerializationStyle;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#parameter-object
+ */
+export interface CookieParameterModel extends ParameterModelBase {
+  readonly in: 'cookie';
+  name: string;
+  required: boolean;
+  style: CookieParameterSerializationStyle;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#parameter-object
+ */
+export type ParameterModel =
+  | PathParameterModel
+  | QueryParameterModel
+  | HeaderParameterModel
+  | CookieParameterModel;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#parameter-object
+ */
+export type ParameterLocation = ParameterModel['in'];
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#media-type-object
+ */
+export interface MediaTypeModel extends SpecificationExtensionsModel {
+  readonly schema: Nullable<SchemaModel>;
+  addSchema(): SchemaModel;
+  deleteSchema(): void;
+
+  readonly exampleCount: number;
+  exampleKeys(): IterableIterator<string>;
+  examples(): IterableIterator<[string, ExampleModel]>;
+  hasExample(key: string): boolean;
+  addExample(key: string): ExampleModel;
+  deleteExample(key: string): void;
+  clearExamples(): void;
+
+  readonly encodingCount: number;
+  encodingKeys(): IterableIterator<string>;
+  encodings(): IterableIterator<[string, EncodingModel]>;
+  hasEncoding(key: string): boolean;
+  addEncoding(key: string): EncodingModel;
+  deleteEncoding(key: string): void;
+  clearEncodings(): void;
+}
+
+export type EncodingSerializationStyle = 'form' | 'spaceDelimited' | 'pipeDelimited' | 'deepObject';
+
+/**
+ * @see https://spec.openapis.org/oas/v3.0.3#encoding-object
+ */
+export interface EncodingModel extends SpecificationExtensionsModel {
+  contentType: Nullable<string>;
+
+  readonly headerCount: number;
+  headerNames(): IterableIterator<string>;
+  headers(): IterableIterator<[string, HeaderModel]>;
+  hasHeader(name: string): boolean;
+  addHeader(name: string): HeaderModel;
+  deleteHeader(name: string): void;
+  clearHeaders(): void;
+
+  style: Nullable<EncodingSerializationStyle>;
+  explode: boolean;
+  allowReserved: boolean;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#operation-object
+ */
+export interface OperationModel extends SpecificationExtensionsModel {
+  readonly tagCount: number;
+  tagNames(): IterableIterator<string>;
+  tags(): IterableIterator<TagModel>;
+  tagAt(index: number): TagModel;
+  removeTagAt(index: number): void;
+  hasTag(name: string): boolean;
+  addTag(name: string): void;
+  removeTag(name: string): void;
+  clearTags(): void;
+
+  summary: Nullable<string>;
+  description: Nullable<CommonMarkString>;
+
+  readonly externalDocs: Nullable<ExternalDocumentationModel>;
+  addExternalDocs(url: URLString): ExternalDocumentationModel;
+  deleteExternalDocs(): void;
+
+  operationId: Nullable<string>;
+
+  readonly parameterCount: number;
+  parameters(): IterableIterator<ParameterModel>;
+  parameterAt(index: number): ParameterModel;
+  removeParameterAt(index: number): void;
+  hasParameter(name: string, location?: ParameterLocation): boolean;
+  getParameter(name: string, location?: ParameterLocation): ParameterModel;
+  addParameter(name: string, location: 'path'): PathParameterModel;
+  addParameter(name: string, location: 'query'): QueryParameterModel;
+  addParameter(name: string, location: 'header'): HeaderParameterModel;
+  addParameter(name: string, location: 'cookie'): CookieParameterModel;
+  removeParameter(name: string, location?: ParameterLocation): void;
+  clearParameters(): void;
+
+  readonly requestBody: Nullable<RequestBodyModel>;
+  addRequestBody(): RequestBodyModel;
+  deleteRequestBody(): void;
+
+  readonly responses: ResponsesModel;
+
+  readonly callbackCount: number;
+  callbackKeys(): IterableIterator<string>;
+  callbacks(): IterableIterator<[string, CallbackModel]>;
+  hasCallback(key: string): boolean;
+  getCallback(key: string): CallbackModel;
+  addCallback(key: string): CallbackModel;
+  deleteCallback(key: string): void;
+  clearCallbacks(): void;
+
+  deprecated: boolean;
+
+  readonly securityRequirementCount: number;
+  securityRequirements(): IterableIterator<SecurityRequirementModel>;
+  securityRequirementAt(index: number): SecurityRequirementModel;
+  addSecurityRequirement(): SecurityRequirementModel;
+  deleteSecurityRequirementAt(index: number): void;
+  clearSecurityRequirements(): void;
+
+  readonly serverCount: number;
+  servers(): IterableIterator<ServerModel>;
+  serverAt(index: number): ServerModel;
+  hasServer(url: string): boolean;
+  addServer(url: string): ServerModel;
+  removeServerAt(index: number): void;
+  clearServers(): void;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#sequrity-requirement-object
+ */
+export interface SecurityRequirementModel extends SpecificationExtensionsModel {
+  readonly schemaCount: number;
+  schemas(): IterableIterator<SecuritySchemaModel>;
+  scopeCount(schema: SecuritySchemaModel): number;
+  scopes(schema: SecuritySchemaModel): IterableIterator<string>;
+  hasScope(schema: SecuritySchemaModel): boolean;
+  addScope(schema: SecuritySchemaModel, scope: string): void;
+  deleteScope(schema: SecuritySchemaModel, scope: string): void;
+  clearScopes(schema: SecuritySchemaModel): void;
+  clearAllScopes(): void;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#tag-object
+ */
+export interface TagModel extends SpecificationExtensionsModel {
+  name: string;
+  description: Nullable<CommonMarkString>;
+
+  readonly externalDocs: Nullable<ExternalDocumentationModel>;
+  addExternalDocs(url: URLString): ExternalDocumentationModel;
+  deleteExternalDocs(): void;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#external-documentation-object
+ */
+export interface ExternalDocumentationModel extends SpecificationExtensionsModel {
+  url: URLString;
+  description: Nullable<CommonMarkString>;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#request-body-object
+ */
+export interface RequestBodyModel extends SpecificationExtensionsModel {
+  description: Nullable<CommonMarkString>;
+
+  readonly mediaTypeCount: number;
+  mediaTypeKeys(): IterableIterator<MIMETypeString>;
+  mediaTypes(): IterableIterator<[MIMETypeString, MediaTypeModel]>;
+  hasMediaType(mediaType: MIMETypeString): boolean;
+  addMediaType(mediaType: MIMETypeString): MediaTypeModel;
+  deleteMediaType(mediaType: MIMETypeString): void;
+  clearMediaTypes(): void;
+
+  required: boolean;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#components-object
+ */
+export interface ResponsesModel extends SpecificationExtensionsModel {
+  readonly defaultResponse: Nullable<ResponseModel>;
+  addDefaultResponse(description: CommonMarkString): ResponseModel;
+  deleteDefaultResponse(): void;
+
+  readonly responseCount: number;
+  responseCodes(): IterableIterator<HTTPStatusCode>;
+  responses(): IterableIterator<[HTTPStatusCode, ResponseModel]>;
+  hasResponse(code: HTTPStatusCode): boolean;
+  getResponse(code: HTTPStatusCode): ResponseModel;
+  addResponse(code: HTTPStatusCode, description: CommonMarkString): ResponseModel;
+  deleteResponse(code: HTTPStatusCode): void;
+  clearResponses(): void;
+}
+
+export type CallbackModel = SpecificationExtensionsModel;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#components-object
+ */
+export interface ComponentsModel extends SpecificationExtensionsModel {
+  readonly schemaCount: number;
+  schemaKeys(): IterableIterator<string>;
+  schemas(): IterableIterator<[string, SchemaModel]>;
+  hasSchema(key: string): boolean;
+  addSchema(key: string): SchemaModel;
+  deleteSchema(key: string): void;
+  clearSchemas(): void;
+
+  readonly responseCount: number;
+  responseKeys(): IterableIterator<string>;
+  responses(): IterableIterator<[string, ResponseModel]>;
+  hasResponse(key: string): boolean;
+  addResponse(key: string, description: CommonMarkString): ResponseModel;
+  deleteResponse(key: string): void;
+  clearResponse(): void;
+
+  readonly parameterCount: number;
+  parameterKeys(): IterableIterator<string>;
+  parameters(): IterableIterator<[string, ParameterModel]>;
+  hasParameter(key: string): boolean;
+  addParameter(key: string, name: string, location: 'path'): PathParameterModel;
+  addParameter(key: string, name: string, location: 'query'): QueryParameterModel;
+  addParameter(key: string, name: string, location: 'header'): HeaderParameterModel;
+  addParameter(key: string, name: string, location: 'cookie'): CookieParameterModel;
+  deleteParameter(key: string): void;
+  clearParameters(): void;
+
+  readonly exampleCount: number;
+  exampleKeys(): IterableIterator<string>;
+  examples(): IterableIterator<[string, ExampleModel]>;
+  hasExample(key: string): boolean;
+  addExample(key: string): ExampleModel;
+  deleteExample(key: string): void;
+  clearExamples(): void;
+
+  readonly requestBodyCount: number;
+  requestBodyKeys(): IterableIterator<string>;
+  requestBodies(): IterableIterator<[string, RequestBodyModel]>;
+  hasRequestBody(key: string): boolean;
+  addRequestBody(key: string): RequestBodyModel;
+  deleteRequestBody(key: string): void;
+  clearRequestBodies(): void;
+
+  readonly headerCount: number;
+  headerKeys(): IterableIterator<string>;
+  headers(): IterableIterator<[string, HeaderModel]>;
+  hasHeader(key: string): boolean;
+  addHeader(key: string): HeaderModel;
+  deleteHeader(key: string): void;
+  clearHeaders(): void;
+
+  readonly securitySchemaCount: number;
+  securitySchemaKeys(): IterableIterator<string>;
+  securitySchemas(): IterableIterator<[string, SecuritySchemaModel]>;
+  hasSecuritySchema(key: string): boolean;
+  addSecuritySchema(
+    key: string,
+    type: 'apiKey',
+    name: string,
+    location: APIKeySecuritySchemaLocation,
+  ): APIKeySecuritySchemaModel;
+  addSecuritySchema(key: string, type: 'http'): HTTPSecuritySchemaModel;
+  addSecuritySchema(key: string, type: 'mutualTLS'): MutualTLSSecuritySchemaModel;
+  addSecuritySchema(key: string, type: 'oauth2'): OAuth2SecuritySchemaModel;
+  addSecuritySchema(
+    key: string,
+    type: 'openIdConnect',
+    connectUrl: URLString,
+  ): OpenIDConnectSecuritySchemaModel;
+  deleteSecuritySchema(key: string): void;
+  clearSecuritySchemas(): void;
+
+  readonly linkCount: number;
+  linkKeys(): IterableIterator<string>;
+  links(): IterableIterator<[string, LinkModel]>;
+  hasLink(key: string): boolean;
+  addLink(key: string): LinkModel;
+  deleteLink(key: string): void;
+  clearLinks(): void;
+
+  readonly callbackCount: number;
+  callbackKeys(): IterableIterator<string>;
+  callbacks(): IterableIterator<[string, CallbackModel]>;
+  hasCallback(key: string): boolean;
+  addCallback(key: string): CallbackModel;
+  deleteCallback(key: string): void;
+  clearCallbacks(): void;
+
+  readonly pathItemCount: number;
+  pathItemKeys(): IterableIterator<string>;
+  pathItems(): IterableIterator<[string, PathItemModel]>;
+  hasPathItem(key: string): boolean;
+  addPathItem(key: string): PathItemModel;
+  deletePathItem(key: string): void;
+  clearPathItems(): void;
+}
+
+export type SchemaType = 'null' | 'boolean' | 'integer' | 'number' | 'string' | 'object' | 'array';
+
+export type SchemaFormat =
+  // JSON Schema formats
+  | 'date-time'
+  | 'time'
+  | 'date'
+  | 'duration'
+  | 'email'
+  | 'idn-email'
+  | 'hostname'
+  | 'idn-hostname'
+  | 'ipv4'
+  | 'ipv6'
+  | 'uuid'
+  | 'uri'
+  | 'uri-reference'
+  | 'iri'
+  | 'iri-reference'
+  | 'uri-template'
+  | 'json-pointer'
+  | 'relative-json-pointer'
+  | 'regex'
+  // OpenAPI formats
+  | 'int32'
+  | 'int64'
+  | 'float'
+  | 'double'
+  | 'byte'
+  | 'binary'
+  | 'password';
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#schema-object
+ */
+export interface SchemaModel extends SpecificationExtensionsModel {
+  title: Nullable<string>;
+  description: Nullable<CommonMarkString>;
+  defaultValue: JSONValue | undefined;
+
+  readonly exampleCount: number;
+  examples(): IterableIterator<JSONValue>;
+  exampleAt(index: number): JSONValue;
+  deleteExampleAt(index: number): void;
+  clearExamples(): void;
+
+  readonly typeCount: number;
+  types(): IterableIterator<SchemaType>;
+  hasType(value: SchemaType): boolean;
+  addType(value: SchemaType): void;
+  deleteType(value: SchemaType): void;
+  clearTypes(): void;
+
+  format: Nullable<SchemaFormat>;
+
+  readonly allowedValueCount: number;
+  allowedValues(): IterableIterator<JSONValue>;
+  hasAllowedValue(value: JSONValue): boolean;
+  addAllowedValue(value: JSONValue): void;
+  removeAllowedValue(value: JSONValue): void;
+  clearAllowedValues(): void;
+
+  minLength: Nullable<number>;
+  maxLength: Nullable<number>;
+  pattern: Nullable<string>;
+
+  minimum: Nullable<number>;
+  exclusiveMinimum: Nullable<number>;
+  maximum: Nullable<number>;
+  exclusiveMaximum: Nullable<number>;
+  multipleOf: Nullable<number>;
+
+  readonly propertyCount: number;
+  propertyNames(): IterableIterator<string>;
+  properties(): IterableIterator<[string, SchemaModel]>;
+  hasProperty(name: string): boolean;
+  getProperty(name: string): SchemaModel;
+  addProperty(name: string): SchemaModel;
+  deleteProperty(name: string): void;
+  clearProperties(): void;
+
+  minProperties: Nullable<number>;
+  maxProperties: Nullable<number>;
+
+  readonly patternPropertyCount: number;
+  patternPropertyNames(): IterableIterator<string>;
+  patternProperties(): IterableIterator<[string, SchemaModel]>;
+  hasPatternProperty(name: string): boolean;
+  getPatternProperty(name: string): SchemaModel;
+  addPatternProperty(name: string): SchemaModel;
+  deletePatternProperty(name: string): void;
+  clearPatternProperties(): void;
+
+  additionalProperties: SchemaModel | false;
+  addAdditionalProperties(): SchemaModel;
+  disableAdditionalProperties(): void;
+
+  requiredPropertyNames(): IterableIterator<string>;
+  requiredProperties(): IterableIterator<[string, SchemaModel]>;
+  isPropertyRequired(name: string): boolean;
+  setPropertyRequired(name: string, value: boolean): void;
+
+  readonly propertyNamesSchema: Nullable<SchemaModel>;
+  addPropertyNamesSchema(): SchemaModel;
+  deletePropertyNamesSchema(): void;
+
+  readonly items: Nullable<SchemaModel>;
+  addItems(): SchemaModel;
+  deleteItems(): void;
+
+  minItems: Nullable<number>;
+  maxItems: Nullable<number>;
+  uniqueItems: boolean;
+
+  readonly containsSchema: Nullable<SchemaModel>;
+  addContainsSchema(): SchemaModel;
+  deleteContainsSchema(): void;
+
+  minContains: Nullable<number>;
+  maxContains: Nullable<number>;
+
+  readonly prefixItemsCount: number;
+  prefixItemsAt(index: number): SchemaModel;
+  addPrefixItem(): SchemaModel;
+  deletePrefixItemAt(index: number): void;
+  clearPrefixItems(): void;
+
+  readonly allOfCount: number;
+  allOf(): IterableIterator<SchemaModel>;
+  allOfAt(index: number): SchemaModel;
+  addAllOf(): SchemaModel;
+  deleteAllOfAt(index: number): void;
+  clearAllOf(): void;
+
+  readonly anyOfCount: number;
+  anyOf(): IterableIterator<SchemaModel>;
+  anyOfAt(index: number): SchemaModel;
+  addAnyOf(): SchemaModel;
+  deleteAnyOfAt(index: number): void;
+  clearAnyOf(): void;
+
+  readonly oneOfCount: number;
+  oneOf(): IterableIterator<SchemaModel>;
+  oneOfAt(index: number): SchemaModel;
+  addOneOf(): SchemaModel;
+  deleteOneOfAt(index: number): void;
+  clearOneOf(): void;
+
+  readonly not: Nullable<SchemaModel>;
+  addNot(): SchemaModel;
+  deleteNot(): void;
+
+  readonly discriminator: Nullable<DiscriminatorModel>;
+  addDiscriminator(propertyName: string): DiscriminatorModel;
+  deleteDiscriminator(): void;
+
+  readonly xml: Nullable<XMLModel>;
+  addXML(): XMLModel;
+  deleteXML(): void;
+
+  readonly externalDocs: Nullable<ExternalDocumentationModel>;
+  addExternalDocs(url: URLString): ExternalDocumentationModel;
+  deleteExternalDocs(): void;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#discriminator-object
+ */
+export interface DiscriminatorModel extends SpecificationExtensionsModel {
+  propertyName: string;
+
+  readonly mappingCount: number;
+  mapping(): IterableIterator<[string, string]>;
+  hasMapping(key: string): boolean;
+  addMapping(key: string, value: string): void;
+  deleteMapping(key: string): void;
+  clearMappings(): void;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#xml-object
+ */
+export interface XMLModel extends SpecificationExtensionsModel {
+  name: Nullable<string>;
+  namespace: Nullable<string>;
+  prefix: Nullable<string>;
+  attribute: boolean;
+  wrapped: boolean;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#response-object
+ */
+export interface ResponseModel extends SpecificationExtensionsModel {
+  description: CommonMarkString;
+
+  readonly headerCount: number;
+  headerNames(): IterableIterator<string>;
+  headers(): IterableIterator<[string, HeaderModel]>;
+  hasHeader(name: string): boolean;
+  getHeader(name: string): HeaderModel;
+  addHeader(name: string): HeaderModel;
+  deleteHeader(name: string): void;
+  clearHeaders(): void;
+
+  readonly mediaTypeCount: number;
+  mediaTypeKeys(): IterableIterator<MIMETypeString>;
+  mediaTypes(): IterableIterator<[MIMETypeString, MediaTypeModel]>;
+  hasMediaType(mediaType: MIMETypeString): boolean;
+  addMediaType(mediaType: MIMETypeString): MediaTypeModel;
+  deleteMediaType(mediaType: MIMETypeString): void;
+  clearMediaTypes(): void;
+
+  readonly linkCount: number;
+  linkKeys(): IterableIterator<string>;
+  links(): IterableIterator<[string, LinkModel]>;
+  hasLink(key: string): boolean;
+  getLink(key: string): LinkModel;
+  addLink(key: string): LinkModel;
+  deleteLink(key: string): void;
+  clearLinks(): void;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#example-object
+ */
+export interface ExampleModel extends SpecificationExtensionsModel {
+  summary: Nullable<string>;
+  description: Nullable<CommonMarkString>;
+  value: JSONValue;
+  externalValue: Nullable<URLString>;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#header-object
+ */
+export interface HeaderModel extends SpecificationExtensionsModel {
+  description: Nullable<CommonMarkString>;
+  required: boolean;
+  deprecated: boolean;
+  style: HeaderParameterSerializationStyle;
+  explode: boolean;
+
+  readonly schema: Nullable<SchemaModel>;
+  addSchema(): SchemaModel;
+  deleteSchema(): void;
+
+  readonly exampleCount: number;
+  exampleKeys(): IterableIterator<string>;
+  examples(): IterableIterator<[string, ExampleModel]>;
+  hasExample(key: string): boolean;
+  addExample(key: string): ExampleModel;
+  deleteExample(key: string): void;
+  clearExamples(): void;
+
+  readonly mediaTypeCount: number;
+  mediaTypeKeys(): IterableIterator<MIMETypeString>;
+  mediaTypes(): IterableIterator<[MIMETypeString, MediaTypeModel]>;
+  hasMediaType(mediaType: MIMETypeString): boolean;
+  addMediaType(mediaType: MIMETypeString): MediaTypeModel;
+  deleteMediaType(mediaType: MIMETypeString): void;
+  clearMediaTypes(): void;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#security-scheme-object
+ */
+export interface SecuritySchemaModelBase extends SpecificationExtensionsModel {
+  description: Nullable<CommonMarkString>;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#security-scheme-object
+ */
+export type APIKeySecuritySchemaLocation = 'query' | 'header' | 'cookie';
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#security-scheme-object
+ */
+export interface APIKeySecuritySchemaModel extends SecuritySchemaModelBase {
+  readonly type: 'apiKey';
+  name: string;
+  in: APIKeySecuritySchemaLocation;
+}
+
+/**
+ * @see https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml
+ */
+export type HTTPSecuritySchemaAuthentication =
+  | 'Basic'
+  | 'Bearer'
+  | 'Digest'
+  | 'HOBA'
+  | 'Mutual'
+  | 'Negotiate'
+  | 'OAuth'
+  | 'SCRAM-SHA-1'
+  | 'SCRAM-SHA-256'
+  | 'vapid';
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#security-scheme-object
+ */
+export interface HTTPSecuritySchemaModel extends SecuritySchemaModelBase {
+  readonly type: 'http';
+  scheme: HTTPSecuritySchemaAuthentication;
+  bearerFormat: Nullable<string>;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#security-scheme-object
+ */
+export interface MutualTLSSecuritySchemaModel extends SecuritySchemaModelBase {
+  readonly type: 'mutualTLS';
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#security-scheme-object
+ */
+export interface OAuth2SecuritySchemaModel extends SecuritySchemaModelBase {
+  readonly type: 'oauth2';
+  readonly flows: OAuthFlowsModel;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#oauth-flows-object
+ */
+export interface OAuthFlowsModel extends SpecificationExtensionsModel {
+  readonly implicit: Nullable<OAuthImplicitFlowModel>;
+  addImplicitFlow(authorizationUrl: URLString, refreshUrl: URLString): OAuthImplicitFlowModel;
+  deleteImplicitFlow(): void;
+
+  readonly password: Nullable<OAuthPasswordFlowModel>;
+  addPasswordFlow(tokenUrl: URLString, refreshUrl: URLString): OAuthPasswordFlowModel;
+  deletePasswordFlow(): void;
+
+  readonly clientCredentials: Nullable<OAuthClientCredentialsFlowModel>;
+  addClientCredentialsFlow(
+    tokenUrl: URLString,
+    refreshUrl: URLString,
+  ): OAuthClientCredentialsFlowModel;
+  deleteClientCredentialsFlow(): void;
+
+  readonly authorizationCode: Nullable<OAuthAuthorizationCodeFlowModel>;
+  addAuthorizationCodeFlow(
+    authorizationUrl: URLString,
+    tokenUrl: URLString,
+    refreshUrl: URLString,
+  ): OAuthAuthorizationCodeFlowModel;
+  deleteAuthorizationCodeFlow(): void;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#oauth-flow-object
+ */
+export interface OAuthFlowModelBase extends SpecificationExtensionsModel {
+  refreshUrl: URLString;
+
+  readonly scopeCount: number;
+  scopeNames(): IterableIterator<string>;
+  scopes(): IterableIterator<[string, string]>;
+  hasScope(name: string): boolean;
+  getScopeDescription(name: string): string;
+  addScope(name: string, description: string): void;
+  deleteScope(name: string): void;
+  clearScopes(): void;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#oauth-flow-object
+ */
+export interface OAuthImplicitFlowModel extends OAuthFlowModelBase {
+  authorizationUrl: URLString;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#oauth-flow-object
+ */
+export interface OAuthPasswordFlowModel extends OAuthFlowModelBase {
+  tokenUrl: URLString;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#oauth-flow-object
+ */
+export interface OAuthClientCredentialsFlowModel extends OAuthFlowModelBase {
+  tokenUrl: URLString;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#oauth-flow-object
+ */
+export interface OAuthAuthorizationCodeFlowModel extends OAuthFlowModelBase {
+  authorizationUrl: URLString;
+  tokenUrl: URLString;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#oauth-flow-object
+ */
+export type OAuthFlowModel =
+  | OAuthImplicitFlowModel
+  | OAuthPasswordFlowModel
+  | OAuthClientCredentialsFlowModel
+  | OAuthAuthorizationCodeFlowModel;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#security-scheme-object
+ */
+export interface OpenIDConnectSecuritySchemaModel extends SecuritySchemaModelBase {
+  readonly type: 'openIdConnect';
+  connectUrl: URLString;
+}
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#security-scheme-object
+ */
+export type SecuritySchemaModel =
+  | APIKeySecuritySchemaModel
+  | HTTPSecuritySchemaModel
+  | MutualTLSSecuritySchemaModel
+  | OAuth2SecuritySchemaModel
+  | OpenIDConnectSecuritySchemaModel;
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#security-scheme-object
+ */
+export type SecuritySchemaType = SecuritySchemaModel['type'];
+
+/**
+ * @see https://spec.openapis.org/oas/v3.1.0#link-object
+ */
+export interface LinkModel extends SpecificationExtensionsModel {
+  operation: Nullable<OperationModel>;
+
+  readonly parameterCount: number;
+  parameterNames(): IterableIterator<string>;
+  parameters(): IterableIterator<[string, JSONValue]>;
+  hasParameter(name: string): boolean;
+  getParameterValue(name: string): JSONValue;
+  setParameterValue(name: string, value: JSONValue): void;
+  deleteParameter(name: string): void;
+  clearParameter(): void;
+
+  requestBody: JSONValue;
+  description: Nullable<CommonMarkString>;
+  server: Nullable<ServerModel>;
+}


### PR DESCRIPTION
## Motivation and Context

This PR introduces type definitions for OpenAPI 3.1 spec objects, as well as data model classes. The PR is the first one is a series, that will bring the full support of OpenAPI 3.1 spec to api-tools.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

Major differences compared to OpenAPI 3.0:

- model classes do not expose container classes (e.g. maps or sets or arrays). Only primitive attributes.
- model classes use getters / setters / private JS fields to limit the access to attributes (this is someting that needs to be back ported to 3.0)
- if a model class needs to provide interface to an embedded collection, it is done by exposing similarly-named attributes and functions. For example, to expose a map:

```ts
class Header ... {
  readonly exampleCount: number;
  exampleKeys(): IterableIterator<string>;
  examples(): IterableIterator<[string, Example]>;
  hasExample(key: string): boolean;
  addExample(key: string): Example;
  deleteExample(key: string): void;
  clearExamples(): void;
}
```
 