### PR TITLE
Improve fetch codegen

### DIFF
--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
@@ -25,7 +25,7 @@ test('simple test', () => {
   operation.operationId = 'readEmployeeList';
 
   const paramOffset = operation.addParameter('offset', 'query');
-  paramOffset.required = false;
+  paramOffset.required = true;
   paramOffset.schema = SchemaFactory.create(paramOffset, 'number');
 
   const paramLimit = operation.addParameter('limit', 'query');
@@ -83,13 +83,15 @@ test('simple test', () => {
     export type ReadEmployeeListResponse = JSONAPIDataDocument<EmployeeResource[]>;
 
     export async function readEmployeeList(
-      offset: number,
-      limit: number,
+      params: {
+        offset: number,
+        limit?: number,
+      },
       extraParams?: ExtraCallParams,
     ): Promise<ReadEmployeeListResponse> {
       const url = makeUrl(\`/employees\`);
-      addQueryParam(url, 'offset', offset);
-      addQueryParam(url, 'limit', limit);
+      addQueryParam(url, 'offset', params.offset);
+      addQueryParam(url, 'limit', params.limit);
 
       const request = {
         headers: COMMON_HEADERS,

--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
@@ -1,6 +1,6 @@
 import { buildEmployeeSchemasForTesting } from '@fresha/openapi-codegen-test-utils';
 import { MEDIA_TYPE_JSON_API, setResourceSchema } from '@fresha/openapi-codegen-utils';
-import { OpenAPIFactory, OperationModel } from '@fresha/openapi-model/build/3.0.3';
+import { OpenAPIFactory, OperationModel, SchemaFactory } from '@fresha/openapi-model/build/3.0.3';
 
 import '@fresha/openapi-codegen-test-utils/build/matchers';
 
@@ -23,6 +23,15 @@ test('simple test', () => {
 
   const operation = openapi.setPathItem('/employees').setOperation('get');
   operation.operationId = 'readEmployeeList';
+
+  const paramOffset = operation.addParameter('offset', 'query');
+  paramOffset.required = false;
+  paramOffset.schema = SchemaFactory.create(paramOffset, 'number');
+
+  const paramLimit = operation.addParameter('limit', 'query');
+  paramLimit.required = false;
+  paramLimit.schema = SchemaFactory.create(paramLimit, 'number');
+
   operation
     .setResponse(200, 'returns a list of employees')
     .setContent(MEDIA_TYPE_JSON_API)
@@ -43,7 +52,7 @@ test('simple test', () => {
       COMMON_HEADERS,
       makeUrl,
       callJsonApi,
-      toString,
+      addQueryParam,
       authorizeRequest,
       ExtraCallParams,
       applyExtraParams,
@@ -74,9 +83,13 @@ test('simple test', () => {
     export type ReadEmployeeListResponse = JSONAPIDataDocument<EmployeeResource[]>;
 
     export async function readEmployeeList(
+      offset: number,
+      limit: number,
       extraParams?: ExtraCallParams,
     ): Promise<ReadEmployeeListResponse> {
       const url = makeUrl(\`/employees\`);
+      addQueryParam(url, 'offset', offset);
+      addQueryParam(url, 'limit', limit);
 
       const request = {
         headers: COMMON_HEADERS,
@@ -125,7 +138,6 @@ test('action returns raw response', () => {
       COMMON_HEADERS,
       makeUrl,
       callApi,
-      toString,
       ExtraCallParams,
       applyExtraParams
     } from './utils';

--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
@@ -131,13 +131,12 @@ export class ActionFunc {
     this.context.logger.info(`Generating code for action ${this.name}`);
 
     addImportDeclarations(this.context.sourceFile, {
-      './utils': [
-        'COMMON_HEADERS',
-        'makeUrl',
-        this.parsesResponse ? 'callJsonApi' : 'callApi',
-        'toString',
-      ],
+      './utils': ['COMMON_HEADERS', 'makeUrl', this.parsesResponse ? 'callJsonApi' : 'callApi'],
     });
+
+    if (this.parameterVars.size) {
+      addImportDeclaration(this.context.sourceFile, './utils', 'addQueryParam');
+    }
 
     if (this.usesAuthCookie) {
       addImportDeclaration(this.context.sourceFile, './utils', 'authorizeRequest');
@@ -172,9 +171,7 @@ export class ActionFunc {
 
       for (const [paramName, paramInfo] of this.parameterVars) {
         if (paramInfo.parameter.in === 'query') {
-          writer.writeLine(
-            `url.searchParams.set('${paramInfo.parameter.name}', toString(${paramName}));`,
-          );
+          writer.writeLine(`addQueryParam(url, '${paramInfo.parameter.name}', ${paramName});`);
         }
       }
       writer.newLine();

--- a/packages/openapi-codegen-client-fetch/src/parts/UtilsFile.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/UtilsFile.ts
@@ -112,8 +112,10 @@ export class UtilsFile {
         }
       };
 
-      export const toString = (val: unknown): string => {
-        return String(val);
+      export const addQueryParam = (url: URL, name: string, param: unknown): void => {
+        if (param !== undefined) {
+          url.searchParams.set(name, String(param));
+        }
       };
 
       export const COMMON_HEADERS = {


### PR DESCRIPTION
## Motivation and Context

This PR improves code generation for TypeScript fetch() clients. It also fixes a bug which manifested itself as all action parameters being required, even if they were optional in the OpenAPI spec.

Before:

one needs to pass all parameters separately

```ts
await actionFunc(arg1: string, arg2: string, extraParams?: ExtraCallParams)
```

Now:

parameters are passed in one object. Optional parameters may not be specified.

```ts
await actionFunc({ arg1, arg2 }: { arg1?: string, arg2: string }, extraParams?: ExtraCallParams);
```

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
