### PR TITLE
Code generated by client-fetch checks cookie only on nodejs

### DIFF
--- a/packages/openapi-codegen-client-fetch/src/parts/UtilsFile.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/UtilsFile.ts
@@ -79,14 +79,14 @@ export class UtilsFile {
       };
 
       export const authorizeRequest = (request: RequestInit, extraParams?: ExtraCallParams): void => {
-        const finalAuthCookieName = extraParams?.authCookieName || authCookieName;
-        const finalAuthCookie = extraParams?.authCookie || authCookie;
-        if (!finalAuthCookieName || !finalAuthCookie) {
-          throw new APIClientError('config', 'Authorization cookie is not set');
-        }
         if (typeof window !== "undefined") {
           request.credentials = "include";
         } else {
+          const finalAuthCookieName = extraParams?.authCookieName || authCookieName;
+          const finalAuthCookie = extraParams?.authCookie || authCookie;
+          if (!finalAuthCookieName || !finalAuthCookie) {
+            throw new APIClientError('config', 'Authorization cookie is not set');
+          }
           request.headers = {
             ...request.headers,
             cookie: \`\${finalAuthCookieName}=\${finalAuthCookie};\`,


### PR DESCRIPTION
## Motivation and Context

This PR fixes a bug in the code generated by client-fetch codegen. Instead of checking the authorisation cookie every time and in every environment (browser, Node.js), it now only checked on Node.js.

Before:

```ts
init({ ... });
setAuthCookie('name', 'value'); // had to do this, even if the cookie was not used
```

Now (browsers):

```ts
init({ ... });
// setAuthCookie is not needed because the cookie is added implicitly by credentials: 'include'
```

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

More information on things that require more attention while reviewing.
