### PR TITLE
Add success callback to the code generated by client-fetch codegen

### DIFF
--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
@@ -56,6 +56,7 @@ test('simple test', () => {
       authorizeRequest,
       ExtraCallParams,
       applyExtraParams,
+      dispatchSuccess,
     } from './utils';
     import type {
       JSONAPIServerResource,
@@ -102,6 +103,8 @@ test('simple test', () => {
       applyExtraParams(request, extraParams);
 
       const response = await callJsonApi(url, request);
+
+      dispatchSuccess(params, response);
 
       return response as unknown as ReadEmployeeListResponse;
     }

--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
@@ -223,6 +223,9 @@ export class ActionFunc {
         if (this.responseType) {
           writer.writeLine(`const response = await callJsonApi(url, request);`);
           writer.newLine();
+          addImportDeclaration(this.context.sourceFile, './utils', 'dispatchSuccess');
+          writer.writeLine('dispatchSuccess(params, response)');
+          writer.newLine();
           writer.writeLine(`return response as unknown as ${this.responseType.name};`);
         } else {
           writer.writeLine(`await callJsonApi(url, request);`);

--- a/packages/openapi-codegen-client-fetch/src/parts/UtilsFile.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/UtilsFile.ts
@@ -34,12 +34,16 @@ export class UtilsFile {
 
       export type FetchFunc = (url: string, init: RequestInit) => Promise<Response>;
 
+      export type SuccessCallbackFunc = (params: unknown, response: JSONValue) => void;
+
       let rootUrl = '';
       let fetcher: FetchFunc = global.fetch;
+      let successCallback: SuccessCallbackFunc | null = null;
 
       export type InitParams = {
         rootUrl: string;
         fetcher?: FetchFunc;
+        successCallback?: SuccessCallbackFunc;
       };
 
       export const init = (params: InitParams): void => {
@@ -49,6 +53,9 @@ export class UtilsFile {
         rootUrl = params.rootUrl;
         if (params.fetcher) {
           fetcher = params.fetcher;
+        }
+        if (params.successCallback) {
+          successCallback = params.successCallback;
         }
       };
 
@@ -155,6 +162,12 @@ export class UtilsFile {
         }
 
         return json as JSONValue;
+      };
+
+      export const dispatchSuccess = (params: unknown, response: JSONValue): void => {
+        if (successCallback) {
+          successCallback(params, response);
+        }
       };
     `,
     );


### PR DESCRIPTION
## Motivation and Context

This PR extends the code generated by `client-fetch` code generator. Now it is possible to set a 'success callback' - a function that gets called after API call succeeds. It accepts the list of parameters passed to the action as well as the response obtained from the server.

The flagship use case for this functionality would be integration with Redux.

Usage:

```ts
const successCallback = (params: unknown, response: JSONValue): void => {
  store.dispatch({
    type: JSON_API_ORM_UPDATE,
    payload: {
      params,
      response,
    },
  });
};


init({
  fetcher: global.fetch,
  rootUrl: 'https://api.example.com',
  successCallback,
});
```

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

Naming may not be fully optimal.
