### PR TITLE
Implement naming conventions for client-fetch codegen

### DIFF
--- a/packages/openapi-codegen-client-fetch/src/command.ts
+++ b/packages/openapi-codegen-client-fetch/src/command.ts
@@ -18,8 +18,8 @@ type Params = BaseParams & {
   withInternal?: boolean;
   withTags?: string[];
   withoutTags?: string[];
-  transformRequest?: NamingConvention;
-  transformResponse?: NamingConvention;
+  apiNaming?: NamingConvention;
+  clientNaming?: NamingConvention;
 };
 
 export const builder = (args: Argv): Argv<Params> =>
@@ -34,10 +34,10 @@ export const builder = (args: Argv): Argv<Params> =>
     .describe('with-tags', 'Generate only operation with tags')
     .array('without-tags')
     .describe('without-tags', 'Generates operations not assigned with this tags')
-    .choices('transform-request', ['camel', 'kebab', 'snake', 'title'])
-    .describe('transform-request', 'Transforms request bodies to specified convention')
-    .choices('transform-response', ['camel', 'kebab', 'snake', 'title'])
-    .describe('transform-response', 'Converts responses to specified convention');
+    .choices('api-naming', ['camel', 'kebab', 'snake', 'title'])
+    .describe('api-naming', 'Naming convention in OpenAPI schema')
+    .choices('client-naming', ['camel', 'kebab', 'snake', 'title'])
+    .describe('client-naming', 'Naming convention on a client');
 
 export const handler = (args: ArgumentsCamelCase<Params>): void => {
   const baseContext = createTSProjectContext(args);
@@ -48,8 +48,8 @@ export const handler = (args: ArgumentsCamelCase<Params>): void => {
     includeInternal: !!args.withInternal,
     includedTags: new Set<string>(args.withTags),
     excludedTags: new Set<string>(args.withoutTags),
-    transformRequest: args.transformRequest ?? null,
-    transformResponse: args.transformResponse ?? null,
+    apiNaming: args.apiNaming ?? null,
+    clientNaming: args.clientNaming ?? null,
   });
 
   generator.run();

--- a/packages/openapi-codegen-client-fetch/src/context.ts
+++ b/packages/openapi-codegen-client-fetch/src/context.ts
@@ -10,8 +10,8 @@ export interface Context extends TSProjectContext {
   readonly includeInternal: boolean;
   readonly includedTags: Set<string>;
   readonly excludedTags: Set<string>;
-  readonly transformRequest: Nullable<NamingConvention>;
-  readonly transformResponse: Nullable<NamingConvention>;
+  readonly apiNaming: Nullable<NamingConvention>;
+  readonly clientNaming: Nullable<NamingConvention>;
 }
 
 export interface ActionContext extends Context {

--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
@@ -1,9 +1,16 @@
 import { buildEmployeeSchemasForTesting } from '@fresha/openapi-codegen-test-utils';
-import { MEDIA_TYPE_JSON_API, setResourceSchema } from '@fresha/openapi-codegen-utils';
+import {
+  addResourceAttributes,
+  addResourceRelationships,
+  MEDIA_TYPE_JSON_API,
+  RelationshipCardinality,
+  setResourceSchema,
+} from '@fresha/openapi-codegen-utils';
 import { OpenAPIFactory, OperationModel, SchemaFactory } from '@fresha/openapi-model/build/3.0.3';
 
 import '@fresha/openapi-codegen-test-utils/build/matchers';
 
+import { ActionContext } from '../context';
 import { createActionTestContext } from '../testHelpers';
 
 import { ActionFunc } from './ActionFunc';
@@ -103,6 +110,105 @@ test('simple test', () => {
       applyExtraParams(request, extraParams);
 
       const response = await callJsonApi(url, request);
+
+      dispatchSuccess(params, response);
+
+      return response as unknown as ReadEmployeeListResponse;
+    }
+  `);
+});
+
+test('specific naming convention for client library', () => {
+  const openapi = OpenAPIFactory.create();
+
+  // construct a resource with kebab-case attributes
+  const employee = openapi.components.setSchema('EmployeeResource');
+  setResourceSchema(employee, 'employees');
+  addResourceAttributes(employee, {
+    'old-name': { type: 'string', required: true },
+    'new-name': { type: 'string', required: true },
+    age: { type: 'number', nullable: true },
+    'is-active': { type: 'boolean', nullable: false },
+  });
+  addResourceRelationships(employee, {
+    'direct-manager': { resourceType: 'employees', cardinality: RelationshipCardinality.One },
+  });
+
+  openapi.components.setSecuritySchema('the_auth', 'apiKey');
+
+  const operation = openapi.setPathItem('/employees').setOperation('get');
+  operation.operationId = 'readEmployeeList';
+
+  operation
+    .setResponse(200, 'returns a list of employees')
+    .setContent(MEDIA_TYPE_JSON_API)
+    .setSchema('object')
+    .setProperty('data', 'array')
+    .setItems(openapi.components.getSchemaOrThrow('EmployeeResource'));
+  operation.addSecurityRequirement().addScopes('the_auth');
+
+  const namedTypes = new Map<string, NamedType>();
+  const generatedTypes = new Set<string>();
+
+  // override default values for api/client naming conventions
+  const context: ActionContext = {
+    ...createActionTestContext(operation, 'src/index.ts'),
+    apiNaming: 'kebab',
+    clientNaming: 'camel',
+  };
+  const action = new ActionFunc(context);
+
+  action.collectData(namedTypes);
+  action.generateCode(generatedTypes);
+
+  expect(action.context.project.getSourceFile('src/index.ts')).toHaveFormattedTypeScriptText(`
+    import {
+      COMMON_HEADERS,
+      makeUrl,
+      callJsonApi,
+      authorizeRequest,
+      ExtraCallParams,
+      applyExtraParams,
+      dispatchSuccess,
+    } from './utils';
+    import {
+      JSONAPIServerResource,
+      JSONAPIResourceRelationship1,
+      JSONAPIDataDocument,
+      camelCaseDeep,
+    } from "@fresha/api-tools-core";
+
+    export type EmployeeResource = JSONAPIServerResource<
+      'employees',
+      {
+        oldName: string;
+        newName: string;
+        age?: number | null;
+        isActive?: boolean;
+      },
+      {
+        directManager: JSONAPIResourceRelationship1<'employees'>;
+      }
+    >;
+
+    export type ReadEmployeeListResponse = JSONAPIDataDocument<EmployeeResource[]>;
+
+    export async function readEmployeeList(
+      extraParams?: ExtraCallParams,
+    ): Promise<ReadEmployeeListResponse> {
+      const url = makeUrl(\`/employees\`);
+
+      const request = {
+        headers: COMMON_HEADERS,
+      };
+
+      authorizeRequest(request, extraParams);
+
+      applyExtraParams(request, extraParams);
+
+      let response = await callJsonApi(url, request);
+
+      response = camelCaseDeep(response);
 
       dispatchSuccess(params, response);
 

--- a/packages/openapi-codegen-client-fetch/src/parts/ResourceType.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ResourceType.ts
@@ -1,3 +1,11 @@
+import {
+  camelCase,
+  JSONValue,
+  kebabCase,
+  Nullable,
+  snakeCase,
+  titleCase,
+} from '@fresha/api-tools-core';
 import { addImportDeclaration, addTypeAlias } from '@fresha/code-morph-ts';
 import { assert, getSchemaMultiProperty } from '@fresha/openapi-codegen-utils';
 import { StructureKind, SyntaxKind } from 'ts-morph';
@@ -6,7 +14,6 @@ import { NamedType } from './NamedType';
 import { schemaToType } from './utils';
 
 import type { ActionContext } from '../context';
-import type { JSONValue, Nullable } from '@fresha/api-tools-core';
 import type { SchemaModel } from '@fresha/openapi-model/build/3.0.3';
 
 enum RelationshipCardinality {
@@ -204,7 +211,7 @@ export class ResourceType extends NamedType {
         if (!typeName.startsWith('Unknown')) {
           typeLiteral.addProperty({
             kind: StructureKind.PropertySignature,
-            name: `'${name}'`,
+            name: `'${this.toClientName(name)}'`,
             type: typeName,
             hasQuestionToken: !this.attributesSchema.required.has(name),
           });
@@ -223,11 +230,26 @@ export class ResourceType extends NamedType {
 
         typeLiteral.addProperty({
           kind: StructureKind.PropertySignature,
-          name: `'${name}'`,
+          name: `'${this.toClientName(name)}'`,
           type: `${relName}<'${info.resourceType}'>`,
           hasQuestionToken: !info.required,
         });
       }
+    }
+  }
+
+  protected toClientName(name: string): string {
+    switch (this.context.clientNaming) {
+      case 'camel':
+        return camelCase(name);
+      case 'kebab':
+        return kebabCase(name);
+      case 'title':
+        return titleCase(name);
+      case 'snake':
+        return snakeCase(name);
+      default:
+        return name;
     }
   }
 }

--- a/packages/openapi-codegen-client-fetch/src/testHelpers.ts
+++ b/packages/openapi-codegen-client-fetch/src/testHelpers.ts
@@ -13,8 +13,8 @@ export const createTestContext = (openapi: OpenAPIModel): Context => {
     includeInternal: false,
     includedTags: new Set<string>(),
     excludedTags: new Set<string>(),
-    transformRequest: 'kebab',
-    transformResponse: 'camel',
+    apiNaming: null,
+    clientNaming: null,
   };
 };
 


### PR DESCRIPTION
## Motivation and Context

This PR adds support in `client-fetch` code generator for different naming conventions both for OpenAPI schema and client library. For example, JSON:API recommends to use kebab-case naming, which is inconvenient for JS/TS clients.

Now, you can specify 2 additional options for `client-fetch` generator, `--api-naming` and `--client-naming`.

```ts
npx fresha-openapi-codegen client-fetch --input AS_BEFORE --output AS_BEFORE \
  --api-naming kebab \
  --client-naming camel
```

with these options, all generated types will be in camel-case. Also, server responses will be transformed by using camelCaseDeep function from `api-tools-core`. And finally, request bodies will be transformed to kebab-case using `kebabCaseDeep` function from `@fresha/api-tools-core`.

Default value for either option is `null`, which means no transformation. Allowed values are, `camel`, `kebab`, `snake` and `title`.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
