### PR TITLE
Use upper case method names in fetch()

### DIFF
--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
@@ -136,7 +136,7 @@ test('specific naming convention for client library', () => {
 
   openapi.components.setSecuritySchema('the_auth', 'apiKey');
 
-  const operation = openapi.setPathItem('/employees').setOperation('get');
+  const operation = openapi.setPathItem('/employees').setOperation('patch');
   operation.operationId = 'readEmployeeList';
 
   operation
@@ -199,6 +199,7 @@ test('specific naming convention for client library', () => {
       const url = makeUrl(\`/employees\`);
 
       const request = {
+        method: 'PATCH',
         headers: COMMON_HEADERS,
       };
 

--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
@@ -199,8 +199,8 @@ export class ActionFunc {
 
       writer.writeLine('const request = {');
       writer.indent(() => {
-        const httpMethod = this.context.operation.httpMethod.toLowerCase();
-        if (httpMethod !== 'get') {
+        const httpMethod = this.context.operation.httpMethod.toUpperCase();
+        if (httpMethod !== 'GET') {
           writer.writeLine(`method: '${httpMethod}',`);
         }
         if (this.requestType) {


### PR DESCRIPTION
## Motivation and Context

This PR fixes a bug in client-fetch codegen. Before, the generated fetch() calls contained HTPP method names in lowercase (e.g. get, post), whereas they must be in upper case.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
