### PR TITLE
Set the TS transpilation target to ES2022

### DIFF
--- a/tools/typescript-config/tsconfig.json
+++ b/tools/typescript-config/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "module": "commonjs",
     "lib": [
       "es2020",


### PR DESCRIPTION
## Motivation and Context

With current settings, usage of e.g. private class fields results in a lot of superfluous code generated. At the same time, Node 18.x (current LTS), which is the primary runtime for this package, supports most of these features natively.

This PR changes the transpiration target from ES2020 to ES2022. This will allow to use

- private class fields
- class / static fields
- top-level await

as have optimally transpiled code.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
