### PR TITLE
Make SchemaModel/SchemaObject compatible with JSON Schema for OpenAPI 3.0.3

### DIFF
--- a/packages/openapi-codegen-server-elixir/src/parts/Action.ts
+++ b/packages/openapi-codegen-server-elixir/src/parts/Action.ts
@@ -289,18 +289,14 @@ export class Action {
     const elixirAtttName = snakeCase(propName);
     const parsers: string[] = [];
 
-    let minimum: number | null = null;
-    if (propSchema.minimum) {
-      minimum = propSchema.minimum;
-    } else if (propSchema.exclusiveMinimum) {
-      minimum = propSchema.exclusiveMinimum + 1;
+    let minimum: Nullable<number> = null;
+    if (propSchema.minimum != null) {
+      minimum = propSchema.exclusiveMinimum ? propSchema.minimum + 1 : propSchema.minimum;
     }
 
-    let maximum: number | null = null;
-    if (propSchema.maximum) {
-      maximum = propSchema.maximum;
-    } else if (propSchema.exclusiveMaximum) {
-      maximum = propSchema.exclusiveMaximum - 1;
+    let maximum: Nullable<number> = null;
+    if (propSchema.maximum != null) {
+      maximum = propSchema.exclusiveMaximum ? propSchema.maximum - 1 : propSchema.maximum;
     }
 
     if (minimum == null || maximum == null) {
@@ -333,8 +329,14 @@ export class Action {
     const parsers: string[] = [];
 
     // Surgex.Parsers doesn't have a way to distinguish between >min and >=min
-    const minimum = propSchema.minimum || propSchema.exclusiveMinimum || null;
-    const maximum = propSchema.maximum || propSchema.exclusiveMaximum || null;
+    let minimum: Nullable<number> = null;
+    if (propSchema.minimum != null) {
+      minimum = propSchema.exclusiveMinimum ? propSchema.minimum - 1 : propSchema.minimum;
+    }
+    let maximum: Nullable<number> = null;
+    if (propSchema.maximum != null) {
+      maximum = propSchema.exclusiveMaximum ? propSchema.maximum + 1 : propSchema.maximum;
+    }
 
     // Surgex.Parsers doesn't distinguish between float and double
     if (minimum == null || maximum == null) {

--- a/packages/openapi-codegen-server-elixir/src/parts/Action.ts
+++ b/packages/openapi-codegen-server-elixir/src/parts/Action.ts
@@ -1,7 +1,10 @@
 import assert from 'assert';
 
 import { Nullable, snakeCase } from '@fresha/api-tools-core';
-import { getOperationRequestBodySchema } from '@fresha/openapi-codegen-utils';
+import {
+  getNumericSchemaRange,
+  getOperationRequestBodySchema,
+} from '@fresha/openapi-codegen-utils';
 
 import type { Context } from '../context';
 import type { SourceFile } from '@fresha/code-morph-ex';
@@ -288,26 +291,17 @@ export class Action {
   ): void {
     const elixirAtttName = snakeCase(propName);
     const parsers: string[] = [];
+    const { min, max } = getNumericSchemaRange(propSchema);
 
-    let minimum: Nullable<number> = null;
-    if (propSchema.minimum != null) {
-      minimum = propSchema.exclusiveMinimum ? propSchema.minimum + 1 : propSchema.minimum;
-    }
-
-    let maximum: Nullable<number> = null;
-    if (propSchema.maximum != null) {
-      maximum = propSchema.exclusiveMaximum ? propSchema.maximum - 1 : propSchema.maximum;
-    }
-
-    if (minimum == null || maximum == null) {
+    if (min == null && max == null) {
       parsers.push(':integer');
     } else {
       const parts = ['{:integer'];
-      if (minimum != null) {
-        parts.push(`min: ${minimum}`);
+      if (min != null) {
+        parts.push(`min: ${min}`);
       }
-      if (maximum != null) {
-        parts.push(`max: ${maximum}`);
+      if (max != null) {
+        parts.push(`max: ${max}`);
       }
       parsers.push(`${parts.join(', ')}}`);
     }
@@ -327,27 +321,19 @@ export class Action {
   ): void {
     const elixirAtttName = snakeCase(propName);
     const parsers: string[] = [];
-
     // Surgex.Parsers doesn't have a way to distinguish between >min and >=min
-    let minimum: Nullable<number> = null;
-    if (propSchema.minimum != null) {
-      minimum = propSchema.exclusiveMinimum ? propSchema.minimum - 1 : propSchema.minimum;
-    }
-    let maximum: Nullable<number> = null;
-    if (propSchema.maximum != null) {
-      maximum = propSchema.exclusiveMaximum ? propSchema.maximum + 1 : propSchema.maximum;
-    }
+    const { min, max } = getNumericSchemaRange(propSchema);
 
     // Surgex.Parsers doesn't distinguish between float and double
-    if (minimum == null || maximum == null) {
+    if (min == null && max == null) {
       parsers.push(':float');
     } else {
       const parts = ['{:float'];
-      if (minimum != null) {
-        parts.push(`min: ${minimum}`);
+      if (min != null) {
+        parts.push(`min: ${min}`);
       }
-      if (maximum != null) {
-        parts.push(`max: ${maximum}`);
+      if (max != null) {
+        parts.push(`max: ${max}`);
       }
       parsers.push(`${parts.join(', ')}}`);
     }

--- a/packages/openapi-codegen-server-elixir/src/parts/Controller.test.ts
+++ b/packages/openapi-codegen-server-elixir/src/parts/Controller.test.ts
@@ -112,6 +112,14 @@ test('request body leads to generating parse_XXXX_conn function, as well as erro
     birthDate: 'date',
     score: 'number',
     gender: { type: 'string', required: true, enum: ['male', 'female', 'other'] },
+    num1: { type: 'number', minimum: 10, exclusiveMinimum: true },
+    num2: { type: 'number', minimum: 10, exclusiveMinimum: false },
+    num3: { type: 'number', maximum: 20, exclusiveMaximum: true },
+    num4: { type: 'number', maximum: 20, exclusiveMaximum: false },
+    int1: { type: 'integer', minimum: 10, exclusiveMinimum: true },
+    int2: { type: 'integer', minimum: 10, exclusiveMinimum: false },
+    int3: { type: 'integer', maximum: 20, exclusiveMaximum: true },
+    int4: { type: 'integer', maximum: 20, exclusiveMaximum: false },
   });
 
   const resourceSchema = requestBodySchema.getPropertyOrThrow('data');
@@ -170,6 +178,14 @@ test('request body leads to generating parse_XXXX_conn function, as well as erro
             birth_date: :date,
             score: :float,
             gender: [:string, :required, {:contain, ~w{male female other}}],
+            num1: {:float, min: 10},
+            num2: {:float, min: 10},
+            num3: {:float, max: 20},
+            num4: {:float, max: 20},
+            int1: {:integer, min: 11},
+            int2: {:integer, min: 10},
+            int3: {:integer, max: 19},
+            int4: {:integer, max: 20},
           },
           relationships: %{
             location: [:resource_id, :required],

--- a/packages/openapi-codegen-server-elixir/src/parts/ResourceTestSuite.test.ts
+++ b/packages/openapi-codegen-server-elixir/src/parts/ResourceTestSuite.test.ts
@@ -1,0 +1,86 @@
+import { faker } from '@faker-js/faker';
+import { addResourceAttributes, setResourceSchema } from '@fresha/openapi-codegen-utils';
+
+import { createTestContext } from '../testHelpers';
+
+import { ResourceTestSuite } from './ResourceTestSuite';
+
+import '@fresha/openapi-codegen-test-utils/build/matchers';
+
+test('simple resource', () => {
+  const context = createTestContext('awesome_web');
+
+  const schema = context.openapi.components.setSchema('TestResource');
+  setResourceSchema(schema, 'resource-tests');
+  addResourceAttributes(schema, {
+    num1: {
+      type: 'number',
+      minimum: 10,
+      exclusiveMinimum: true,
+      maximum: 20,
+      exclusiveMaximum: true,
+    },
+    num2: { type: 'number', minimum: 10, maximum: 20 },
+    int1: {
+      type: 'integer',
+      minimum: 10,
+      exclusiveMinimum: true,
+      maximum: 20,
+      exclusiveMaximum: true,
+    },
+    int2: { type: 'integer', minimum: 10, maximum: 20 },
+  });
+
+  const resourceSchema = context.registry.addResourceSchema(schema);
+
+  faker.seed(38459284924);
+
+  const generator = new ResourceTestSuite(
+    context,
+    'AwesomeWeb.TestResource',
+    'AwesomeWeb.TestResource',
+    resourceSchema,
+  );
+  generator.collectData();
+  generator.generateCode();
+
+  expect(generator.sourceFile).toHaveFormattedElixirText(`
+    defmodule AwesomeWeb.TestResource do
+      @moduledoc false
+
+      use ExUnit.Case, async: false
+      import AwesomeWeb.Factory
+      alias AwesomeWeb.TestResource
+
+      test "build/1" do
+        config = build(
+          :resource_tests,
+          id: 884,
+          num1: 11.75,
+          num2: 11.6,
+          int1: 16,
+          int2: 10,
+        )
+
+        assert ResourceTestsResource.build(config) == %Jabbax.Document.Resource{
+          type: "resource-tests",
+          id: 884,
+          attributes: %{
+            num1: 11.75,
+            num2: 11.6,
+            int1: 16,
+            int2: 10,
+          },
+          relationships: %{},
+        }
+      end
+
+      test "link/1" do
+        assert ResourceTestsResource.link(%{ id: 3525 }) == %Jabbax.Document.ResourceId{
+          type: "resource-tests",
+          id: 3525,
+        }
+      end
+    end
+  `);
+});

--- a/packages/openapi-codegen-server-elixir/src/parts/ResourceTestSuite.ts
+++ b/packages/openapi-codegen-server-elixir/src/parts/ResourceTestSuite.ts
@@ -69,15 +69,11 @@ export class ResourceTestSuite {
         case 'integer': {
           let min: number | undefined;
           if (attrSchema.minimum != null) {
-            min = attrSchema.minimum;
-          } else if (attrSchema.exclusiveMinimum != null) {
-            min = attrSchema.exclusiveMinimum + 1;
+            min = attrSchema.exclusiveMinimum ? attrSchema.minimum : attrSchema.minimum + 1;
           }
           let max: number | undefined;
           if (attrSchema.maximum != null) {
-            max = attrSchema.maximum;
-          } else if (attrSchema.exclusiveMaximum != null) {
-            max = attrSchema.exclusiveMaximum - 1;
+            max = attrSchema.exclusiveMaximum ? attrSchema.maximum : attrSchema.maximum - 1;
           }
           result.set(attrName, faker.datatype.number({ min, max }));
           break;
@@ -85,15 +81,11 @@ export class ResourceTestSuite {
         case 'number': {
           let min: number | undefined;
           if (attrSchema.minimum != null) {
-            min = attrSchema.minimum;
-          } else if (attrSchema.exclusiveMinimum != null) {
-            min = attrSchema.exclusiveMinimum + 1;
+            min = attrSchema.exclusiveMinimum ? attrSchema.minimum : attrSchema.minimum + 1;
           }
           let max: number | undefined;
           if (attrSchema.maximum != null) {
-            max = attrSchema.maximum;
-          } else if (attrSchema.exclusiveMaximum != null) {
-            max = attrSchema.exclusiveMaximum - 1;
+            max = attrSchema.exclusiveMaximum ? attrSchema.maximum : attrSchema.maximum - 1;
           }
           result.set(attrName, faker.datatype.number({ min, max, precision: 0.01 }));
           break;

--- a/packages/openapi-codegen-server-nestjs/src/DTO.test.ts
+++ b/packages/openapi-codegen-server-nestjs/src/DTO.test.ts
@@ -81,9 +81,9 @@ describe('serialization', () => {
     const schema = context.openapi.components.setSchema('Error', 'object');
     schema.setProperties({
       min: { type: 'number', minimum: 10 },
-      minExclusive: { type: 'number', exclusiveMinimum: 15 },
+      minExclusive: { type: 'number', minimum: 15, exclusiveMinimum: true },
       max: { type: 'number', maximum: 20 },
-      maxExclusive: { type: 'number', exclusiveMaximum: 25 },
+      maxExclusive: { type: 'number', maximum: 25, exclusiveMaximum: false },
     });
 
     new DTO(context, 'Response', schema).generateCode();
@@ -101,7 +101,7 @@ describe('serialization', () => {
         min?: number;
 
         @Expose()
-        @Min(15)
+        @Min(16)
         @IsInt()
         minExclusive?: number;
 

--- a/packages/openapi-codegen-server-nestjs/src/DTO.test.ts
+++ b/packages/openapi-codegen-server-nestjs/src/DTO.test.ts
@@ -83,7 +83,11 @@ describe('serialization', () => {
       min: { type: 'number', minimum: 10 },
       minExclusive: { type: 'number', minimum: 15, exclusiveMinimum: true },
       max: { type: 'number', maximum: 20 },
-      maxExclusive: { type: 'number', maximum: 25, exclusiveMaximum: false },
+      maxExclusive: { type: 'number', maximum: 25, exclusiveMaximum: true },
+      intMin: { type: 'integer', minimum: 10 },
+      intMinExclusive: { type: 'integer', minimum: 15, exclusiveMinimum: true },
+      intMax: { type: 'integer', maximum: 20 },
+      intMaxExclusive: { type: 'integer', maximum: 25, exclusiveMaximum: true },
     });
 
     new DTO(context, 'Response', schema).generateCode();
@@ -101,7 +105,7 @@ describe('serialization', () => {
         min?: number;
 
         @Expose()
-        @Min(16)
+        @Min(15)
         @IsInt()
         minExclusive?: number;
 
@@ -114,6 +118,26 @@ describe('serialization', () => {
         @Max(25)
         @IsInt()
         maxExclusive?: number;
+
+        @Expose()
+        @Min(10)
+        @IsInt()
+        intMin?: number;
+
+        @Expose()
+        @Min(16)
+        @IsInt()
+        intMinExclusive?: number;
+
+        @Expose()
+        @Max(20)
+        @IsInt()
+        intMax?: number;
+
+        @Expose()
+        @Max(24)
+        @IsInt()
+        intMaxExclusive?: number;
       }`,
     );
   });

--- a/packages/openapi-codegen-server-nestjs/src/DTO.ts
+++ b/packages/openapi-codegen-server-nestjs/src/DTO.ts
@@ -3,6 +3,7 @@ import path from 'path';
 
 import { Nullable, titleCase } from '@fresha/api-tools-core';
 import { addDecorator, addImportDeclaration } from '@fresha/code-morph-ts';
+import { getNumericSchemaRange } from '@fresha/openapi-codegen-utils';
 
 import type { Context } from './context';
 import type { SchemaModel, SchemaPropertyObject } from '@fresha/openapi-model/build/3.0.3';
@@ -47,6 +48,7 @@ export class DTO {
           case 'boolean':
             this.addBooleanProperty(classDecl, prop);
             break;
+          case 'integer':
           case 'number':
             this.addNumericProperty(classDecl, prop);
             break;
@@ -105,23 +107,17 @@ export class DTO {
     });
     propDef.prependWhitespace('\n');
 
+    const { min, max } = getNumericSchemaRange(prop.schema);
+
     addImportDeclaration(this.sourceFile, 'class-transformer', 'Expose');
     addDecorator(propDef, 'Expose', undefined);
-    if (prop.schema.minimum != null) {
+    if (min != null) {
       addImportDeclaration(this.sourceFile, 'class-validator', 'Min');
-      addDecorator(
-        propDef,
-        'Min',
-        prop.schema.exclusiveMinimum ? prop.schema.minimum + 1 : prop.schema.minimum,
-      );
+      addDecorator(propDef, 'Min', min);
     }
-    if (prop.schema.maximum != null) {
+    if (max != null) {
       addImportDeclaration(this.sourceFile, 'class-validator', 'Max');
-      addDecorator(
-        propDef,
-        'Max',
-        prop.schema.exclusiveMaximum ? prop.schema.maximum - 1 : prop.schema.maximum,
-      );
+      addDecorator(propDef, 'Max', max);
     }
     addImportDeclaration(this.sourceFile, 'class-validator', 'IsInt');
     addDecorator(propDef, 'IsInt', undefined);

--- a/packages/openapi-codegen-server-nestjs/src/DTO.ts
+++ b/packages/openapi-codegen-server-nestjs/src/DTO.ts
@@ -109,19 +109,19 @@ export class DTO {
     addDecorator(propDef, 'Expose', undefined);
     if (prop.schema.minimum != null) {
       addImportDeclaration(this.sourceFile, 'class-validator', 'Min');
-      addDecorator(propDef, 'Min', prop.schema.minimum);
-    }
-    if (prop.schema.exclusiveMinimum != null) {
-      addImportDeclaration(this.sourceFile, 'class-validator', 'Min');
-      addDecorator(propDef, 'Min', prop.schema.exclusiveMinimum);
+      addDecorator(
+        propDef,
+        'Min',
+        prop.schema.exclusiveMinimum ? prop.schema.minimum + 1 : prop.schema.minimum,
+      );
     }
     if (prop.schema.maximum != null) {
       addImportDeclaration(this.sourceFile, 'class-validator', 'Max');
-      addDecorator(propDef, 'Max', prop.schema.maximum);
-    }
-    if (prop.schema.exclusiveMaximum != null) {
-      addImportDeclaration(this.sourceFile, 'class-validator', 'Max');
-      addDecorator(propDef, 'Max', prop.schema.exclusiveMaximum);
+      addDecorator(
+        propDef,
+        'Max',
+        prop.schema.exclusiveMaximum ? prop.schema.maximum - 1 : prop.schema.maximum,
+      );
     }
     addImportDeclaration(this.sourceFile, 'class-validator', 'IsInt');
     addDecorator(propDef, 'IsInt', undefined);

--- a/packages/openapi-codegen-utils/src/openapi.ts
+++ b/packages/openapi-codegen-utils/src/openapi.ts
@@ -310,3 +310,28 @@ export const getSchemaProperties = function* getSchemaProperties(
     }
   }
 };
+
+export const getNumericSchemaRange = (
+  schema: SchemaModel,
+  precision = 0.0,
+): { min?: number; max?: number } => {
+  assert(
+    schema.type === 'integer' || schema.type === 'number',
+    'This function is indended to work for numeric schemas only',
+  );
+
+  let { minimum, maximum } = schema;
+  const delta = schema.type === 'integer' ? 1 : precision;
+
+  if (minimum != null && schema.exclusiveMinimum) {
+    minimum += delta;
+  }
+  if (maximum != null && schema.exclusiveMaximum) {
+    maximum -= delta;
+  }
+
+  return {
+    min: minimum ?? undefined,
+    max: maximum ?? undefined,
+  };
+};

--- a/packages/openapi-diff/src/Differ.ts
+++ b/packages/openapi-diff/src/Differ.ts
@@ -352,11 +352,7 @@ export class Differ {
           this.#items.push(new DiffItem(`${basePointer}/type`, 'major', `changed`));
         }
 
-        this.diffSchema(
-          schema1.items as Nullable<SchemaModel>,
-          schema2.items as Nullable<SchemaModel>,
-          `${basePointer}/items`,
-        );
+        this.diffSchema(schema1.items, schema2.items, `${basePointer}/items`);
 
         const propNames1 = new Set<string>(schema1.properties.keys());
         const propNames2 = new Set<string>(schema2.properties.keys());

--- a/packages/openapi-model/examples/json-api.yaml
+++ b/packages/openapi-model/examples/json-api.yaml
@@ -36,23 +36,7 @@ paths:
         $ref: "#/components/requestBodies/JSONAPIRequest"
       responses:
         default:
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  - type: string
-                    nullable: true
-                  - type: number
-                    minimum: 0
-                    maximum: 100
-                  - type: object
-                    properties:
-                      one:
-                        type: boolean
-                      two:
-                        type: number
+          $ref: "#/components/responses/JSONAPIDataResponse"
 components:
   schemas:
     JSONAPIVersion:

--- a/packages/openapi-model/src/3.0.3/model/OpenAPIReader.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPIReader.test.ts
@@ -44,9 +44,9 @@ describe('SchemaModel', () => {
     expect(emptySchema).toHaveProperty('title', null);
     expect(emptySchema).toHaveProperty('multipleOf', null);
     expect(emptySchema).toHaveProperty('maximum', null);
-    expect(emptySchema).toHaveProperty('exclusiveMaximum', null);
+    expect(emptySchema).toHaveProperty('exclusiveMaximum', false);
     expect(emptySchema).toHaveProperty('minimum', null);
-    expect(emptySchema).toHaveProperty('exclusiveMinimum', null);
+    expect(emptySchema).toHaveProperty('exclusiveMinimum', false);
     expect(emptySchema).toHaveProperty('minLength', null);
     expect(emptySchema).toHaveProperty('maxLength', null);
     expect(emptySchema).toHaveProperty('pattern', null);
@@ -95,9 +95,9 @@ describe('SchemaModel', () => {
             title: 'error message schema',
             multipleOf: 4,
             maximum: 100,
-            exclusiveMaximum: 99,
+            exclusiveMaximum: false,
             minimum: 10,
-            exclusiveMinimum: 11,
+            exclusiveMinimum: true,
             minLength: 5,
             maxLength: 25,
             pattern: '*',
@@ -152,9 +152,9 @@ describe('SchemaModel', () => {
     expect(errorMessageSchema).toHaveProperty('title', 'error message schema');
     expect(errorMessageSchema).toHaveProperty('multipleOf', 4);
     expect(errorMessageSchema).toHaveProperty('maximum', 100);
-    expect(errorMessageSchema).toHaveProperty('exclusiveMaximum', 99);
+    expect(errorMessageSchema).toHaveProperty('exclusiveMaximum', false);
     expect(errorMessageSchema).toHaveProperty('minimum', 10);
-    expect(errorMessageSchema).toHaveProperty('exclusiveMinimum', 11);
+    expect(errorMessageSchema).toHaveProperty('exclusiveMinimum', true);
     expect(errorMessageSchema).toHaveProperty('minLength', 5);
     expect(errorMessageSchema).toHaveProperty('maxLength', 25);
     expect(errorMessageSchema).toHaveProperty('pattern', '*');

--- a/packages/openapi-model/src/3.0.3/model/OpenAPIReader.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPIReader.ts
@@ -482,9 +482,9 @@ export class OpenAPIReader {
     model.title = getStringAttribute(json, 'title', false);
     model.multipleOf = getNumericAttribute(json, 'multipleOf', false);
     model.maximum = getNumericAttribute(json, 'maximum', false);
-    model.exclusiveMaximum = json.exclusiveMaximum ?? null;
+    model.exclusiveMaximum = json.exclusiveMaximum ?? false;
     model.minimum = getNumericAttribute(json, 'minimum', false);
-    model.exclusiveMinimum = json.exclusiveMinimum ?? null;
+    model.exclusiveMinimum = json.exclusiveMinimum ?? false;
     model.minLength = getNumericAttribute(json, 'minLength', false);
     model.maxLength = getNumericAttribute(json, 'maxLength', false);
     model.pattern = getStringAttribute(json, 'pattern', false);
@@ -508,13 +508,7 @@ export class OpenAPIReader {
       model.not = this.parseSchema(json.not, model);
     }
     if (json.items) {
-      if (Array.isArray(json.items)) {
-        for (const item of json.items) {
-          model.addTupleItem(this.parseSchema(item, model));
-        }
-      } else {
-        model.setItems(this.parseSchema(json.items, model));
-      }
+      model.setItems(this.parseSchema(json.items, model));
     }
     if (json.properties) {
       for (const [key, value] of Object.entries(json.properties)) {

--- a/packages/openapi-model/src/3.0.3/model/OpenAPIWriter.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPIWriter.ts
@@ -328,13 +328,13 @@ export class OpenAPIWriter {
     if (schema.maximum != null) {
       result.maximum = schema.maximum;
     }
-    if (schema.exclusiveMaximum != null) {
+    if (schema.exclusiveMaximum) {
       result.exclusiveMaximum = schema.exclusiveMaximum;
     }
     if (schema.minimum != null) {
       result.minimum = schema.minimum;
     }
-    if (schema.exclusiveMinimum != null) {
+    if (schema.exclusiveMinimum) {
       result.exclusiveMinimum = schema.exclusiveMinimum;
     }
     if (schema.maxLength != null) {
@@ -389,11 +389,7 @@ export class OpenAPIWriter {
       result.not = this.writeSchema(schema.not, schema);
     }
     if (schema.items != null) {
-      if (Array.isArray(schema.items)) {
-        result.items = schema.items.map(subschema => this.writeSchema(subschema, schema));
-      } else {
-        result.items = this.writeSchema(schema.items, schema);
-      }
+      result.items = this.writeSchema(schema.items, schema);
     }
     if (schema.properties.size) {
       result.properties = {};

--- a/packages/openapi-model/src/3.0.3/model/Schema.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Schema.test.ts
@@ -443,8 +443,8 @@ describe('Schema', () => {
         const prop0 = schema.setProperty('prop0', { type: 'integer' });
         expect(prop0).toHaveProperty('minimum', null);
         expect(prop0).toHaveProperty('maximum', null);
-        expect(prop0).toHaveProperty('exclusiveMinimum', null);
-        expect(prop0).toHaveProperty('exclusiveMaximum', null);
+        expect(prop0).toHaveProperty('exclusiveMinimum', false);
+        expect(prop0).toHaveProperty('exclusiveMaximum', false);
 
         const prop1 = schema.setProperty('prop1', { type: 'integer', minimum: 12 });
         expect(prop1).toHaveProperty('minimum', 12);
@@ -456,19 +456,19 @@ describe('Schema', () => {
         expect(prop3).toHaveProperty('minimum', 12);
         expect(prop3).toHaveProperty('maximum', 30);
 
-        const prop4 = schema.setProperty('prop4', { type: 'integer', exclusiveMinimum: 12 });
-        expect(prop4).toHaveProperty('exclusiveMinimum', 12);
+        const prop4 = schema.setProperty('prop4', { type: 'integer', exclusiveMinimum: true });
+        expect(prop4).toHaveProperty('exclusiveMinimum', true);
 
-        const prop5 = schema.setProperty('prop5', { type: 'integer', exclusiveMaximum: 25 });
-        expect(prop5).toHaveProperty('exclusiveMaximum', 25);
+        const prop5 = schema.setProperty('prop5', { type: 'integer', exclusiveMaximum: false });
+        expect(prop5).toHaveProperty('exclusiveMaximum', false);
 
         const prop6 = schema.setProperty('prop6', {
           type: 'integer',
-          exclusiveMinimum: 12,
-          exclusiveMaximum: 30,
+          exclusiveMinimum: true,
+          exclusiveMaximum: false,
         });
-        expect(prop6).toHaveProperty('exclusiveMinimum', 12);
-        expect(prop6).toHaveProperty('exclusiveMaximum', 30);
+        expect(prop6).toHaveProperty('exclusiveMinimum', true);
+        expect(prop6).toHaveProperty('exclusiveMaximum', false);
       });
     });
 
@@ -676,26 +676,6 @@ describe('Schema', () => {
     expect(itemsSchema).toBe(schema.items);
     expect(itemsSchema.type).toBe('number');
     expect(itemsSchema.format).toBe('double');
-  });
-
-  test('addTupleItem, removeTupleItemAt, clearTupleItems', () => {
-    const schema = SchemaFactory.create(openapi.components, 'array');
-    const item1 = schema.addTupleItem('boolean');
-    const item2 = schema.addTupleItem('string');
-    const item3 = schema.addTupleItem('integer');
-    expect(schema.isTuple()).toBeTruthy();
-
-    expect(Array.isArray(schema.items)).toBe(true);
-
-    expect(schema.items).toHaveProperty('0', item1);
-    expect(schema.items).toHaveProperty('1', item2);
-    expect(schema.items).toHaveProperty('2', item3);
-
-    schema.deleteTupleItemAt(1);
-    expect(schema.items).toHaveProperty('1', item3);
-
-    schema.clearTupleItems();
-    expect(schema.items).toStrictEqual([]);
   });
 
   test('addAllOf', () => {

--- a/packages/openapi-model/src/3.0.3/model/Schema.ts
+++ b/packages/openapi-model/src/3.0.3/model/Schema.ts
@@ -40,9 +40,9 @@ export class Schema extends BasicNode<SchemaModelParent> implements SchemaModel 
   title: Nullable<string>;
   multipleOf: Nullable<number>;
   maximum: Nullable<number>;
-  exclusiveMaximum: Nullable<number>;
+  exclusiveMaximum: boolean;
   minimum: Nullable<number>;
-  exclusiveMinimum: Nullable<number>;
+  exclusiveMinimum: boolean;
   maxLength: Nullable<number>;
   minLength: Nullable<number>;
   pattern: Nullable<string>;
@@ -58,7 +58,7 @@ export class Schema extends BasicNode<SchemaModelParent> implements SchemaModel 
   readonly oneOf: SchemaModel[];
   readonly anyOf: SchemaModel[];
   not: Nullable<SchemaModel>;
-  items: Nullable<SchemaModel | SchemaModel[]>;
+  items: Nullable<SchemaModel>;
   readonly properties: Map<string, SchemaModel>;
   additionalProperties: Nullable<SchemaModel | boolean>;
   description: Nullable<CommonMarkString>;
@@ -158,10 +158,10 @@ export class Schema extends BasicNode<SchemaModelParent> implements SchemaModel 
             result.maximum = params.maximum;
           }
           if (params.exclusiveMinimum != null) {
-            result.exclusiveMinimum = params.exclusiveMinimum;
+            result.exclusiveMinimum = !!params.exclusiveMinimum;
           }
           if (params.exclusiveMaximum != null) {
-            result.exclusiveMaximum = params.exclusiveMaximum;
+            result.exclusiveMaximum = !!params.exclusiveMaximum;
           }
           break;
         }
@@ -267,9 +267,9 @@ export class Schema extends BasicNode<SchemaModelParent> implements SchemaModel 
     this.title = null;
     this.multipleOf = null;
     this.maximum = null;
-    this.exclusiveMaximum = null;
+    this.exclusiveMaximum = false;
     this.minimum = null;
-    this.exclusiveMinimum = null;
+    this.exclusiveMinimum = false;
     this.minLength = null;
     this.maxLength = null;
     this.pattern = null;
@@ -436,29 +436,6 @@ export class Schema extends BasicNode<SchemaModelParent> implements SchemaModel 
     assert(!this.items, `This schema's items have already been set`);
     this.items = isSchemaModel(options) ? options : Schema.create(this, options);
     return this.items;
-  }
-
-  addTupleItem(options: CreateOrSetSchemaOptions): SchemaModel {
-    if (!Array.isArray(this.items)) {
-      this.items = [];
-    }
-
-    const subschema = Schema.createOrGet(this, options);
-    this.items.push(subschema);
-
-    return subschema;
-  }
-
-  deleteTupleItemAt(index: number): void {
-    if (Array.isArray(this.items)) {
-      this.items.splice(index, 1);
-    }
-  }
-
-  clearTupleItems(): void {
-    if (Array.isArray(this.items)) {
-      this.items.splice(0, this.items.length);
-    }
   }
 
   addAllOf(typeOrSchema: CreateOrSetSchemaOptions): SchemaModel {

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -87,8 +87,8 @@ type SchemaCreateObject = (
       type: 'integer' | 'number' | 'int32' | 'int64';
       minimum?: number;
       maximum?: number;
-      exclusiveMinimum?: number;
-      exclusiveMaximum?: number;
+      exclusiveMinimum?: boolean;
+      exclusiveMaximum?: boolean;
       enum?: number[];
       default?: number;
     }
@@ -153,14 +153,15 @@ export type SchemaPropertyObject = {
 
 /**
  * @see https://spec.openapis.org/oas/v3.0.3#schema-object
+ * @see https://github.com/OAI/OpenAPI-Specification/blob/main/schemas/v3.0/schema.yaml
  */
 export interface SchemaModel extends TreeNode<SchemaModelParent>, SpecificationExtensionsModel {
   title: Nullable<string>;
   multipleOf: Nullable<number>;
   maximum: Nullable<number>;
-  exclusiveMaximum: Nullable<number>;
+  exclusiveMaximum: boolean;
   minimum: Nullable<number>;
-  exclusiveMinimum: Nullable<number>;
+  exclusiveMinimum: boolean;
   maxLength: Nullable<number>;
   minLength: Nullable<number>;
   pattern: Nullable<string>;
@@ -176,7 +177,7 @@ export interface SchemaModel extends TreeNode<SchemaModelParent>, SpecificationE
   oneOf: Nullable<SchemaModel[]>;
   anyOf: Nullable<SchemaModel[]>;
   not: Nullable<SchemaModel>;
-  items: Nullable<SchemaModel | SchemaModel[]>;
+  items: Nullable<SchemaModel>;
   readonly properties: ReadonlyMap<string, SchemaModel>;
   additionalProperties: Nullable<SchemaModel | boolean>;
   description: Nullable<CommonMarkString>;
@@ -264,28 +265,6 @@ export interface SchemaModel extends TreeNode<SchemaModelParent>, SpecificationE
    * @return this.items
    */
   setItems(options: CreateOrSetSchemaOptions): SchemaModel;
-
-  /**
-   * Utility function to handle tuple-like schemas. It adds a new subschema at the end of
-   * `items` schema array. If items is not an array, it makes it one.
-   *
-   * @see https://json-schema.org/understanding-json-schema/reference/array.html#tuple-validation
-   */
-  addTupleItem(options: CreateOrSetSchemaOptions): SchemaModel;
-
-  /**
-   * Utility function to handle tuple-like schemas. It removes a tuple subschema from given
-   * index in the `items` schema array. It `items` is not an array, it does nothing.
-   *
-   * @param index subschema index
-   */
-  deleteTupleItemAt(index: number): void;
-
-  /**
-   * Utility function to handle tuple-like schemas. It removes all subschemas from `items`
-   * array, but does not change the `items` itself.
-   */
-  clearTupleItems(): void;
 
   addAllOf(options: CreateOrSetSchemaOptions): SchemaModel;
   deleteAllOfAt(index: number): void;

--- a/packages/openapi-model/src/3.0.3/types.ts
+++ b/packages/openapi-model/src/3.0.3/types.ts
@@ -143,9 +143,9 @@ export type SchemaObject = {
   title?: string;
   multipleOf?: number;
   maximum?: number;
-  exclusiveMaximum?: number;
+  exclusiveMaximum?: boolean;
   minimum?: number;
-  exclusiveMinimum?: number;
+  exclusiveMinimum?: boolean;
   maxLength?: number;
   minLength?: number;
   pattern?: string;
@@ -161,7 +161,7 @@ export type SchemaObject = {
   oneOf?: ObjectOrRef<SchemaObject>[];
   anyOf?: ObjectOrRef<SchemaObject>[];
   not?: ObjectOrRef<SchemaObject>;
-  items?: ObjectOrRef<SchemaObject> | ObjectOrRef<SchemaObject>[];
+  items?: ObjectOrRef<SchemaObject>;
   properties?: Record<string, ObjectOrRef<SchemaObject>>;
   additionalProperties?: ObjectOrRef<SchemaObject> | boolean;
   description?: CommonMarkString;


### PR DESCRIPTION
## Motivation and Context

There are several discrepancies between the [JSON Schema for OpenAPI 3.0.3](https://github.com/OAI/OpenAPI-Specification/blob/main/schemas/v3.0/schema.yaml) and current implementation in `@fresha/openapi-model`:

- `exclusiveMinimum` and `exclusiveMaximum` must be booleans
- `items` cannot be an array of schemas

This PR fixes these issues. It also adds a couple of (previously missing) tests for Elixir / NestJS codegens.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
