### PR TITLE
Correctly handle actions w/o parameters in client-fetch codegen

### DIFF
--- a/examples/openapi-codegen-test-api.yaml
+++ b/examples/openapi-codegen-test-api.yaml
@@ -11,17 +11,17 @@ info:
     url: https://github.com/mykulyak
   x-root-url: API_SERVER_URL
 paths:
-  # /test-parameterless-get:
-  #   get:
-  #     description: A GET operation without parameters
-  #     operationId: testParameterlessGet
-  #     responses:
-  #       200:
-  #         description: A list of BlockedTime resources.
-  #         content:
-  #           application/vnd.api+json:
-  #             schema:
-  #               $ref: "#/components/schemas/BlockedTimeListDocument"
+  /test-parameterless-get:
+    get:
+      description: A GET operation without parameters
+      operationId: testParameterlessGet
+      responses:
+        200:
+          description: A list of BlockedTime resources.
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: "#/components/schemas/BlockedTimeListDocument"
   /blocked-times:
     get:
       description: Returns list of blocked time resources, based on search criteria

--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
@@ -211,7 +211,7 @@ test('specific naming convention for client library', () => {
 
       response = camelCaseDeep(response);
 
-      dispatchSuccess(params, response);
+      dispatchSuccess(undefined, response);
 
       return response as unknown as ReadEmployeeListResponse;
     }

--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
@@ -161,10 +161,11 @@ export class ActionFunc {
       './utils': ['t:ExtraCallParams', 'applyExtraParams'],
     });
 
+    const actionFuncHasParams = this.parameterVars.size || this.requestType;
     const actionFunc = addFunction(
       this.context.sourceFile,
       this.name,
-      this.parameterVars.size || this.requestType
+      actionFuncHasParams
         ? { params: '{}', extraParams: 'ExtraCallParams' }
         : { extraParams: 'ExtraCallParams' },
       `Promise<${resultType}>`,
@@ -243,7 +244,11 @@ export class ActionFunc {
           }
           writer.newLine();
           addImportDeclaration(this.context.sourceFile, './utils', 'dispatchSuccess');
-          writer.writeLine('dispatchSuccess(params, response)');
+          writer.writeLine(
+            actionFuncHasParams
+              ? 'dispatchSuccess(params, response)'
+              : 'dispatchSuccess(undefined, response)',
+          );
           writer.newLine();
           writer.writeLine(`return response as unknown as ${this.responseType.name};`);
         } else {


### PR DESCRIPTION
## Motivation and Context

Currently, `client-fetch` codegen incorrectly generates code for actions without parameters. Namely, it calls `successCallback(params, response)` where `params` is undefined.

This PR fixes this behaviour. Now, actions without parameters call success callback as `successCallback(undefined, response)`.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
