### PR TITLE
client-fetch codegen passes action name to successCallback

### DIFF
--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
@@ -111,7 +111,7 @@ test('simple test', () => {
 
       const response = await callJsonApi(url, request);
 
-      dispatchSuccess(params, response);
+      dispatchSuccess('readEmployeeList', params, response);
 
       return response as unknown as ReadEmployeeListResponse;
     }
@@ -211,7 +211,7 @@ test('specific naming convention for client library', () => {
 
       response = camelCaseDeep(response);
 
-      dispatchSuccess(undefined, response);
+      dispatchSuccess('readEmployeeList', undefined, response);
 
       return response as unknown as ReadEmployeeListResponse;
     }

--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
@@ -245,9 +245,9 @@ export class ActionFunc {
           writer.newLine();
           addImportDeclaration(this.context.sourceFile, './utils', 'dispatchSuccess');
           writer.writeLine(
-            actionFuncHasParams
-              ? 'dispatchSuccess(params, response)'
-              : 'dispatchSuccess(undefined, response)',
+            `dispatchSuccess('${this.name}', ${
+              actionFuncHasParams ? 'params' : 'undefined'
+            }, response)`,
           );
           writer.newLine();
           writer.writeLine(`return response as unknown as ${this.responseType.name};`);

--- a/packages/openapi-codegen-client-fetch/src/parts/UtilsFile.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/UtilsFile.ts
@@ -34,7 +34,7 @@ export class UtilsFile {
 
       export type FetchFunc = (url: string, init: RequestInit) => Promise<Response>;
 
-      export type SuccessCallbackFunc = (params: unknown, response: JSONValue) => void;
+      export type SuccessCallbackFunc = (actionName: string, params: unknown, response: JSONValue) => void;
 
       let rootUrl = '';
       let fetcher: FetchFunc = global.fetch;
@@ -164,9 +164,9 @@ export class UtilsFile {
         return json as JSONValue;
       };
 
-      export const dispatchSuccess = (params: unknown, response: JSONValue): void => {
+      export const dispatchSuccess = (actionName: string, params: unknown, response: JSONValue): void => {
         if (successCallback) {
-          successCallback(params, response);
+          successCallback(actionName, params, response);
         }
       };
     `,


### PR DESCRIPTION
## Motivation and Context

Inside `successCallback` function in the code generated by `client-fetch` generator, it is not possible to learn which action has been called. Therefore, it is not possible to do something different for different API actions.

This PR changes signature of the `successCallback` to `(actionName: string, params: unknown, response: JSONValue) => void`. 

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
