### PR TITLE
Implement generation of request formatters in client-fetch

### DIFF
--- a/packages/openapi-codegen-client-fetch/src/Generator.ts
+++ b/packages/openapi-codegen-client-fetch/src/Generator.ts
@@ -1,15 +1,24 @@
 import { Generator as GeneratorBase, getOperations } from '@fresha/openapi-codegen-utils';
 import { SourceFile, ts } from 'ts-morph';
 
-import { ActionFunc, NamedType, IndexFile, UtilsFile } from './parts';
+import {
+  ActionFunc,
+  RequestFormatterFunc,
+  NamedType,
+  DocumentType,
+  IndexFile,
+  UtilsFile,
+} from './parts';
 
 import type { Context } from './context';
 
 export class Generator extends GeneratorBase<Context> {
   readonly context: Context;
   protected readonly sourceFile: SourceFile;
+  protected readonly formattersFile: SourceFile;
   protected readonly typesFile: SourceFile;
   protected readonly actionFuncs: Map<string, ActionFunc>;
+  protected readonly requestFormatterFuncs: Map<string, RequestFormatterFunc>;
   protected readonly namedTypes: Map<string, NamedType>;
   protected readonly indexFile: IndexFile;
   protected readonly utilsFile: UtilsFile;
@@ -18,8 +27,10 @@ export class Generator extends GeneratorBase<Context> {
     super(context);
     this.context = context;
     this.sourceFile = this.context.createSourceFile('src/actions.ts');
+    this.formattersFile = this.context.createSourceFile('src/formatters.ts');
     this.typesFile = this.context.createSourceFile('src/types.ts');
     this.actionFuncs = new Map<string, ActionFunc>();
+    this.requestFormatterFuncs = new Map<string, RequestFormatterFunc>();
     this.namedTypes = new Map<string, NamedType>();
     this.indexFile = new IndexFile(this.context);
     this.utilsFile = new UtilsFile(this.context);
@@ -34,11 +45,21 @@ export class Generator extends GeneratorBase<Context> {
       const actionFunc = new ActionFunc({
         ...this.context,
         sourceFile: this.sourceFile,
+        formattersFile: this.formattersFile,
         typesFile: this.typesFile,
         operation,
       });
       actionFunc.collectData(this.namedTypes);
       this.actionFuncs.set(actionFunc.name, actionFunc);
+    }
+    if (this.context.withFormatters) {
+      for (const namedType of this.namedTypes.values()) {
+        if (namedType instanceof DocumentType && namedType.isRequestBody) {
+          const requestFormatterFunc = new RequestFormatterFunc(namedType);
+          requestFormatterFunc.collectData();
+          this.requestFormatterFuncs.set(requestFormatterFunc.name, requestFormatterFunc);
+        }
+      }
     }
     this.utilsFile.collectData();
   }
@@ -51,6 +72,11 @@ export class Generator extends GeneratorBase<Context> {
 
     for (const actionFunc of this.actionFuncs.values()) {
       actionFunc.generateCode();
+    }
+    if (this.context.withFormatters) {
+      for (const requestFormatterFunc of this.requestFormatterFuncs.values()) {
+        requestFormatterFunc.generateCode();
+      }
     }
 
     this.indexFile.generateCode();
@@ -66,6 +92,10 @@ export class Generator extends GeneratorBase<Context> {
           indentStyle: ts.IndentStyle.Smart,
         });
       }
+    }
+
+    if (!this.context.withFormatters) {
+      this.context.project.removeSourceFile(this.formattersFile);
     }
 
     if (!this.context.dryRun) {

--- a/packages/openapi-codegen-client-fetch/src/command.ts
+++ b/packages/openapi-codegen-client-fetch/src/command.ts
@@ -18,6 +18,7 @@ type Params = BaseParams & {
   withInternal?: boolean;
   withTags?: string[];
   withoutTags?: string[];
+  withFormatters?: boolean;
   apiNaming?: NamingConvention;
   clientNaming?: NamingConvention;
 };
@@ -34,6 +35,8 @@ export const builder = (args: Argv): Argv<Params> =>
     .describe('with-tags', 'Generate only operation with tags')
     .array('without-tags')
     .describe('without-tags', 'Generates operations not assigned with this tags')
+    .boolean('with-formatters')
+    .describe('with-formatters', 'Generate request formatters')
     .choices('api-naming', ['camel', 'kebab', 'snake', 'title'])
     .describe('api-naming', 'Naming convention in OpenAPI schema')
     .choices('client-naming', ['camel', 'kebab', 'snake', 'title'])
@@ -48,6 +51,7 @@ export const handler = (args: ArgumentsCamelCase<Params>): void => {
     includeInternal: !!args.withInternal,
     includedTags: new Set<string>(args.withTags),
     excludedTags: new Set<string>(args.withoutTags),
+    withFormatters: !!args.withFormatters,
     apiNaming: args.apiNaming ?? null,
     clientNaming: args.clientNaming ?? null,
   });

--- a/packages/openapi-codegen-client-fetch/src/context.ts
+++ b/packages/openapi-codegen-client-fetch/src/context.ts
@@ -10,6 +10,7 @@ export interface Context extends TSProjectContext {
   readonly includeInternal: boolean;
   readonly includedTags: Set<string>;
   readonly excludedTags: Set<string>;
+  readonly withFormatters: boolean;
   readonly apiNaming: Nullable<NamingConvention>;
   readonly clientNaming: Nullable<NamingConvention>;
 }
@@ -17,5 +18,6 @@ export interface Context extends TSProjectContext {
 export interface ActionContext extends Context {
   readonly operation: OperationModel;
   readonly sourceFile: SourceFile;
+  readonly formattersFile: SourceFile;
   readonly typesFile: SourceFile;
 }

--- a/packages/openapi-codegen-client-fetch/src/parts/DocumentType.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/DocumentType.ts
@@ -11,17 +11,33 @@ import type { ActionContext } from '../context';
 import type { SchemaModel } from '@fresha/openapi-model/build/3.0.3';
 
 export class DocumentType extends NamedType {
-  protected isRequestBody: boolean;
-  protected primaryResourceTypes: NamedType[];
-  protected primaryDataIsArray: boolean;
-  protected includedResourceTypes: NamedType[];
+  primaryResourceTypes: NamedType[];
+  primaryDataIsArray: boolean;
+  includedResourceTypes: NamedType[];
 
   constructor(context: ActionContext, name: string, schema: SchemaModel, isRequestBody: boolean) {
-    super(context, name, schema);
-    this.isRequestBody = isRequestBody;
+    super(context, name, schema, isRequestBody);
     this.primaryResourceTypes = [];
     this.primaryDataIsArray = false;
     this.includedResourceTypes = [];
+  }
+
+  get primaryResourceTypeCount(): number {
+    return this.primaryResourceTypes.length;
+  }
+
+  primaryResourceType(): ResourceType {
+    assert(!this.primaryDataIsArray, 'This is an array type', this.context.operation);
+    assert(
+      this.primaryResourceTypes[0] instanceof ResourceType,
+      'Primary data type is not a resource',
+      this.context.operation,
+    );
+    return this.primaryResourceTypes[0];
+  }
+
+  get includedResourceTypeCount(): number {
+    return this.includedResourceTypes.length;
   }
 
   collectData(namedTypes: Map<string, NamedType>): void {

--- a/packages/openapi-codegen-client-fetch/src/parts/IndexFile.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/IndexFile.ts
@@ -14,12 +14,13 @@ export class IndexFile {
   collectData(): void {}
 
   generateCode(): void {
-    this.sourceFile.insertText(
-      0,
-      `export * from './types';
-      export * from './actions';
-      export { init, setAuthCookie, APIClientErrorKind, APIClientError } from './utils';
-      `,
+    this.sourceFile.addStatements(`export * from './types';`);
+    this.sourceFile.addStatements(`export * from './actions';`);
+    if (this.context.withFormatters) {
+      this.sourceFile.addStatements(`export * from './fromatters';`);
+    }
+    this.sourceFile.addStatements(
+      `export { init, setAuthCookie, APIClientErrorKind, APIClientError } from './utils';`,
     );
   }
 }

--- a/packages/openapi-codegen-client-fetch/src/parts/NamedType.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/NamedType.ts
@@ -5,11 +5,13 @@ export abstract class NamedType {
   readonly context: ActionContext;
   readonly name: string;
   readonly schema: SchemaModel;
+  readonly isRequestBody: boolean;
 
-  constructor(context: ActionContext, name: string, schema: SchemaModel) {
+  constructor(context: ActionContext, name: string, schema: SchemaModel, isRequestBody: boolean) {
     this.context = context;
     this.name = name;
     this.schema = schema;
+    this.isRequestBody = isRequestBody;
   }
 
   abstract collectData(namedTypes: Map<string, NamedType>): void;

--- a/packages/openapi-codegen-client-fetch/src/parts/RequestFormatterFunc.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/RequestFormatterFunc.test.ts
@@ -1,0 +1,110 @@
+import { buildEmployeeSchemasForTesting } from '@fresha/openapi-codegen-test-utils';
+import {
+  addResourceRelationships,
+  MEDIA_TYPE_JSON_API,
+  RelationshipCardinality,
+  setDataDocumentSchema,
+} from '@fresha/openapi-codegen-utils';
+import { OpenAPIFactory } from '@fresha/openapi-model/build/3.0.3';
+
+import { createActionTestContext } from '../testHelpers';
+
+import { DocumentType } from './DocumentType';
+import { NamedType } from './NamedType';
+import { RequestFormatterFunc } from './RequestFormatterFunc';
+
+import '@fresha/openapi-codegen-test-utils/build/matchers';
+
+test('simple', () => {
+  const openapi = OpenAPIFactory.create();
+  buildEmployeeSchemasForTesting(openapi);
+
+  const operation = openapi.setPathItem('/employees').setOperation('post');
+  operation.operationId = 'createEmployee';
+
+  const requestBodySchema = operation
+    .setRequestBody()
+    .setContent(MEDIA_TYPE_JSON_API)
+    .setSchema('object');
+  requestBodySchema.title = 'CreateEmployeeRequest';
+  setDataDocumentSchema(requestBodySchema, 'employees');
+
+  requestBodySchema
+    .getPropertyDeepOrThrow('data')
+    .getPropertyDeepOrThrow('attributes')
+    .setProperties({
+      'full-name': { type: 'string', required: true },
+      age: { type: 'integer', required: true },
+      gender: { type: 'string', enum: ['male', 'female'] },
+    });
+
+  addResourceRelationships(requestBodySchema.getPropertyDeepOrThrow('data'), {
+    manager: {
+      resourceType: 'employees',
+      cardinality: RelationshipCardinality.One,
+      required: true,
+    },
+    subordinates: {
+      resourceType: 'employees',
+      cardinality: RelationshipCardinality.Many,
+      required: false,
+    },
+    mentor: {
+      resourceType: 'employees',
+      cardinality: RelationshipCardinality.ZeroOrOne,
+      required: false,
+    },
+  });
+
+  const namedTypes = new Map<string, NamedType>();
+  const generatedTypes = new Set<string>();
+
+  const context = createActionTestContext(operation, 'src/index.ts');
+  const requestType = new DocumentType(context, 'CreateEmployeeRequest', requestBodySchema, true);
+  requestType.collectData(namedTypes);
+
+  for (const namedType of namedTypes.values()) {
+    namedType.generateCode(generatedTypes);
+  }
+
+  const requestFormatter = new RequestFormatterFunc(requestType);
+  requestFormatter.collectData();
+  requestFormatter.generateCode();
+
+  expect(requestFormatter.context.project.getSourceFile('src/formatters.ts'))
+    .toHaveFormattedTypeScriptText(`
+    import type { CreateEmployeeRequest } from './types';
+
+    export function formatCreateEmployeeRequest(params: {
+      fullName: string;
+      age: number;
+      gender?: 'male' | 'female';
+      manager: string;
+      subordinates?: string[];
+      mentor?: string | null;
+    }): CreateEmployeeRequest {
+      return {
+        jsonapi: { version: '1.0' },
+        data: {
+          type: 'employees',
+          attributes: {
+            'full-name': params.fullName,
+            age: params.age,
+            gender: params.gender,
+          },
+          relationships: {
+            manager: { data: { type: 'employees', id: manager, }, },
+            subordinates:
+              subordinates !== undefined
+                ? { data: subordinates.map(id => ({ type: 'employees', id })), }
+                : undefined,
+            mentor:
+              mentor !== undefined
+                ? { data: mentor == null ? { type: 'employees', id: mentor } : null }
+                : undefined,
+          },
+        },
+      };
+    };
+  `);
+});

--- a/packages/openapi-codegen-client-fetch/src/parts/RequestFormatterFunc.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/RequestFormatterFunc.ts
@@ -1,0 +1,183 @@
+import assert from 'assert';
+
+import { addFunction, addImportDeclaration } from '@fresha/code-morph-ts';
+import {
+  camelCase,
+  getOperationIdOrThrow,
+  RelationshipCardinality,
+} from '@fresha/openapi-codegen-utils';
+import { CodeBlockWriter, FunctionDeclaration, SyntaxKind } from 'ts-morph';
+
+import { schemaToType } from './utils';
+
+import type { DocumentType } from './DocumentType';
+import type { ActionContext } from '../context';
+import type { OperationModel } from '@fresha/openapi-model/build/3.0.3';
+
+const requestFormatterName = (operation: OperationModel) => {
+  const operationId = getOperationIdOrThrow(operation);
+  return camelCase(`format_${operationId}_request`);
+};
+
+export class RequestFormatterFunc {
+  readonly context: ActionContext;
+  readonly name: string;
+  readonly resultType: DocumentType;
+
+  constructor(resultType: DocumentType) {
+    this.context = resultType.context;
+    this.name = requestFormatterName(this.context.operation);
+    this.resultType = resultType;
+  }
+
+  collectData(): void {
+    this.context.logger.info(`Collecting data for request formatter ${this.name}`);
+    // const primaryResource = this.resultType.primaryResourceType();
+    // for (const prop of primaryResource.schema
+    //   .getPropertyDeepOrThrow('attributes')
+    //   .getProperties()) {
+    //   global.console.log(prop.name, prop.schema.type);
+    // }
+  }
+
+  generateCode(): void {
+    this.context.logger.info(`Generating code for request formatter: ${this.name}`);
+
+    if (this.resultType) {
+      addImportDeclaration(this.context.formattersFile, './types', `t:${this.resultType.name}`);
+    }
+
+    const primaryResource = this.resultType.primaryResourceType();
+    const funcHasArgs =
+      primaryResource.attributesSchema?.hasPropertiesDeep() || !!primaryResource.relationships.size;
+
+    const func = addFunction(
+      this.context.formattersFile,
+      this.name,
+      funcHasArgs
+        ? {
+            params: '{}',
+          }
+        : {},
+      this.resultType.name,
+      true,
+    );
+
+    this.generateParameters(func);
+
+    func.addStatements((writer: CodeBlockWriter) => {
+      writer.write('return ');
+      writer.inlineBlock(() => {
+        writer.write("jsonapi: { version: '1.0' },");
+
+        writer.writeLine('data: ');
+        writer.inlineBlock(() => {
+          writer.writeLine(`type: '${String(primaryResource.resourceType)}',`);
+          // writer.writeLine(`id: '${String(primaryResource.resourceType)}',`);
+          this.generateAttributes(writer);
+          this.generateRelationships(writer);
+        });
+
+        if (this.resultType.includedResourceTypeCount) {
+          writer.write('included: ');
+          writer.inlineBlock(() => {});
+        }
+      });
+    });
+  }
+
+  protected generateParameters(func: FunctionDeclaration): void {
+    const primaryResource = this.resultType.primaryResourceType();
+
+    const paramsType = func
+      .getParameterOrThrow('params')
+      .getTypeNodeOrThrow()
+      .asKindOrThrow(SyntaxKind.TypeLiteral);
+
+    if (primaryResource.attributesSchema) {
+      for (const { name, schema } of primaryResource.attributesSchema.getPropertiesDeep()) {
+        paramsType.addProperty({
+          name: camelCase(name),
+          type: schemaToType(schema),
+          hasQuestionToken: !primaryResource.attributesSchema.isPropertyRequired(name),
+        });
+      }
+    }
+
+    if (primaryResource.relationships.size) {
+      for (const [relName, relDef] of primaryResource.relationships) {
+        let paramType: string;
+        switch (relDef.cardinality) {
+          case RelationshipCardinality.Many:
+            paramType = 'string[]';
+            break;
+          case RelationshipCardinality.One:
+            paramType = 'string';
+            break;
+          case RelationshipCardinality.ZeroOrOne:
+            paramType = 'string | null';
+            break;
+          default:
+            assert.fail(`Unsupported cardinality ${String(relDef.cardinality)}`);
+        }
+
+        paramsType.addProperty({
+          name: camelCase(relName),
+          type: paramType,
+          hasQuestionToken: !relDef.required,
+        });
+      }
+    }
+  }
+
+  protected generateAttributes(writer: CodeBlockWriter): void {
+    const primaryResource = this.resultType.primaryResourceType();
+
+    writer.writeLine('attributes: ');
+    writer.inlineBlock(() => {
+      // TODO need SchemaModel#propertyDeepCount property, returning a number of
+      // properties in this schema and its allOf subschemas
+      if (primaryResource.attributesSchema) {
+        for (const { name } of primaryResource.attributesSchema.getPropertiesDeep()) {
+          writer.writeLine(`'${name}': params.${camelCase(name)},`);
+        }
+      }
+    });
+    writer.write(',');
+  }
+
+  protected generateRelationships(writer: CodeBlockWriter): void {
+    const primaryResource = this.resultType.primaryResourceType();
+
+    writer.writeLine('relationships: ');
+    writer.inlineBlock(() => {
+      if (primaryResource.relationships.size) {
+        for (const [relName, relDef] of primaryResource.relationships) {
+          const paramName = camelCase(relName);
+
+          let str = '';
+
+          switch (relDef.cardinality) {
+            case RelationshipCardinality.ZeroOrOne:
+              str = `{ data: ${paramName} == null ? { type: '${relDef.resourceType}', id: ${paramName} } : null }`;
+              break;
+            case RelationshipCardinality.One:
+              str = `{ data: { type: '${relDef.resourceType}', id: ${paramName} } }`;
+              break;
+            case RelationshipCardinality.Many:
+              str = `{ data: ${paramName}.map(id => ({ type: '${relDef.resourceType}', id })) }`;
+              break;
+            default:
+              assert.fail(`Unsupported relationship cardinality ${String(relDef.cardinality)}`);
+          }
+
+          writer.writeLine(
+            relDef.required
+              ? `'${relName}': ${str},`
+              : `'${relName}': ${paramName} !== undefined ? ${str} : undefined,`,
+          );
+        }
+      }
+    });
+  }
+}

--- a/packages/openapi-codegen-client-fetch/src/parts/index.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/index.ts
@@ -1,4 +1,7 @@
 export { ActionFunc } from './ActionFunc';
+export { RequestFormatterFunc } from './RequestFormatterFunc';
 export { NamedType } from './NamedType';
+export { DocumentType } from './DocumentType';
+export { ResourceType } from './ResourceType';
 export { IndexFile } from './IndexFile';
 export { UtilsFile } from './UtilsFile';

--- a/packages/openapi-codegen-client-fetch/src/testHelpers.ts
+++ b/packages/openapi-codegen-client-fetch/src/testHelpers.ts
@@ -13,6 +13,7 @@ export const createTestContext = (openapi: OpenAPIModel): Context => {
     includeInternal: false,
     includedTags: new Set<string>(),
     excludedTags: new Set<string>(),
+    withFormatters: true,
     apiNaming: null,
     clientNaming: null,
   };
@@ -24,11 +25,13 @@ export const createActionTestContext = (
 ): ActionContext => {
   const base = createTestContext(operation.root);
   const sourceFile = base.project.createSourceFile(fileName, '');
+  const formattersFile = base.project.createSourceFile('/src/formatters.ts', '');
   const typesFile = base.project.createSourceFile('/src/types.ts', '');
 
   return {
     ...base,
     sourceFile,
+    formattersFile,
     typesFile,
     operation,
   };

--- a/packages/openapi-model/src/3.0.3/model/Schema.ts
+++ b/packages/openapi-model/src/3.0.3/model/Schema.ts
@@ -339,6 +339,10 @@ export class Schema extends BasicNode<SchemaModelParent> implements SchemaModel 
     return result;
   }
 
+  hasPropertiesDeep(): boolean {
+    return !!this.allOf.reduce((accum, elem) => accum + elem.properties.size, this.properties.size);
+  }
+
   *getPropertiesDeep(): IterableIterator<SchemaPropertyObject> {
     // here we should iterate over any kind of schemas
     for (const prop of this.getProperties()) {

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -231,6 +231,12 @@ export interface SchemaModel extends TreeNode<SchemaModelParent>, SpecificationE
   clearProperties(): void;
 
   /**
+   * Returns true if this schema of any of its allOf subschemas define any properties.
+   * Returns false otherwise.
+   */
+  hasPropertiesDeep(): boolean;
+
+  /**
    * Iterates over properties of this schema. Includes nested properties
    * from allOf clause. Goes 1 level deep.
    */


### PR DESCRIPTION
## Motivation and Context

For JSON:API clients, building request bodies is a tedious and error-prone task, even with complete types. This PR extends the `client-fetch` code generator with the ability to generate functions that format request bodies.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

`client-fetch` generates formatters when it is invoked with the `--with-formatters` options. This is done for compatibility reasons, but will change in future versions.

All request formatter functions are placed in the `src/formatters.ts` file.

A request formatter function is generated for each requestBody defined. For JSON:API requests, they accept simplified representation of request data:

- attributes and relationships are put into the same object
- relationship data is an ID or a list thereof (for N-relationships)

An example of a formatter generated for the following request document:

Document primary data is a JSON:API resource with **type** is `create-employee-request`, and

- attributes
  - **name** - string, required
  - **age** - number, nullable, optional
  - **gender** - enum (male, female), optional
- relationships
  - **manager** - 1-type to `employees, required
  - **subordinates** - N-type to `employee`, optional
  - **mentor** - 0-type to `employee`, required

```ts
export function formatCreateEmployeeRequest(params: {{
  name: string;
  age?: number | null;
  gender?: 'male' | 'female';
  manager: string | number;
  subordinates?: (string | number)[];
  mentor: 
}): CreateEmployeeRequest {
  return {
    jsonapi: { version: '1.0' },
    data: {
      type: 'employee-create-request',
      attributes: {
        name: params.name,
        age: params.age,
        gender: params.gender,
      },
      relationships: {
        manager: {
          data: {
            type: 'employees',
            id: params.manager,
          },
        },
        subordinates: params.subordinates !== undefined ? {
          data: params.subordinates.map(id => ({ type: 'employees', id })),
        } : undefined,
        mentor: {
          data: params.mentor ? {
            type: 'employee',
            id: params.mentor,
          } : null,
        },
      },
    },
  };
}
```
