### PR TITLE
Generate OpenAPI client types in a separate file

### DIFF
--- a/packages/openapi-codegen-client-fetch/src/Generator.ts
+++ b/packages/openapi-codegen-client-fetch/src/Generator.ts
@@ -8,6 +8,7 @@ import type { Context } from './context';
 export class Generator extends GeneratorBase<Context> {
   readonly context: Context;
   protected readonly sourceFile: SourceFile;
+  protected readonly typesFile: SourceFile;
   protected readonly actionFuncs: Map<string, ActionFunc>;
   protected readonly namedTypes: Map<string, NamedType>;
   protected readonly indexFile: IndexFile;
@@ -17,6 +18,7 @@ export class Generator extends GeneratorBase<Context> {
     super(context);
     this.context = context;
     this.sourceFile = this.context.createSourceFile('src/actions.ts');
+    this.typesFile = this.context.createSourceFile('src/types.ts');
     this.actionFuncs = new Map<string, ActionFunc>();
     this.namedTypes = new Map<string, NamedType>();
     this.indexFile = new IndexFile(this.context);
@@ -32,6 +34,7 @@ export class Generator extends GeneratorBase<Context> {
       const actionFunc = new ActionFunc({
         ...this.context,
         sourceFile: this.sourceFile,
+        typesFile: this.typesFile,
         operation,
       });
       actionFunc.collectData(this.namedTypes);
@@ -42,9 +45,12 @@ export class Generator extends GeneratorBase<Context> {
 
   generateCode(): void {
     const generatedTypes = new Set<string>();
+    for (const namedType of this.namedTypes.values()) {
+      namedType.generateCode(generatedTypes);
+    }
 
     for (const actionFunc of this.actionFuncs.values()) {
-      actionFunc.generateCode(generatedTypes);
+      actionFunc.generateCode();
     }
 
     this.indexFile.generateCode();

--- a/packages/openapi-codegen-client-fetch/src/context.ts
+++ b/packages/openapi-codegen-client-fetch/src/context.ts
@@ -17,4 +17,5 @@ export interface Context extends TSProjectContext {
 export interface ActionContext extends Context {
   readonly operation: OperationModel;
   readonly sourceFile: SourceFile;
+  readonly typesFile: SourceFile;
 }

--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
@@ -48,24 +48,17 @@ test('simple test', () => {
   operation.addSecurityRequirement().addScopes('the_auth');
 
   const namedTypes = new Map<string, NamedType>();
-  const generatedTypes = new Set<string>();
 
   const action = createAction(operation);
   action.collectData(namedTypes);
-  action.generateCode(generatedTypes);
+  action.generateCode();
 
-  expect(action.context.project.getSourceFile('src/index.ts')).toHaveFormattedTypeScriptText(`
-    import {
-      COMMON_HEADERS,
-      makeUrl,
-      callJsonApi,
-      addQueryParam,
-      authorizeRequest,
-      ExtraCallParams,
-      applyExtraParams,
-      dispatchSuccess,
-      transformResponse,
-    } from './utils';
+  const generatedTypes = new Set<string>();
+  for (const namedType of namedTypes.values()) {
+    namedType.generateCode(generatedTypes);
+  }
+
+  expect(action.context.project.getSourceFile('src/types.ts')).toHaveFormattedTypeScriptText(`
     import type {
       JSONAPIServerResource,
       JSONAPIResourceRelationship1,
@@ -90,6 +83,21 @@ test('simple test', () => {
     >;
 
     export type ReadEmployeeListResponse = JSONAPIDataDocument<EmployeeResource[]>;
+  `);
+
+  expect(action.context.project.getSourceFile('src/index.ts')).toHaveFormattedTypeScriptText(`
+    import {
+      COMMON_HEADERS,
+      makeUrl,
+      callJsonApi,
+      addQueryParam,
+      authorizeRequest,
+      ExtraCallParams,
+      applyExtraParams,
+      dispatchSuccess,
+      transformResponse,
+    } from './utils';
+    import type { ReadEmployeeListResponse } from './types';
 
     export async function readEmployeeList(
       params: {
@@ -149,7 +157,6 @@ test('specific naming convention for client library', () => {
   operation.addSecurityRequirement().addScopes('the_auth');
 
   const namedTypes = new Map<string, NamedType>();
-  const generatedTypes = new Set<string>();
 
   // override default values for api/client naming conventions
   const context: ActionContext = {
@@ -160,24 +167,18 @@ test('specific naming convention for client library', () => {
   const action = new ActionFunc(context);
 
   action.collectData(namedTypes);
-  action.generateCode(generatedTypes);
+  action.generateCode();
 
-  expect(action.context.project.getSourceFile('src/index.ts')).toHaveFormattedTypeScriptText(`
-    import {
-      COMMON_HEADERS,
-      makeUrl,
-      callJsonApi,
-      authorizeRequest,
-      ExtraCallParams,
-      applyExtraParams,
-      dispatchSuccess,
-      transformResponse,
-    } from './utils';
-    import {
+  const generatedTypes = new Set<string>();
+  for (const namedType of namedTypes.values()) {
+    namedType.generateCode(generatedTypes);
+  }
+
+  expect(action.context.project.getSourceFile('src/types.ts')).toHaveFormattedTypeScriptText(`
+    import type {
       JSONAPIServerResource,
       JSONAPIResourceRelationship1,
       JSONAPIDataDocument,
-      camelCaseDeep,
     } from "@fresha/api-tools-core";
 
     export type EmployeeResource = JSONAPIServerResource<
@@ -194,6 +195,21 @@ test('specific naming convention for client library', () => {
     >;
 
     export type ReadEmployeeListResponse = JSONAPIDataDocument<EmployeeResource[]>;
+  `);
+
+  expect(action.context.project.getSourceFile('src/index.ts')).toHaveFormattedTypeScriptText(`
+    import {
+      COMMON_HEADERS,
+      makeUrl,
+      callJsonApi,
+      authorizeRequest,
+      ExtraCallParams,
+      applyExtraParams,
+      dispatchSuccess,
+      transformResponse,
+    } from './utils';
+    import type { ReadEmployeeListResponse } from './types';
+    import { camelCaseDeep } from '@fresha/api-tools-core';
 
     export async function readEmployeeList(
       extraParams?: ExtraCallParams,
@@ -241,11 +257,26 @@ test('action returns raw response', () => {
   });
 
   const namedTypes = new Map<string, NamedType>();
-  const generatedTypes = new Set<string>();
 
   const action = createAction(operation);
   action.collectData(namedTypes);
-  action.generateCode(generatedTypes);
+  action.generateCode();
+
+  const generatedTypes = new Set<string>();
+  for (const namedType of namedTypes.values()) {
+    namedType.generateCode(generatedTypes);
+  }
+
+  expect(action.context.project.getSourceFile('src/types.ts')).toHaveFormattedTypeScriptText(`
+    import type {
+      JSONAPIServerResource,
+      JSONAPIDataDocument,
+    } from "@fresha/api-tools-core";
+
+    export type EmployeeResource = JSONAPIServerResource<'employees'>;
+
+    export type ReadEmployeeListResponse = JSONAPIDataDocument<EmployeeResource[]>;
+  `);
 
   expect(action.context.project.getSourceFile('src/index.ts')).toHaveFormattedTypeScriptText(`
     import {
@@ -255,14 +286,7 @@ test('action returns raw response', () => {
       ExtraCallParams,
       applyExtraParams
     } from './utils';
-    import type {
-      JSONAPIServerResource,
-      JSONAPIDataDocument,
-    } from "@fresha/api-tools-core";
-
-    export type EmployeeResource = JSONAPIServerResource<'employees'>;
-
-    export type ReadEmployeeListResponse = JSONAPIDataDocument<EmployeeResource[]>;
+    import type { ReadEmployeeListResponse } from './types';
 
     export async function readEmployeeList(
       extraParams?: ExtraCallParams,

--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
@@ -128,7 +128,7 @@ export class ActionFunc {
     this.usesAuthCookie = !!this.context.operation.getSecurityRequirements().length;
   }
 
-  generateCode(generatedTypes: Set<string>): void {
+  generateCode(): void {
     this.context.logger.info(`Generating code for action ${this.name}`);
 
     addImportDeclarations(this.context.sourceFile, {
@@ -144,10 +144,10 @@ export class ActionFunc {
     }
 
     if (this.requestType) {
-      this.requestType.generateCode(generatedTypes);
+      addImportDeclaration(this.context.sourceFile, './types', `t:${this.requestType.name}`);
     }
     if (this.responseType) {
-      this.responseType.generateCode(generatedTypes);
+      addImportDeclaration(this.context.sourceFile, './types', `t:${this.responseType.name}`);
     }
 
     let resultType = 'void';

--- a/packages/openapi-codegen-client-fetch/src/parts/DocumentType.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/DocumentType.test.ts
@@ -40,7 +40,7 @@ test('generic', () => {
   documentType.collectData(namedTypes);
   documentType.generateCode(generatedTypes);
 
-  expect(documentType.context.project.getSourceFile('src/index.ts')).toHaveFormattedTypeScriptText(`
+  expect(documentType.context.project.getSourceFile('src/types.ts')).toHaveFormattedTypeScriptText(`
     import type { JSONAPIDataDocument } from '@fresha/api-tools-core';
 
     export type SimpleResponseDocument = JSONAPIDataDocument;
@@ -78,7 +78,7 @@ describe('primary data', () => {
     documentType.collectData(namedTypes);
     documentType.generateCode(generatedTypes);
 
-    expect(documentType.context.project.getSourceFile('src/index.ts'))
+    expect(documentType.context.project.getSourceFile('src/types.ts'))
       .toHaveFormattedTypeScriptText(`
       import type {
         JSONAPIServerResource,
@@ -104,7 +104,7 @@ describe('primary data', () => {
     documentType.collectData(namedTypes);
     documentType.generateCode(generatedTypes);
 
-    expect(documentType.context.project.getSourceFile('src/index.ts'))
+    expect(documentType.context.project.getSourceFile('src/types.ts'))
       .toHaveFormattedTypeScriptText(`
       import type {
         JSONAPIServerResource,
@@ -132,7 +132,7 @@ describe('primary data', () => {
     documentType.collectData(namedTypes);
     documentType.generateCode(generatedTypes);
 
-    expect(documentType.context.project.getSourceFile('src/index.ts'))
+    expect(documentType.context.project.getSourceFile('src/types.ts'))
       .toHaveFormattedTypeScriptText(`
       import type {
         JSONAPIServerResource,
@@ -164,7 +164,7 @@ describe('primary data', () => {
     documentType.collectData(namedTypes);
     documentType.generateCode(generatedTypes);
 
-    expect(documentType.context.project.getSourceFile('src/index.ts'))
+    expect(documentType.context.project.getSourceFile('src/types.ts'))
       .toHaveFormattedTypeScriptText(`
       import type {
         JSONAPIServerResource,
@@ -195,7 +195,7 @@ describe('primary data', () => {
     documentType.collectData(namedTypes);
     documentType.generateCode(generatedTypes);
 
-    expect(documentType.context.project.getSourceFile('src/index.ts'))
+    expect(documentType.context.project.getSourceFile('src/types.ts'))
       .toHaveFormattedTypeScriptText(`
       import type { JSONAPIDataDocument } from '@fresha/api-tools-core';
 
@@ -237,7 +237,7 @@ describe('included', () => {
     documentType.collectData(namedTypes);
     documentType.generateCode(generatedTypes);
 
-    expect(documentType.context.project.getSourceFile('src/index.ts'))
+    expect(documentType.context.project.getSourceFile('src/types.ts'))
       .toHaveFormattedTypeScriptText(`
       import type {
         JSONAPIServerResource,
@@ -280,7 +280,7 @@ describe('included', () => {
     documentType.collectData(namedTypes);
     documentType.generateCode(generatedTypes);
 
-    expect(documentType.context.project.getSourceFile('src/index.ts'))
+    expect(documentType.context.project.getSourceFile('src/types.ts'))
       .toHaveFormattedTypeScriptText(`
       import type {
         JSONAPIServerResource,

--- a/packages/openapi-codegen-client-fetch/src/parts/DocumentType.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/DocumentType.ts
@@ -179,8 +179,8 @@ export class DocumentType extends NamedType {
     }
 
     const typeBaseName = this.isRequestBody ? 'JSONAPIClientDocument' : 'JSONAPIDataDocument';
-    addImportDeclaration(this.context.sourceFile, '@fresha/api-tools-core', `t:${typeBaseName}`);
-    const typeAlias = addTypeAlias(this.context.sourceFile, this.name, typeBaseName, true);
+    addImportDeclaration(this.context.typesFile, '@fresha/api-tools-core', `t:${typeBaseName}`);
+    const typeAlias = addTypeAlias(this.context.typesFile, this.name, typeBaseName, true);
 
     const typeAliasArgs = [];
     if (this.primaryResourceTypes.length) {

--- a/packages/openapi-codegen-client-fetch/src/parts/IndexFile.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/IndexFile.ts
@@ -16,7 +16,8 @@ export class IndexFile {
   generateCode(): void {
     this.sourceFile.insertText(
       0,
-      `export * from './actions';
+      `export * from './types';
+      export * from './actions';
       export { init, setAuthCookie, APIClientErrorKind, APIClientError } from './utils';
       `,
     );

--- a/packages/openapi-codegen-client-fetch/src/parts/ResourceType.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ResourceType.test.ts
@@ -47,7 +47,8 @@ test('simple, client resource', () => {
   resourceType.collectData(namedTypes);
   resourceType.generateCode(generatedTypes);
 
-  expect(resourceType.context.project.getSourceFile('src/index.ts')).toHaveFormattedTypeScriptText(`
+  expect(resourceType.context.project.getSourceFileOrThrow('src/types.ts'))
+    .toHaveFormattedTypeScriptText(`
     import type { JSONAPIClientResource } from '@fresha/api-tools-core';
 
     export type SimpleResource = JSONAPIClientResource;
@@ -74,7 +75,7 @@ test('attributes', () => {
   resourceType.collectData(namedTypes);
   resourceType.generateCode(generatedTypes);
 
-  expect(resourceType.context.project.getSourceFile('src/index.ts')).toHaveFormattedTypeScriptText(`
+  expect(resourceType.context.project.getSourceFile('src/types.ts')).toHaveFormattedTypeScriptText(`
     import type { JSONAPIServerResource } from '@fresha/api-tools-core';
 
     export type HelloResource = JSONAPIServerResource<
@@ -107,7 +108,7 @@ test('relationships', () => {
   resourceType.collectData(namedTypes);
   resourceType.generateCode(generatedTypes);
 
-  expect(resourceType.context.project.getSourceFile('src/index.ts')).toHaveFormattedTypeScriptText(`
+  expect(resourceType.context.project.getSourceFile('src/types.ts')).toHaveFormattedTypeScriptText(`
     import type {
       JSONAPIServerResource,
       JSONAPIResourceRelationship1,

--- a/packages/openapi-codegen-client-fetch/src/parts/ResourceType.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ResourceType.ts
@@ -196,9 +196,9 @@ export class ResourceType extends NamedType {
 
     const templateName = this.isRequestBody ? 'JSONAPIClientResource' : 'JSONAPIServerResource';
 
-    addImportDeclaration(this.context.sourceFile, '@fresha/api-tools-core', `t:${templateName}`);
+    addImportDeclaration(this.context.typesFile, '@fresha/api-tools-core', `t:${templateName}`);
 
-    const typeAlias = addTypeAlias(this.context.sourceFile, this.name, templateName, true);
+    const typeAlias = addTypeAlias(this.context.typesFile, this.name, templateName, true);
     const typeAliasType = typeAlias.getNodeProperty('type').asKindOrThrow(SyntaxKind.TypeReference);
 
     if (this.resourceType) {
@@ -226,7 +226,7 @@ export class ResourceType extends NamedType {
       const typeLiteral = typeAliasType.addTypeArgument('{}').asKindOrThrow(SyntaxKind.TypeLiteral);
       for (const [name, info] of this.relationships) {
         const relName = `JSONAPIResourceRelationship${info.cardinality.toString()}`;
-        addImportDeclaration(this.context.sourceFile, '@fresha/api-tools-core', `t:${relName}`);
+        addImportDeclaration(this.context.typesFile, '@fresha/api-tools-core', `t:${relName}`);
 
         typeLiteral.addProperty({
           kind: StructureKind.PropertySignature,

--- a/packages/openapi-codegen-client-fetch/src/testHelpers.ts
+++ b/packages/openapi-codegen-client-fetch/src/testHelpers.ts
@@ -24,10 +24,12 @@ export const createActionTestContext = (
 ): ActionContext => {
   const base = createTestContext(operation.root);
   const sourceFile = base.project.createSourceFile(fileName, '');
+  const typesFile = base.project.createSourceFile('/src/types.ts', '');
 
   return {
     ...base,
     sourceFile,
+    typesFile,
     operation,
   };
 };


### PR DESCRIPTION
## Motivation and Context

This PR makes the client-fetch code generator to generate request / response types in a separate file named `src/types.ts`. For client library users this change should be transparent.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
