### PR TITLE
Add JSDoc blocks to action functions, request and response types

### DIFF
--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
@@ -30,14 +30,26 @@ test('simple test', () => {
 
   const operation = openapi.setPathItem('/employees').setOperation('get');
   operation.operationId = 'readEmployeeList';
+  operation.summary = 'Reads employee list';
+  operation.description = `
+    This operation reads a list of employee resources, and returns them as a JSON:API
+    document. Besides employees, it includes resources associated with employees, like
+    addresses and **departments**.
+  `
+    .split(/\n/)
+    .map(line => line.trim())
+    .filter(line => !!line.length)
+    .join('\n');
 
   const paramOffset = operation.addParameter('offset', 'query');
   paramOffset.required = true;
   paramOffset.schema = SchemaFactory.create(paramOffset, 'number');
+  paramOffset.description = 'Index of the first employee to retrieve';
 
   const paramLimit = operation.addParameter('limit', 'query');
   paramLimit.required = false;
   paramLimit.schema = SchemaFactory.create(paramLimit, 'number');
+  paramLimit.description = 'Maximal number of employee resources to retrieve';
 
   operation
     .setResponse(200, 'returns a list of employees')
@@ -67,6 +79,21 @@ test('simple test', () => {
       JSONAPIDataDocument,
     } from "@fresha/api-tools-core";
 
+    /**
+     * EmployeeResource
+     *
+     * Attributes:
+     * -  name
+     * -  age
+     * -  gender
+     * -  active
+     *
+     * Relationships:
+     * -  manager relationship to the 'employees' resource
+     * -  buddy relationship to the 'employees' resource
+     * -  subordinates relationship to the 'employees' resource
+     *
+     */
     export type EmployeeResource = JSONAPIServerResource<
       'employees',
       {
@@ -82,6 +109,13 @@ test('simple test', () => {
       }
     >;
 
+    /**
+     * This is a response resource
+     *
+     * Primary data resources:
+     *  - EmployeeResource
+     *
+     */
     export type ReadEmployeeListResponse = JSONAPIDataDocument<EmployeeResource[]>;
   `);
 
@@ -99,6 +133,24 @@ test('simple test', () => {
     } from './utils';
     import type { ReadEmployeeListResponse } from './types';
 
+    /**
+     * Reads employee list
+     *
+     * This operation reads a list of employee resources, and returns them as a JSON:API
+     * document. Besides employees, it includes resources associated with employees, like
+     * addresses and **departments**.
+     *
+     * @param params call parameters
+     * @param params.offset Index of the first employee to retrieve
+     * @param [params.limit] Maximal number of employee resources to retrieve
+     *
+     * @param [extraParams] additional parameters
+     * @param [extraParams.authCookieName] name of the authorization cookie for this request
+     * @param [extraParams.authCookie] value of the authorization cookie for this request
+     * @param [extraParams.xForwardedFor] sends X-Forwarded-For header with specified value
+     * @param [extraParams.xForwardedHost] sends X-Forwarded-Host header with specified value
+     * @param [extraParams.xForwardedProto] sends X-Forwarded-Proto header with specified value
+     */
     export async function readEmployeeList(
       params: {
         offset: number,
@@ -181,6 +233,19 @@ test('specific naming convention for client library', () => {
       JSONAPIDataDocument,
     } from "@fresha/api-tools-core";
 
+    /**
+     * EmployeeResource
+     *
+     * Attributes:
+     * -  old-name
+     * -  new-name
+     * -  age
+     * -  is-active
+     *
+     * Relationships:
+     * -  direct-manager relationship to the 'employees' resource
+     *
+     */
     export type EmployeeResource = JSONAPIServerResource<
       'employees',
       {
@@ -194,6 +259,13 @@ test('specific naming convention for client library', () => {
       }
     >;
 
+    /**
+     * This is a response resource
+     *
+     * Primary data resources:
+     *  - EmployeeResource
+     *
+     */
     export type ReadEmployeeListResponse = JSONAPIDataDocument<EmployeeResource[]>;
   `);
 
@@ -211,6 +283,14 @@ test('specific naming convention for client library', () => {
     import type { ReadEmployeeListResponse } from './types';
     import { camelCaseDeep } from '@fresha/api-tools-core';
 
+    /**
+     * @param [extraParams] additional parameters
+     * @param [extraParams.authCookieName] name of the authorization cookie for this request
+     * @param [extraParams.authCookie] value of the authorization cookie for this request
+     * @param [extraParams.xForwardedFor] sends X-Forwarded-For header with specified value
+     * @param [extraParams.xForwardedHost] sends X-Forwarded-Host header with specified value
+     * @param [extraParams.xForwardedProto] sends X-Forwarded-Proto header with specified value
+     */
     export async function readEmployeeList(
       extraParams?: ExtraCallParams,
     ): Promise<ReadEmployeeListResponse> {
@@ -273,8 +353,19 @@ test('action returns raw response', () => {
       JSONAPIDataDocument,
     } from "@fresha/api-tools-core";
 
+    /**
+     * EmployeeResource
+     *
+     */
     export type EmployeeResource = JSONAPIServerResource<'employees'>;
 
+    /**
+     * This is a response resource
+     *
+     * Primary data resources:
+     *  - EmployeeResource
+     *
+     */
     export type ReadEmployeeListResponse = JSONAPIDataDocument<EmployeeResource[]>;
   `);
 
@@ -288,6 +379,14 @@ test('action returns raw response', () => {
     } from './utils';
     import type { ReadEmployeeListResponse } from './types';
 
+    /**
+     * @param [extraParams] additional parameters
+     * @param [extraParams.authCookieName] name of the authorization cookie for this request
+     * @param [extraParams.authCookie] value of the authorization cookie for this request
+     * @param [extraParams.xForwardedFor] sends X-Forwarded-For header with specified value
+     * @param [extraParams.xForwardedHost] sends X-Forwarded-Host header with specified value
+     * @param [extraParams.xForwardedProto] sends X-Forwarded-Proto header with specified value
+     */
     export async function readEmployeeList(
       extraParams?: ExtraCallParams,
     ): Promise<Response> {

--- a/packages/openapi-codegen-client-fetch/src/parts/DocumentType.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/DocumentType.test.ts
@@ -43,6 +43,10 @@ test('generic', () => {
   expect(documentType.context.project.getSourceFile('src/types.ts')).toHaveFormattedTypeScriptText(`
     import type { JSONAPIDataDocument } from '@fresha/api-tools-core';
 
+    /**
+     * This is a response resource
+     *
+     */
     export type SimpleResponseDocument = JSONAPIDataDocument;
   `);
 });
@@ -85,8 +89,19 @@ describe('primary data', () => {
         JSONAPIDataDocument,
       } from '@fresha/api-tools-core';
 
+      /**
+       * Employee
+       *
+       */
       export type Employee = JSONAPIServerResource<'employees'>;
 
+      /**
+       * This is a response resource
+       *
+       * Primary data resources:
+       *  - Employee
+       *
+       */
       export type SimpleResponseDocument = JSONAPIDataDocument<Employee>;
     `);
   });
@@ -113,6 +128,13 @@ describe('primary data', () => {
 
       export type Unknown1 = JSONAPIServerResource<'employees'>;
 
+      /**
+       * This is a response resource
+       *
+       * Primary data resources:
+       *  - Unknown1
+       *
+       */
       export type SimpleResponseDocument = JSONAPIDataDocument<Unknown1>;
     `);
   });
@@ -139,10 +161,26 @@ describe('primary data', () => {
         JSONAPIDataDocument,
       } from '@fresha/api-tools-core';
 
+      /**
+       * EmployeeResource
+       *
+       */
       export type EmployeeResource = JSONAPIServerResource<'employees'>;
 
+      /**
+       * OrganizationResource
+       *
+       */
       export type OrganizationResource = JSONAPIServerResource<'organizations'>;
 
+      /**
+       * This is a response resource
+       *
+       * Primary data resources:
+       *  - EmployeeResource
+       *  - OrganizationResource
+       *
+       */
       export type ResponseDocumentWithUnionTypes = JSONAPIDataDocument<EmployeeResource | OrganizationResource>;
     `);
   });
@@ -171,8 +209,19 @@ describe('primary data', () => {
         JSONAPIDataDocument,
       } from '@fresha/api-tools-core';
 
+      /**
+       * Employee
+       *
+       */
       export type Employee = JSONAPIServerResource<'employees'>;
 
+      /**
+       * This is a response resource
+       *
+       * Primary data resources:
+       *  - Employee
+       *
+       */
       export type SimpleResponseDocument = JSONAPIDataDocument<Employee[]>;
     `);
   });
@@ -199,6 +248,13 @@ describe('primary data', () => {
       .toHaveFormattedTypeScriptText(`
       import type { JSONAPIDataDocument } from '@fresha/api-tools-core';
 
+      /**
+       * This is a response resource
+       *
+       * Primary data resources:
+       *  - Employee
+       *
+       */
       export type SimpleResponseDocument = JSONAPIDataDocument<Employee[]>;
     `);
   });
@@ -244,8 +300,22 @@ describe('included', () => {
         JSONAPIDataDocument,
       } from '@fresha/api-tools-core';
 
+      /**
+       * Employee
+       *
+       */
       export type Employee = JSONAPIServerResource<'employees'>;
 
+      /**
+       * This is a response resource
+       *
+       * Primary data resources:
+       *  - Employee
+       *
+       * Included resources:
+       *  - Employee
+       *
+       */
       export type DocumentWithIncludedResources = JSONAPIDataDocument<
         Employee,
         Employee
@@ -287,10 +357,29 @@ describe('included', () => {
         JSONAPIDataDocument,
       } from '@fresha/api-tools-core';
 
+      /**
+       * Employee
+       *
+       */
       export type Employee = JSONAPIServerResource<'employees'>;
 
+      /**
+       * Organization
+       *
+       */
       export type Organization = JSONAPIServerResource<'organizations'>;
 
+      /**
+       * This is a response resource
+       *
+       * Primary data resources:
+       *  - Employee
+       *
+       * Included resources:
+       *  - Organization
+       *  - Employee
+       *
+       */
       export type DocumentWithIncludedResources = JSONAPIDataDocument<
         Employee,
         Organization | Employee

--- a/packages/openapi-codegen-client-fetch/src/parts/ResourceType.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ResourceType.test.ts
@@ -78,6 +78,16 @@ test('attributes', () => {
   expect(resourceType.context.project.getSourceFile('src/types.ts')).toHaveFormattedTypeScriptText(`
     import type { JSONAPIServerResource } from '@fresha/api-tools-core';
 
+    /**
+     * HelloResource
+     *
+     * Attributes:
+     * -  name
+     * -  age
+     * -  gender
+     * -  active
+     *
+     */
     export type HelloResource = JSONAPIServerResource<
       'hello',
       {
@@ -94,6 +104,15 @@ test('relationships', () => {
   buildEmployeeSchemasForTesting(operation.root);
 
   const employee = operation.root.components.getSchemaOrThrow('EmployeeResource');
+  employee.title = 'Employee resource';
+  employee.description = `
+    This resource contains information about a single employee.
+    It also links to other related resources.
+  `
+    .split(/\n/)
+    .map(line => line.trim())
+    .filter(line => !!line.length)
+    .join('\n');
 
   // remove attributes to unclutter output
   employee.getPropertyDeepOrThrow('attributes').clearProperties();
@@ -116,6 +135,18 @@ test('relationships', () => {
       JSONAPIResourceRelationshipN,
     } from '@fresha/api-tools-core';
 
+    /**
+     * Employee resource
+     *
+     * This resource contains information about a single employee.
+     * It also links to other related resources.
+     *
+     * Relationships:
+     * -  manager relationship to the 'employees' resource
+     * -  buddy relationship to the 'employees' resource
+     * -  subordinates relationship to the 'employees' resource
+     *
+     */
     export type HelloResource = JSONAPIServerResource<
       'employees',
       {},


### PR DESCRIPTION
## Motivation and Context

This PR extends client fetch codegen with JSDoc documentation blocks. This improves IDE support when working with client libraries.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
