### PR TITLE
Improve fresha-openapi-diff logic and output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12785,6 +12785,8 @@
         "@fresha/api-tools-core": "^0.5.0",
         "@fresha/openapi-model": "^0.7.0",
         "chalk": "^4.1.2",
+        "semver": "^7.3.8",
+        "yaml": "^2.2.1",
         "yargs": "^17.6.2"
       },
       "bin": {
@@ -12794,7 +12796,46 @@
         "@fresha/eslint-config": "^0.2.0",
         "@fresha/jest-config": "^0.2.0",
         "@fresha/typescript-config": "^0.2.0",
+        "@types/semver": "^7.3.13",
         "typescript": "^5.0.2"
+      }
+    },
+    "packages/openapi-diff/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/openapi-diff/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/openapi-diff/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "packages/openapi-diff/node_modules/yaml": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "packages/openapi-lint": {

--- a/packages/openapi-diff/package.json
+++ b/packages/openapi-diff/package.json
@@ -59,12 +59,15 @@
     "@fresha/eslint-config": "^0.2.0",
     "@fresha/jest-config": "^0.2.0",
     "@fresha/typescript-config": "^0.2.0",
+    "@types/semver": "^7.3.13",
     "typescript": "^5.0.2"
   },
   "dependencies": {
     "@fresha/api-tools-core": "^0.5.0",
     "@fresha/openapi-model": "^0.7.0",
     "chalk": "^4.1.2",
+    "semver": "^7.3.8",
+    "yaml": "^2.2.1",
     "yargs": "^17.6.2"
   },
   "gitHead": "5830273395fc060b19d06814b9396ce07eea778d"

--- a/packages/openapi-diff/src/Differ.ts
+++ b/packages/openapi-diff/src/Differ.ts
@@ -3,6 +3,7 @@ import console from 'console';
 
 import { Nullable } from '@fresha/api-tools-core';
 import chalk from 'chalk';
+import { SemVer } from 'semver';
 
 import { DiffItem } from './DiffItem';
 import { Severity } from './types';
@@ -638,18 +639,19 @@ export class Differ {
       severities.add(item.severity);
     }
 
-    let [major, minor, patch] = this.#model2.info.version.split('.');
-
+    const version1 = new SemVer(this.#model1.info.version);
     if (severities.has('major')) {
-      major = `${Number(major) + 1}`;
+      version1.inc('major');
     } else if (severities.has('minor')) {
-      minor = `${Number(minor) + 1}`;
+      version1.inc('minor');
     } else if (severities.has('patch')) {
-      patch = `${Number(patch) + 1}`;
+      version1.inc('patch');
     }
 
-    this.#outdatedVersion = severities.size > 0;
-    this.#newVersion = `${major}.${minor}.${patch}`;
+    const version2 = new SemVer(this.#model2.info.version);
+
+    this.#outdatedVersion = version2.compare(version1) < 0;
+    this.#newVersion = (this.#outdatedVersion ? version1 : version2).toString();
   }
 
   print(): void {

--- a/packages/openapi-diff/src/index.ts
+++ b/packages/openapi-diff/src/index.ts
@@ -1,7 +1,9 @@
 import assert from 'assert';
 import console from 'console';
+import fs from 'fs';
 
-import { OpenAPIReader, OpenAPIWriter } from '@fresha/openapi-model/build/3.0.3';
+import { OpenAPIObject, OpenAPIReader } from '@fresha/openapi-model/build/3.0.3';
+import yaml from 'yaml';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
@@ -13,7 +15,7 @@ try {
       'For more information, see https://github.com/fresha/api-tools/tree/main/packages/openapi-diff',
     )
     .usage('Usage: $0 [OPTIONS] FILE1 FILE2')
-    .string('print-version')
+    .boolean('print-version')
     .describe('print-version', 'Prints suggested new version')
     .boolean('update-version')
     .describe('update-version', 'Updates schema version based on changes')
@@ -37,9 +39,18 @@ try {
     const suggestedNewVersion = differ.newVersion;
     console.log(suggestedNewVersion);
   } else if (argv.updateVersion) {
-    openapi2.info.version = differ.newVersion;
-    const writer = new OpenAPIWriter();
-    writer.writeToFile(openapi2, inputPath2);
+    // temporarily use yaml, to retain attribute order
+    const inputText = fs.readFileSync(inputPath2, 'utf-8');
+    const data = yaml.parse(inputText) as OpenAPIObject;
+
+    data.info.version = differ.newVersion;
+
+    const text = yaml.stringify(data);
+    fs.writeFileSync(inputPath2, text, 'utf-8');
+
+    // openapi2.info.version = differ.newVersion;
+    // const writer = new OpenAPIWriter();
+    // writer.writeToFile(openapi2, inputPath2);
   } else {
     differ.print();
     if (differ.outdatedVersion) {


### PR DESCRIPTION
## Motivation and Context

This PR improves fresha-openapi-diff in two areas:

- it correctly increments versions if the target has been changed
- when using `--update-version`, it preserves the order of attributes from original schema file (before, it messed them)

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
