### PR TITLE
Improve test coverage in openapi-model

### DIFF
--- a/packages/openapi-model/jest.config.js
+++ b/packages/openapi-model/jest.config.js
@@ -7,9 +7,9 @@ module.exports = {
   coverageThreshold: {
     ...coverageThreshold,
     './src/3.0.3/**/*.ts': {
-      branches: 60,
-      functions: 60,
-      lines: 60,
+      branches: 70,
+      functions: 80,
+      lines: 80,
     },
   },
 };

--- a/packages/openapi-model/src/3.0.3/model/OpenAPI.ts
+++ b/packages/openapi-model/src/3.0.3/model/OpenAPI.ts
@@ -161,30 +161,23 @@ export class OpenAPI implements OpenAPIModel, SpecificationExtensionsModel {
   }
 
   getPathItem(url: ParametrisedURLString): PathItem | undefined {
-    return this.paths.get(url);
+    return this.#paths.getItem(url);
   }
 
   getPathItemOrThrow(url: ParametrisedURLString): PathItem {
-    const result = this.paths.get(url);
-    assert(result);
-    return result;
+    return this.#paths.getItemOrThrow(url);
   }
 
   setPathItem(url: ParametrisedURLString): PathItem {
-    if (this.paths.has(url)) {
-      throw new Error(`Duplicate path item ${url}`);
-    }
-    const pathItem = new PathItem(this.paths);
-    this.paths.set(url, pathItem);
-    return pathItem;
+    return this.#paths.setPathItem(url);
   }
 
   deletePathItem(url: ParametrisedURLString): void {
-    this.paths.delete(url);
+    this.#paths.deletePathItem(url);
   }
 
   clearPathItems(): void {
-    this.paths.clear();
+    this.#paths.clearPathItems();
   }
 
   get components(): Components {

--- a/packages/openapi-model/src/3.0.3/model/Parameter/CookieParameter.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Parameter/CookieParameter.test.ts
@@ -1,0 +1,26 @@
+import { OpenAPIFactory } from '../OpenAPI';
+import { CookieParameterSerializationStyle } from '../types';
+
+import { CookieParameter } from './CookieParameter';
+
+let param: CookieParameter;
+
+beforeEach(() => {
+  const openapi = OpenAPIFactory.create();
+  param = openapi.components.setParameter('key', 'cookie', 'q') as CookieParameter;
+});
+
+test('defaults', () => {
+  expect(param.style).toBe('form');
+  expect(param.explode).toBe(true);
+  expect(param.required).toBe(false);
+});
+
+test('mutations', () => {
+  expect(() => {
+    param.style = 'matrix' as CookieParameterSerializationStyle;
+  }).toThrow();
+
+  param.required = true;
+  expect(param.required).toBe(true);
+});

--- a/packages/openapi-model/src/3.0.3/model/Parameter/CookieParameter.ts
+++ b/packages/openapi-model/src/3.0.3/model/Parameter/CookieParameter.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import { ParameterBase } from './ParameterBase';
 import { defaultExplode, defaultRequired } from './utils';
 
@@ -34,6 +36,7 @@ export class CookieParameter extends ParameterBase<'cookie'> implements CookiePa
   }
 
   set style(value: CookieParameterSerializationStyle) {
+    assert(value === 'form', `Invalid style ${value}`);
     this.#style = value;
   }
 }

--- a/packages/openapi-model/src/3.0.3/model/Parameter/HeaderParameter.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Parameter/HeaderParameter.test.ts
@@ -1,0 +1,25 @@
+import { OpenAPIFactory } from '../OpenAPI';
+
+import type { HeaderParameter } from './HeaderParameter';
+import type { HeaderParameterSerializationStyle } from '../types';
+
+let param: HeaderParameter;
+
+beforeEach(() => {
+  const openapi = OpenAPIFactory.create();
+  param = openapi.components.setParameter('key', 'header', 'q') as HeaderParameter;
+});
+
+test('defaults', () => {
+  expect(param.required).toBe(false);
+  expect(param.style).toBe('simple');
+});
+
+test('mutations', () => {
+  param.required = true;
+  expect(param.required).toBe(true);
+
+  expect(() => {
+    param.style = 'deepObject' as HeaderParameterSerializationStyle;
+  }).toThrow();
+});

--- a/packages/openapi-model/src/3.0.3/model/Parameter/HeaderParameter.ts
+++ b/packages/openapi-model/src/3.0.3/model/Parameter/HeaderParameter.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import { ParameterBase } from './ParameterBase';
 import { defaultExplode, defaultRequired } from './utils';
 
@@ -34,6 +36,7 @@ export class HeaderParameter extends ParameterBase<'header'> implements HeaderPa
   }
 
   set style(value: HeaderParameterSerializationStyle) {
+    assert(value === 'simple', `Invalid style ${value}`);
     this.#style = value;
   }
 }

--- a/packages/openapi-model/src/3.0.3/model/Parameter/ParameterBase.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Parameter/ParameterBase.test.ts
@@ -2,6 +2,9 @@ import { OpenAPIFactory } from '../OpenAPI';
 
 import { ParameterBase } from './ParameterBase';
 
+import type { Example } from '../Example';
+import type { MediaType } from '../MediaType';
+
 class Param extends ParameterBase<'path'> {}
 
 let param: Param;
@@ -11,22 +14,132 @@ beforeEach(() => {
   param = new Param(openapi.components, 'path', 'x');
 });
 
-test('getExample + getExampleOrThrow', () => {
-  param.setExample('json');
-  param.setExample('xml');
+test('schema', () => {
+  expect(param.schema).toBeNull();
 
-  expect(param.getExample('json')).not.toBeUndefined();
-  expect(param.getExample('wrong')).toBeUndefined();
-  expect(param.getExampleOrThrow('xml')).not.toBeUndefined();
-  expect(() => param.getExampleOrThrow('wrong')).toThrow();
+  const schema = param.setSchema({ type: 'string' });
+  expect(schema.parent).toBe(param);
+  expect(param.schema).toBe(schema);
+
+  expect(() => param.setSchema({ type: 'string' })).toThrow();
+
+  param.deleteSchema();
+
+  expect(param.schema).toBeNull();
+
+  const sharedSchema = param.root.components.setSchema('SharedSchema', { type: 'string' });
+  param.setSchema(sharedSchema);
+  expect(param.schema).toBe(sharedSchema);
+  expect(param.schema?.parent).toBe(param.root.components);
 });
 
-test('getContent + getContentOrThrow', () => {
-  param.setMediaType('application/json');
-  param.setMediaType('application/xml');
+describe('examples collection', () => {
+  test('querying', () => {
+    expect(param.exampleCount).toBe(0);
 
-  expect(param.getMediaType('application/json')).not.toBeUndefined();
-  expect(param.getMediaType('wrong')).toBeUndefined();
-  expect(param.getMediaTypeOrThrow('application/xml')).not.toBeUndefined();
-  expect(() => param.getMediaTypeOrThrow('wrong')).toThrow();
+    const example1 = param.setExample('json');
+    const example2 = param.setExample('xml');
+
+    expect(param.exampleCount).toBe(2);
+    expect(Array.from(param.exampleKeys())).toStrictEqual(['json', 'xml']);
+    expect(Array.from(param.examples())).toStrictEqual([
+      ['json', example1],
+      ['xml', example2],
+    ]);
+    expect(param.hasExample('json')).toBe(true);
+    expect(param.hasExample('wrong')).toBe(false);
+    expect(param.getExample('json')).toBe(example1);
+    expect(param.getExample('wrong')).toBeUndefined();
+    expect(param.getExampleOrThrow('xml')).toBe(example2);
+    expect(() => param.getExampleOrThrow('wrong')).toThrow();
+  });
+
+  test('mutation', () => {
+    param.setExample('json');
+    expect(() => param.setExample('json')).toThrow();
+
+    param.setExample('xml');
+    param.setExample('yaml');
+
+    expect(param.exampleCount).toBe(3);
+    expect(param.hasExample('xml')).toBe(true);
+
+    param.deleteExample('xml');
+
+    expect(param.exampleCount).toBe(2);
+    expect(param.hasExample('xml')).toBe(false);
+
+    param.clearExamples();
+
+    expect(param.exampleCount).toBe(0);
+  });
+
+  test('setExampleModel', () => {
+    param.setExample('json');
+
+    const sharedExample = param.root.components.setExample('SharedExample') as Example;
+
+    expect(() => param.setExampleModel('json', sharedExample)).toThrow();
+
+    param.setExampleModel('xml', sharedExample);
+  });
+});
+
+describe('media types collection', () => {
+  test('querying', () => {
+    expect(param.mediaTypeCount).toBe(0);
+
+    const mediaType1 = param.setMediaType('application/json');
+    const mediaType2 = param.setMediaType('application/xml');
+
+    expect(Array.from(param.mediaTypeKeys())).toStrictEqual([
+      'application/json',
+      'application/xml',
+    ]);
+    expect(Array.from(param.mediaTypes())).toStrictEqual([
+      ['application/json', mediaType1],
+      ['application/xml', mediaType2],
+    ]);
+
+    expect(param.hasMediaType('application/json')).toBe(true);
+    expect(param.hasMediaType('wrong')).toBe(false);
+
+    expect(param.getMediaType('application/json')).toBe(mediaType1);
+    expect(param.getMediaType('wrong')).toBeUndefined();
+    expect(param.getMediaTypeOrThrow('application/xml')).toBe(mediaType2);
+    expect(() => param.getMediaTypeOrThrow('wrong')).toThrow();
+  });
+
+  test('mutation', () => {
+    param.setMediaType('image/jpeg');
+    expect(() => param.setMediaType('image/jpeg')).toThrow();
+
+    param.setMediaType('image/png');
+    param.setMediaType('image/gif');
+
+    expect(param.mediaTypeCount).toBe(3);
+    expect(param.hasMediaType('image/png')).toBe(true);
+
+    param.deleteMediaType('image/png');
+
+    expect(param.mediaTypeCount).toBe(2);
+    expect(param.hasMediaType('image/png')).toBe(false);
+
+    param.clearMediaTypes();
+
+    expect(param.mediaTypeCount).toBe(0);
+  });
+
+  test('setMediaTypeModel', () => {
+    const anotherParam = param.root.components.setParameter('AnotherParam', 'path', 'x');
+    const anotherMediaType = anotherParam.setMediaType('application/json') as MediaType;
+
+    const mediaType = param.setMediaType('application/json');
+
+    expect(() => param.setMediaTypeModel('application/json', anotherMediaType)).toThrow();
+
+    param.setMediaTypeModel('application/xml', mediaType);
+    expect(param.getMediaType('application/xml')).toBe(mediaType);
+    expect(param.getMediaType('application/json')).toBe(mediaType);
+  });
 });

--- a/packages/openapi-model/src/3.0.3/model/Parameter/ParameterBase.ts
+++ b/packages/openapi-model/src/3.0.3/model/Parameter/ParameterBase.ts
@@ -83,6 +83,7 @@ export abstract class ParameterBase<TLocation extends ParameterLocation>
   }
 
   setSchema(params: CreateOrSetSchemaOptions): Schema {
+    assert(this.#schema === null, 'Schema already set');
     if (isSchemaModel(params)) {
       this.#schema = params as Schema;
     } else {
@@ -131,12 +132,11 @@ export abstract class ParameterBase<TLocation extends ParameterLocation>
 
   setExampleModel(name: string, model: Example): void {
     assert(!this.hasExample(name), `Example named '${name}' has already been set`);
-    assert.equal(model.parent, this);
-    assert(!Array.from(this.#examples.values()).includes(model));
     this.#examples.set(name, model);
   }
 
   setExample(name: string): Example {
+    assert(!this.hasExample(name), `Example named '${name}' has already been set`);
     const result = new Example(this as unknown as ExampleModelParent);
     this.#examples.set(name, result);
     return result;
@@ -182,14 +182,11 @@ export abstract class ParameterBase<TLocation extends ParameterLocation>
       `Content for mime type '${mimeType}' has already been set`,
     );
     assert.equal(model.parent, this, `Wrong parent for content model`);
-    assert(
-      !Array.from(this.#content.values()).includes(model),
-      `Content model for mime type '${mimeType}' is already in the list`,
-    );
     this.#content.set(mimeType, model);
   }
 
   setMediaType(key: MIMETypeString): MediaType {
+    assert(!this.#content.has(key), `Content for mime type '${key}' has already been set`);
     const result = new MediaType(this as unknown as MediaTypeModelParent);
     this.#content.set(key, result);
     return result;

--- a/packages/openapi-model/src/3.0.3/model/Parameter/PathParameter.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Parameter/PathParameter.test.ts
@@ -1,0 +1,27 @@
+import { OpenAPIFactory } from '../OpenAPI';
+
+import type { PathParameter } from './PathParameter';
+import type { PathParameterSerializationStyle } from '../types';
+
+let param: PathParameter;
+
+beforeEach(() => {
+  const openapi = OpenAPIFactory.create();
+  param = openapi.components.setParameter('key', 'path', 'p') as PathParameter;
+});
+
+test('defaults', () => {
+  expect(param.style).toBe('simple');
+  expect(param.explode).toBe(false);
+  expect(param.required).toBe(true);
+});
+
+test('style', () => {
+  expect(param.style).toBe('simple');
+  param.style = 'label';
+  expect(param.style).toBe('label');
+
+  expect(() => {
+    param.style = 'deepObject' as PathParameterSerializationStyle;
+  }).toThrow();
+});

--- a/packages/openapi-model/src/3.0.3/model/Parameter/PathParameter.ts
+++ b/packages/openapi-model/src/3.0.3/model/Parameter/PathParameter.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import { ParameterBase } from './ParameterBase';
 import { defaultExplode } from './utils';
 
@@ -24,6 +26,7 @@ export class PathParameter extends ParameterBase<'path'> implements PathParamete
   }
 
   set style(value: PathParameterSerializationStyle) {
+    assert(['matrix', 'label', 'simple'].includes(value), `Invalid style ${value}`);
     this.#style = value;
   }
 

--- a/packages/openapi-model/src/3.0.3/model/Parameter/QueryParameter.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Parameter/QueryParameter.test.ts
@@ -1,0 +1,36 @@
+import { OpenAPIFactory } from '../OpenAPI';
+
+import type { QueryParameter } from './QueryParameter';
+import type { QueryParameterSerializationStyle } from '../types';
+
+let param: QueryParameter;
+
+beforeEach(() => {
+  const openapi = OpenAPIFactory.create();
+  param = openapi.components.setParameter('key', 'query', 'q') as QueryParameter;
+});
+
+test('defaults', () => {
+  expect(param.style).toBe('form');
+  expect(param.explode).toBe(true);
+  expect(param.required).toBe(false);
+  expect(param.allowEmptyValue).toBe(false);
+  expect(param.allowReserved).toBe(false);
+});
+
+test('mutations', () => {
+  param.style = 'spaceDelimited';
+  expect(param.style).toBe('spaceDelimited');
+  expect(() => {
+    param.style = 'matrix' as QueryParameterSerializationStyle;
+  }).toThrow();
+
+  param.required = true;
+  expect(param.required).toBe(true);
+
+  param.allowEmptyValue = true;
+  expect(param.allowEmptyValue).toBe(true);
+
+  param.allowReserved = true;
+  expect(param.allowReserved).toBe(true);
+});

--- a/packages/openapi-model/src/3.0.3/model/Parameter/QueryParameter.ts
+++ b/packages/openapi-model/src/3.0.3/model/Parameter/QueryParameter.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import { ParameterBase } from './ParameterBase';
 import { defaultRequired, defaultExplode } from './utils';
 
@@ -46,6 +48,10 @@ export class QueryParameter extends ParameterBase<'query'> implements QueryParam
   }
 
   set style(value: QueryParameterSerializationStyle) {
+    assert(
+      ['form', 'spaceDelimited', 'pipeDelimited', 'deepObject'].includes(value),
+      `Invalid style ${value}`,
+    );
     this.#style = value;
   }
 

--- a/packages/openapi-model/src/3.0.3/model/Paths.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Paths.test.ts
@@ -1,18 +1,29 @@
 import { OpenAPIFactory } from './OpenAPI';
+import { PathItem } from './PathItem';
 
-let { paths } = OpenAPIFactory.create();
+import type { Paths } from './Paths';
+
+let paths: Paths;
 
 beforeEach(() => {
-  paths = OpenAPIFactory.create().paths;
+  paths = OpenAPIFactory.create().paths as Paths;
 });
 
-test('getItem + getItemOrThrow', () => {
-  paths.root.setPathItem('/people');
-  paths.root.setPathItem('/pets');
+test('querying', () => {
+  const item1 = paths.root.setPathItem('/people');
+  const item2 = paths.root.setPathItem('/pets');
 
-  expect(paths.getItem('/people')).not.toBeUndefined();
+  expect(paths.pathItemCount).toBe(2);
+  expect([...paths.pathItemUrls()]).toStrictEqual(['/people', '/pets']);
+  expect([...paths.pathItems()]).toStrictEqual([
+    ['/people', item1],
+    ['/pets', item2],
+  ]);
+  expect(paths.hasPathItem('/people')).toBe(true);
+  expect(paths.hasPathItem('/wizards')).toBe(false);
+  expect(paths.getItem('/people')).toBe(item1);
   expect(paths.getItem('/wizards')).toBeUndefined();
-  expect(paths.getItemOrThrow('/pets')).not.toBeUndefined();
+  expect(paths.getItemOrThrow('/pets')).toBe(item2);
   expect(() => paths.getItemOrThrow('/monsters')).toThrow();
 });
 
@@ -34,7 +45,7 @@ test('getItemUrl() + getItemUrlOrThrow()', () => {
 });
 
 test('getItemUrl() + mutations', () => {
-  const item = paths.root.setPathItem('/hello');
+  const item = paths.root.setPathItem('/hello') as PathItem;
   paths.root.deletePathItem('/hello');
   expect(paths.getItemUrl(item)).toBeUndefined();
 });

--- a/packages/openapi-model/src/3.0.3/model/Paths.ts
+++ b/packages/openapi-model/src/3.0.3/model/Paths.ts
@@ -56,38 +56,18 @@ export class Paths extends BasicNode<PathsModelParent> implements PathsModel {
   }
 
   setPathItem(key: string): PathItem {
+    assert(!this.#items.has(key), `Path item at ${key} already exists`);
     const result = new PathItem(this);
     this.#items.set(key, result);
     return result;
   }
 
-  clear(): void {
+  deletePathItem(key: ParametrisedURLString): void {
+    this.#items.delete(key);
+  }
+
+  clearPathItems(): void {
     this.#items.clear();
-  }
-
-  delete(key: string): boolean {
-    return this.#items.delete(key);
-  }
-
-  forEach(
-    callbackfn: (value: PathItem, key: string, map: Map<string, PathItem>) => void,
-    thisArg?: unknown,
-  ): void {
-    this.#items.forEach(callbackfn, thisArg);
-  }
-
-  get(key: string): PathItem | undefined {
-    return this.#items.get(key);
-  }
-
-  has(key: string): boolean {
-    return this.#items.has(key);
-  }
-
-  set(key: string, value: PathItem): this {
-    assert(value.parent === this, `Path item at ${key} does not belong to the paths object`);
-    this.#items.set(key, value);
-    return this;
   }
 
   sort(sorter: (entry1: [string, PathItem], entry2: [string, PathItem]) => number): void {

--- a/packages/openapi-model/src/3.0.3/model/Response.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Response.test.ts
@@ -9,7 +9,7 @@ beforeEach(() => {
 });
 
 describe('headers collection', () => {
-  test('getHeader + getHeaderOrThrow', () => {
+  test('querying', () => {
     response.setHeader('X-Language');
     response.setHeader('X-Fresha');
 
@@ -18,10 +18,25 @@ describe('headers collection', () => {
     expect(response.getHeaderOrThrow('X-Language')).not.toBeUndefined();
     expect(() => response.getHeaderOrThrow('?')).toThrow();
   });
+
+  test('mutations', () => {
+    response.setHeader('X-Language');
+    response.setHeader('X-Fresha');
+
+    expect(() => {
+      response.setHeader('X-Language');
+    }).toThrow();
+
+    response.deleteHeader('X-Language');
+    expect(response.getHeader('X-Language')).toBeUndefined();
+
+    response.clearHeaders();
+    expect(response.getHeader('X-Fresha')).toBeUndefined();
+  });
 });
 
 describe('media type collection', () => {
-  test('getContent + getContentOrThrow', () => {
+  test('querying', () => {
     response.setMediaType('application/json');
     response.setMediaType('application/xml');
 
@@ -32,16 +47,62 @@ describe('media type collection', () => {
     expect(response.getMediaTypeOrThrow('application/xml')).not.toBeUndefined();
     expect(() => response.getMediaTypeOrThrow('-')).toThrow();
   });
+
+  test('mutations', () => {
+    response.setMediaType('application/json');
+    response.setMediaType('application/xml');
+
+    expect(() => {
+      response.setMediaType('application/json');
+    }).toThrow();
+
+    response.deleteMediaType('application/json');
+    expect(response.mediaTypeCount).toBe(1);
+
+    response.clearMediaTypes();
+    expect(response.mediaTypeCount).toBe(0);
+  });
 });
 
 describe('links collection', () => {
-  test('getLink + getLinkOrThrow', () => {
+  test('querying', () => {
+    expect(response.linkCount).toBe(0);
+
+    const link1 = response.setLink('Language');
+    const link2 = response.setLink('Fresha');
+
+    expect(response.linkCount).toBe(2);
+    expect([...response.linkKeys()]).toStrictEqual(['Language', 'Fresha']);
+    expect([...response.links()]).toStrictEqual([
+      ['Language', link1],
+      ['Fresha', link2],
+    ]);
+    expect(response.hasLink('Language')).toBe(true);
+    expect(response.hasLink('_')).toBe(false);
+    expect(response.getLink('Language')).toBe(link1);
+    expect(response.getLink('_')).toBeUndefined();
+    expect(response.getLinkOrThrow('Fresha')).toBe(link2);
+    expect(() => response.getLinkOrThrow('?')).toThrow();
+  });
+
+  test('mutations', () => {
     response.setLink('Language');
     response.setLink('Fresha');
 
-    expect(response.getLink('Language')).not.toBeUndefined();
-    expect(response.getLink('_')).toBeUndefined();
-    expect(response.getLinkOrThrow('Fresha')).not.toBeUndefined();
-    expect(() => response.getLinkOrThrow('?')).toThrow();
+    expect(() => {
+      response.setLink('Language');
+    }).toThrow();
+
+    const sharedLink = response.root.components.setLink('SharedLink');
+    expect(() => {
+      response.setLinkModel('Fresha', sharedLink);
+    }).toThrow();
+    response.setLinkModel('Shared', sharedLink);
+
+    response.deleteLink('Language');
+    expect(response.linkCount).toBe(2);
+
+    response.clearLinks();
+    expect(response.linkCount).toBe(0);
   });
 });

--- a/packages/openapi-model/src/3.0.3/model/Response.ts
+++ b/packages/openapi-model/src/3.0.3/model/Response.ts
@@ -55,11 +55,12 @@ export class Response extends BasicNode<ResponseModelParent> implements Response
 
   getHeaderOrThrow(name: string): Header {
     const result = this.getHeader(name);
-    assert(result);
+    assert(result, `Header '${name}' does not exist`);
     return result;
   }
 
   setHeader(name: string): Header {
+    assert(!this.hasHeader(name), `Header '${name}' already exists`);
     const result = new Header(this);
     this.#headers.set(name, result);
     return result;
@@ -95,14 +96,12 @@ export class Response extends BasicNode<ResponseModelParent> implements Response
 
   getMediaTypeOrThrow(mimeType: MIMETypeString): MediaType {
     const result = this.getMediaType(mimeType);
-    assert(result);
+    assert(result, `Media type '${mimeType}' does not exist`);
     return result;
   }
 
   setMediaType(mimeType: MIMETypeString): MediaType {
-    if (this.#content.has(mimeType)) {
-      throw new Error(`Duplicate content for ${mimeType}`);
-    }
+    assert(!this.hasMediaType(mimeType), `Media type '${mimeType}' already exists`);
     const result = new MediaType(this);
     this.#content.set(mimeType, result);
     return result;
@@ -143,6 +142,7 @@ export class Response extends BasicNode<ResponseModelParent> implements Response
   }
 
   setLink(key: string): Link {
+    assert(!this.hasLink(key), `Link '${key}' already exists`);
     const result = new Link(this);
     this.#links.set(key, result);
     return result;
@@ -150,10 +150,6 @@ export class Response extends BasicNode<ResponseModelParent> implements Response
 
   setLinkModel(key: string, link: Link): void {
     assert(!this.hasLink(key), `Link '${key}' already exists`);
-    assert(
-      !Array.from(this.#links.values()).includes(link),
-      `Link to be placed under the '${key}' key already exists under different key`,
-    );
     this.#links.set(key, link);
   }
 

--- a/packages/openapi-model/src/3.0.3/model/SecurityScheme/APIKeySecurityScheme.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/SecurityScheme/APIKeySecurityScheme.test.ts
@@ -1,0 +1,29 @@
+import { OpenAPIFactory } from '../OpenAPI';
+
+import type { APIKeySecurityScheme } from './APIKeySecurityScheme';
+import type { APIKeySecuritySchemaModelLocation } from '../types';
+
+let schema: APIKeySecurityScheme;
+
+beforeEach(() => {
+  const openapi = OpenAPIFactory.create();
+  schema = openapi.components.setSecuritySchema('key', 'apiKey') as APIKeySecurityScheme;
+});
+
+test('defaults', () => {
+  expect(schema.name).toBe('key');
+  expect(schema.in).toBe('header');
+});
+
+test('mutations', () => {
+  schema.name = 'key2';
+  expect(schema.name).toBe('key2');
+  expect(schema.root.components.getSecuritySchema('key')).toBe(schema);
+
+  schema.in = 'query';
+  expect(schema.in).toBe('query');
+
+  expect(() => {
+    schema.in = 'invalid' as APIKeySecuritySchemaModelLocation;
+  }).toThrow();
+});

--- a/packages/openapi-model/src/3.0.3/model/SecurityScheme/APIKeySecurityScheme.ts
+++ b/packages/openapi-model/src/3.0.3/model/SecurityScheme/APIKeySecurityScheme.ts
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import { SecuritySchemeBase } from './SecuritySchemeBase';
 
 import type {
@@ -31,6 +33,7 @@ export class APIKeySecurityScheme
   }
 
   set name(value: string) {
+    assert(value, `Invalid or empty name '${value}'`);
     this.#name = value;
   }
 
@@ -39,6 +42,7 @@ export class APIKeySecurityScheme
   }
 
   set in(value: APIKeySecuritySchemaModelLocation) {
+    assert(['query', 'header', 'cookie'].includes(value), `Invalid location '${value}'`);
     this.#in = value;
   }
 }

--- a/packages/openapi-model/src/3.0.3/model/SecurityScheme/OpenIdConnectSecurityScheme.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/SecurityScheme/OpenIdConnectSecurityScheme.test.ts
@@ -1,0 +1,26 @@
+import { OpenAPIFactory } from '../OpenAPI';
+
+import { OpenIdConnectSecurityScheme } from './OpenIdConnectSecurityScheme';
+
+let schema: OpenIdConnectSecurityScheme;
+
+beforeEach(() => {
+  const openapi = OpenAPIFactory.create();
+  schema = openapi.components.setSecuritySchema(
+    'key',
+    'openIdConnect',
+  ) as OpenIdConnectSecurityScheme;
+});
+
+test('defaults', () => {
+  expect(schema.openIdConnectUrl).toBe('http://www.example.com');
+});
+
+test('mutations', () => {
+  schema.openIdConnectUrl = 'http://www.example.com/2';
+  expect(schema.openIdConnectUrl).toBe('http://www.example.com/2');
+
+  expect(() => {
+    schema.openIdConnectUrl = 'invalid/url';
+  }).toThrow();
+});

--- a/packages/openapi-model/src/3.0.3/model/SecurityScheme/OpenIdConnectSecurityScheme.ts
+++ b/packages/openapi-model/src/3.0.3/model/SecurityScheme/OpenIdConnectSecurityScheme.ts
@@ -1,3 +1,7 @@
+import assert from 'assert';
+
+import isURL from 'validator/lib/isURL';
+
 import { SecuritySchemeBase } from './SecuritySchemeBase';
 
 import type { OpenIDConnectSecuritySchemaModel, SecuritySchemaModelParent } from '../types';
@@ -14,7 +18,13 @@ export class OpenIdConnectSecurityScheme
 
   constructor(parent: SecuritySchemaModelParent, openIdConnectUrl: URLString) {
     super(parent, 'openIdConnect');
+    this.#assertUrl(openIdConnectUrl);
     this.#openIdConnectUrl = openIdConnectUrl;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  #assertUrl(value: URLString): void {
+    assert(isURL(value), `Invalid URL '${value}'`);
   }
 
   get openIdConnectUrl(): URLString {
@@ -22,6 +32,7 @@ export class OpenIdConnectSecurityScheme
   }
 
   set openIdConnectUrl(value: URLString) {
+    this.#assertUrl(value);
     this.#openIdConnectUrl = value;
   }
 }

--- a/packages/openapi-model/src/3.0.3/model/ServerVariable.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/ServerVariable.test.ts
@@ -1,0 +1,46 @@
+import { OpenAPIFactory } from './OpenAPI';
+
+import type { ServerVariable } from './ServerVariable';
+
+let serverVariable: ServerVariable;
+
+beforeEach(() => {
+  const openapi = OpenAPIFactory.create();
+  const server = openapi.addServer('https://www.example.com/{version}');
+  serverVariable = server.getVariableOrThrow('version') as ServerVariable;
+});
+
+test('allowed values', () => {
+  expect(serverVariable.allowedValueCount).toBe(0);
+
+  serverVariable.addAllowedValues('1.0', '1.1');
+
+  expect(serverVariable.allowedValueCount).toBe(2);
+  expect([...serverVariable.allowedValues()]).toStrictEqual(['1.0', '1.1']);
+  expect(serverVariable.hasAllowedValue('1.0')).toBe(true);
+  expect(serverVariable.hasAllowedValue('1.2')).toBe(false);
+
+  serverVariable.deleteAllowedValues('1.1', '1.4');
+  expect(serverVariable.allowedValueCount).toBe(1);
+
+  serverVariable.clearAllowedValues();
+  expect(serverVariable.allowedValueCount).toBe(0);
+});
+
+test('default value', () => {
+  serverVariable.defaultValue = 'can set becase the list of allowed values is empty';
+  expect(serverVariable.defaultValue).not.toBe('');
+
+  serverVariable.addAllowedValues('1.5');
+  expect(() => {
+    serverVariable.defaultValue = '1.0';
+  }).toThrow();
+
+  serverVariable.addAllowedValues('1.1', '1.2');
+  serverVariable.defaultValue = '1.1';
+
+  expect(serverVariable.defaultValue).toBe('1.1');
+
+  serverVariable.deleteAllowedValues('1.1');
+  expect(serverVariable.defaultValue).toBe('');
+});

--- a/packages/openapi-model/src/3.0.3/model/ServerVariable.ts
+++ b/packages/openapi-model/src/3.0.3/model/ServerVariable.ts
@@ -49,7 +49,7 @@ export class ServerVariable
         resetDefault = true;
       }
     }
-    if (resetDefault && !this.#allowedValues.size) {
+    if (resetDefault && this.#allowedValues.size) {
       this.#defaultValue = '';
     }
   }

--- a/packages/openapi-model/src/3.0.3/model/Tag.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/Tag.test.ts
@@ -2,12 +2,36 @@ import { OpenAPI } from './OpenAPI';
 import { Tag } from './Tag';
 
 let parent: OpenAPI;
+let tag: Tag;
 
 beforeEach(() => {
   parent = new OpenAPI('Tag.test', '0.0.1');
+  tag = new Tag(parent, 'tag#1');
 });
 
 test('constructor', () => {
-  const tag = new Tag(parent, 'tag#1');
   expect(tag.name).toBe('tag#1');
+});
+
+test('mutations', () => {
+  expect(tag.description).toBeNull();
+
+  tag.description = 'description#1';
+  expect(tag.description).toBe('description#1');
+
+  expect(tag.name).toBe('tag#1');
+  expect(() => {
+    tag.name = '';
+  }).toThrow();
+});
+
+test('externalDocs', () => {
+  expect(tag.externalDocs).toBeNull();
+
+  const externalDocs = tag.setExternalDocs('https://www.example.com');
+  expect(tag.externalDocs).toBe(externalDocs);
+  expect(externalDocs.url).toBe('https://www.example.com');
+
+  tag.deleteExternalDocs();
+  expect(tag.externalDocs).toBeNull();
 });

--- a/packages/openapi-model/src/3.0.3/model/XML.test.ts
+++ b/packages/openapi-model/src/3.0.3/model/XML.test.ts
@@ -16,3 +16,19 @@ test('basic logic', () => {
   expect(xml).toHaveProperty('attribute', false);
   expect(xml).toHaveProperty('wrapped', false);
 });
+
+test('mutations', () => {
+  const xml = parent.setXML();
+
+  xml.name = 'name2';
+  xml.namespace = 'namespace2';
+  xml.prefix = 'prefix2';
+  xml.attribute = true;
+  xml.wrapped = true;
+
+  expect(xml).toHaveProperty('name', 'name2');
+  expect(xml).toHaveProperty('namespace', 'namespace2');
+  expect(xml).toHaveProperty('prefix', 'prefix2');
+  expect(xml).toHaveProperty('attribute', true);
+  expect(xml).toHaveProperty('wrapped', true);
+});

--- a/packages/openapi-model/src/3.0.3/model/types.ts
+++ b/packages/openapi-model/src/3.0.3/model/types.ts
@@ -929,6 +929,9 @@ export interface PathsModel extends TreeNodeModel<PathsModelParent>, Specificati
 
   setPathItem(key: ParametrisedURLString): PathItemModel;
 
+  deletePathItem(url: ParametrisedURLString): void;
+  clearPathItems(): void;
+
   sort(
     sorter: (
       entry1: [ParametrisedURLString, PathItemModel],


### PR DESCRIPTION
## Motivation and Context

This PR improves test coverage of the `@fresha/openapi-model` package, and makes it possible to set the coverage threshold to 70% (branch) and 80% (lines or functions).

Apart from more tests, I fixed several smaller bugs in property setters.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
