### PR TITLE
Allow optional header parameters

### DIFF
--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
@@ -162,10 +162,10 @@ test('simple test', () => {
       addQueryParam(url, 'offset', params.offset);
       addQueryParam(url, 'limit', params.limit);
 
-      const headers = {...COMMON_HEADERS}
+      const headers = {...COMMON_HEADERS};
 
       const request = {
-        headers: headers,
+        headers,
       };
 
       authorizeRequest(request, extraParams);
@@ -298,11 +298,11 @@ test('specific naming convention for client library', () => {
     ): Promise<ReadEmployeeListResponse> {
       const url = makeUrl(\`/employees\`);
 
-      const headers = {...COMMON_HEADERS}
+      const headers = {...COMMON_HEADERS};
 
       const request = {
         method: 'PATCH',
-        headers: headers,
+        headers,
       };
 
       authorizeRequest(request, extraParams);
@@ -396,10 +396,10 @@ test('action returns raw response', () => {
     ): Promise<Response> {
       const url = makeUrl(\`/employees\`);
 
-      const headers = {...COMMON_HEADERS}
+      const headers = {...COMMON_HEADERS};
 
       const request = {
-        headers: headers,
+        headers,
       };
 
       applyExtraParams(request, extraParams);
@@ -420,15 +420,13 @@ test('test optional header parameters', () => {
   const operation = openapi.setPathItem('/test-endpoint').addOperation('get');
   operation.operationId = 'test';
   operation.summary = 'operation with an optional header';
-  operation.description = `This operation has an optional header parameter`
+  operation.description = `This operation has an optional header parameter`;
 
   const headerParameter = operation.addParameter('Optional-Header-Parameter', 'header');
   headerParameter.required = false;
   headerParameter.setSchema('string');
   headerParameter.description = 'optional header parameter';
-  operation
-    .setResponse(200, 'returns a success')
-    .setMediaType(MEDIA_TYPE_JSON_API)
+  operation.setResponse(200, 'returns a success').setMediaType(MEDIA_TYPE_JSON_API);
 
   operation.addSecurityRequirement().addSchema('the_auth');
 
@@ -483,7 +481,7 @@ test('test optional header parameters', () => {
         headers['Optional-Header-Parameter'] = params.OptionalHeaderParameter;
 
       const request = {
-        headers: headers,
+        headers,
       };
 
       authorizeRequest(request, extraParams);

--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
@@ -206,7 +206,7 @@ export class ActionFunc {
         }
       }
 
-      writer.writeLine('const headers = {...COMMON_HEADERS}');
+      writer.writeLine('const headers = {...COMMON_HEADERS};');
 
       writer.newLine();
 
@@ -226,7 +226,7 @@ export class ActionFunc {
         if (this.requestType) {
           writer.writeLine('body: JSON.stringify(body),');
         }
-        writer.write('headers: headers,');
+        writer.write('headers,');
       });
       writer.writeLine('};');
       writer.newLine();

--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
@@ -206,6 +206,17 @@ export class ActionFunc {
         }
       }
 
+      writer.writeLine('const headers = {...COMMON_HEADERS}');
+
+      writer.newLine();
+
+      if (this.headerToSet.size) {
+        for (const [headerName, varName] of this.headerToSet) {
+          writer.writeLine(`if (params.${varName}) headers['${headerName}'] = params.${varName}`);
+        }
+      }
+      writer.newLine();
+
       writer.writeLine('const request = {');
       writer.indent(() => {
         const httpMethod = this.context.operation.httpMethod.toUpperCase();
@@ -215,18 +226,7 @@ export class ActionFunc {
         if (this.requestType) {
           writer.writeLine('body: JSON.stringify(body),');
         }
-        if (this.headerToSet.size) {
-          writer.write('headers:');
-          writer.block(() => {
-            writer.writeLine('...COMMON_HEADERS,');
-            for (const [headerName, varName] of this.headerToSet) {
-              writer.writeLine(`'${headerName}': params.${varName}`);
-            }
-          });
-          writer.writeLine(',');
-        } else {
-          writer.writeLine('headers: COMMON_HEADERS,');
-        }
+        writer.write('headers: headers,');
       });
       writer.writeLine('};');
       writer.newLine();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Fresha API tools.
-->

## Motivation and Context

When I made a header parameter optional in the refresh schema the client libraries failed to build with a type error

## Type of changes

This PR aims to fix this issue

- [x] Bug fix (non-breaking change which fixes an issue)

here is the original error
https://github.com/surgeventures/system/actions/runs/4532203561/jobs/7983379313?pr=55153