### PR TITLE
Improve test coverage in codegen client fetch

### DIFF
--- a/packages/openapi-codegen-client-fetch/package.json
+++ b/packages/openapi-codegen-client-fetch/package.json
@@ -22,7 +22,7 @@
     "lint": "run-s eslint typecheck",
     "lint:fix": "run-s eslint:fix typecheck",
     "prebuild": "npm run clean",
-    "test": "jest",
+    "test": "jest --coverage",
     "typecheck": "tsc --noEmit"
   },
   "files": [

--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
@@ -6,7 +6,7 @@ import {
   RelationshipCardinality,
   setResourceSchema,
 } from '@fresha/openapi-codegen-utils';
-import { OpenAPIFactory, OperationModel } from '@fresha/openapi-model/build/3.0.3';
+import { OpenAPIFactory, OpenAPIModel, OperationModel } from '@fresha/openapi-model/build/3.0.3';
 
 import '@fresha/openapi-codegen-test-utils/build/matchers';
 
@@ -22,8 +22,13 @@ const createAction = (operation: OperationModel, filePath = 'src/index.ts'): Act
   return new ActionFunc(context);
 };
 
+let openapi: OpenAPIModel;
+
+beforeEach(() => {
+  openapi = OpenAPIFactory.create();
+});
+
 test('simple test', () => {
-  const openapi = OpenAPIFactory.create();
   buildEmployeeSchemasForTesting(openapi);
 
   openapi.components.setSecuritySchema('the_auth', 'apiKey');
@@ -79,8 +84,6 @@ test('simple test', () => {
 });
 
 test('specific naming convention for client library', () => {
-  const openapi = OpenAPIFactory.create();
-
   // construct a resource with kebab-case attributes
   const employee = openapi.components.setSchema('EmployeeResource');
   setResourceSchema(employee, 'employees');
@@ -134,8 +137,6 @@ test('specific naming convention for client library', () => {
 });
 
 test('action returns raw response', () => {
-  const openapi = OpenAPIFactory.create();
-
   const schema = openapi.components.setSchema('EmployeeResource');
   setResourceSchema(schema, 'employees');
 
@@ -173,7 +174,6 @@ test('action returns raw response', () => {
 });
 
 test('test optional header parameters', () => {
-  const openapi = OpenAPIFactory.create();
   buildEmployeeSchemasForTesting(openapi);
 
   openapi.components.setSecuritySchema('the_auth', 'apiKey');

--- a/packages/openapi-codegen-client-fetch/src/parts/DocumentType.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/DocumentType.ts
@@ -64,9 +64,7 @@ export class DocumentType extends NamedType {
     const primaryDataSchemas: SchemaModel[] = [];
 
     if (primaryDataSchema?.type === 'array') {
-      if (Array.isArray(primaryDataSchema.items)) {
-        primaryDataSchemas.push(...primaryDataSchema.items);
-      } else if (primaryDataSchema.items) {
+      if (primaryDataSchema.items) {
         primaryDataSchemas.push(primaryDataSchema.items);
       }
       this.primaryDataIsArray = true;

--- a/packages/openapi-codegen-client-fetch/src/parts/IndexFile.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/IndexFile.test.ts
@@ -1,0 +1,18 @@
+import { OpenAPIFactory } from '@fresha/openapi-model/build/3.0.3';
+
+import { createTestContext } from '../testHelpers';
+
+import { IndexFile } from './IndexFile';
+
+test('simple', () => {
+  const openapi = OpenAPIFactory.create();
+  const context = createTestContext(openapi);
+  const utils = new IndexFile(context);
+
+  utils.collectData();
+  utils.generateCode();
+
+  expect(context.project.getSourceFileOrThrow('src/index.ts').getText()).toMatchSnapshot(
+    'src/index.ts',
+  );
+});

--- a/packages/openapi-codegen-client-fetch/src/parts/ResourceType.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ResourceType.test.ts
@@ -14,8 +14,6 @@ import { createActionTestContext } from '../testHelpers';
 import { NamedType } from './NamedType';
 import { ResourceType } from './ResourceType';
 
-import '@fresha/openapi-codegen-test-utils/build/matchers';
-
 const createResourceType = (
   operation: OperationModel,
   name: string,
@@ -47,12 +45,9 @@ test('simple, client resource', () => {
   resourceType.collectData(namedTypes);
   resourceType.generateCode(generatedTypes);
 
-  expect(resourceType.context.project.getSourceFileOrThrow('src/types.ts'))
-    .toHaveFormattedTypeScriptText(`
-    import type { JSONAPIClientResource } from '@fresha/api-tools-core';
-
-    export type SimpleResource = JSONAPIClientResource;
-  `);
+  expect(
+    resourceType.context.project.getSourceFileOrThrow('src/types.ts').getText(),
+  ).toMatchSnapshot('src/types.ts');
 });
 
 test('attributes', () => {
@@ -75,29 +70,9 @@ test('attributes', () => {
   resourceType.collectData(namedTypes);
   resourceType.generateCode(generatedTypes);
 
-  expect(resourceType.context.project.getSourceFile('src/types.ts')).toHaveFormattedTypeScriptText(`
-    import type { JSONAPIServerResource } from '@fresha/api-tools-core';
-
-    /**
-     * HelloResource
-     *
-     * Attributes:
-     * -  name
-     * -  age
-     * -  gender
-     * -  active
-     *
-     */
-    export type HelloResource = JSONAPIServerResource<
-      'hello',
-      {
-        name: string;
-        age?: number | null;
-        gender: 'male' | 'female' | 'other' | null;
-        active?: boolean;
-      }
-    >;
-  `);
+  expect(
+    resourceType.context.project.getSourceFileOrThrow('src/types.ts').getText(),
+  ).toMatchSnapshot();
 });
 
 test('relationships', () => {
@@ -126,34 +101,7 @@ test('relationships', () => {
   resourceType.collectData(namedTypes);
   resourceType.generateCode(generatedTypes);
 
-  expect(resourceType.context.project.getSourceFile('src/types.ts')).toHaveFormattedTypeScriptText(`
-    import type {
-      JSONAPIServerResource,
-      JSONAPIResourceRelationship1,
-      JSONAPIResourceRelationship0,
-      JSONAPIResourceRelationshipN,
-    } from '@fresha/api-tools-core';
-
-    /**
-     * Employee resource
-     *
-     * This resource contains information about a single employee.
-     * It also links to other related resources.
-     *
-     * Relationships:
-     * -  manager relationship to the 'employees' resource
-     * -  buddy relationship to the 'employees' resource
-     * -  subordinates relationship to the 'employees' resource
-     *
-     */
-    export type HelloResource = JSONAPIServerResource<
-      'employees',
-      {},
-      {
-        manager: JSONAPIResourceRelationship1<'employees'>;
-        buddy: JSONAPIResourceRelationship0<'employees'>;
-        subordinates: JSONAPIResourceRelationshipN<'employees'>;
-      }
-    >;
-  `);
+  expect(
+    resourceType.context.project.getSourceFileOrThrow('src/types.ts').getText(),
+  ).toMatchSnapshot('src/types.ts');
 });

--- a/packages/openapi-codegen-client-fetch/src/parts/UtilsFile.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/UtilsFile.test.ts
@@ -1,0 +1,18 @@
+import { OpenAPIFactory } from '@fresha/openapi-model/build/3.0.3/model/OpenAPI';
+
+import { createTestContext } from '../testHelpers';
+
+import { UtilsFile } from './UtilsFile';
+
+test('simple', () => {
+  const openapi = OpenAPIFactory.create();
+  const context = createTestContext(openapi);
+
+  const utils = new UtilsFile(context);
+  utils.collectData();
+  utils.generateCode();
+
+  expect(context.project.getSourceFileOrThrow('src/utils.ts').getText()).toMatchSnapshot(
+    'src/utils.ts',
+  );
+});

--- a/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/DocumentType.test.ts.snap
+++ b/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/DocumentType.test.ts.snap
@@ -1,0 +1,196 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generic: src/types.ts 1`] = `
+"import type { JSONAPIDataDocument } from "@fresha/api-tools-core";
+
+
+/**
+ * This is a response resource
+ *
+ */
+export type SimpleResponseDocument = JSONAPIDataDocument;
+"
+`;
+
+exports[`included includes resources of multiple types: src/types.ts 1`] = `
+"import type { JSONAPIServerResource, JSONAPIDataDocument } from "@fresha/api-tools-core";
+
+
+/**
+ * Employee
+ *
+ */
+export type Employee = JSONAPIServerResource<'employees'>;
+
+/**
+ * Organization
+ *
+ */
+export type Organization = JSONAPIServerResource<'organizations'>;
+
+/**
+ * This is a response resource
+ *
+ * Primary data resources:
+ *  - Employee
+ *
+ * Included resources:
+ *  - Organization
+ *  - Employee
+ *
+ */
+export type DocumentWithIncludedResources = JSONAPIDataDocument<Employee, Organization | Employee>;
+"
+`;
+
+exports[`included single type of included resources: src/types.ts 1`] = `
+"import type { JSONAPIServerResource, JSONAPIDataDocument } from "@fresha/api-tools-core";
+
+
+/**
+ * Employee
+ *
+ */
+export type Employee = JSONAPIServerResource<'employees'>;
+
+/**
+ * This is a response resource
+ *
+ * Primary data resources:
+ *  - Employee
+ *
+ * Included resources:
+ *  - Employee
+ *
+ */
+export type DocumentWithIncludedResources = JSONAPIDataDocument<Employee, Employee>;
+"
+`;
+
+exports[`jsdocs: src/types.ts 1`] = `
+"import type { JSONAPIServerResource, JSONAPIDataDocument } from "@fresha/api-tools-core";
+
+
+/**
+ * Employee
+ *
+ */
+export type Employee = JSONAPIServerResource<'employees'>;
+
+/**
+ * A simple object schema
+ *
+ * This is a description of the schema.
+ * The schema represents a simple object.
+ *
+ * This is a response resource
+ *
+ * Primary data resources:
+ *  - Employee
+ *
+ */
+export type SimpleResponseDocument = JSONAPIDataDocument<Employee>;
+"
+`;
+
+exports[`primary data multiple resources of the same type: src/types.ts 1`] = `
+"import type { JSONAPIServerResource, JSONAPIDataDocument } from "@fresha/api-tools-core";
+
+
+/**
+ * Employee
+ *
+ */
+export type Employee = JSONAPIServerResource<'employees'>;
+
+/**
+ * This is a response resource
+ *
+ * Primary data resources:
+ *  - Employee
+ *
+ */
+export type SimpleResponseDocument = JSONAPIDataDocument<(Employee)[]>;
+"
+`;
+
+exports[`primary data single inline resource: src/types.ts 1`] = `
+"import type { JSONAPIServerResource, JSONAPIDataDocument } from "@fresha/api-tools-core";
+
+
+export type Unknown1 = JSONAPIServerResource<'employees'>;
+
+/**
+ * This is a response resource
+ *
+ * Primary data resources:
+ *  - Unknown1
+ *
+ */
+export type SimpleResponseDocument = JSONAPIDataDocument<Unknown1>;
+"
+`;
+
+exports[`primary data single resource of possibly multiple types: src/types.ts 1`] = `
+"import type { JSONAPIServerResource, JSONAPIDataDocument } from "@fresha/api-tools-core";
+
+
+/**
+ * EmployeeResource
+ *
+ */
+export type EmployeeResource = JSONAPIServerResource<'employees'>;
+
+/**
+ * OrganizationResource
+ *
+ */
+export type OrganizationResource = JSONAPIServerResource<'organizations'>;
+
+/**
+ * This is a response resource
+ *
+ * Primary data resources:
+ *  - EmployeeResource
+ *  - OrganizationResource
+ *
+ */
+export type ResponseDocumentWithUnionTypes = JSONAPIDataDocument<EmployeeResource | OrganizationResource>;
+"
+`;
+
+exports[`primary data single shared resource: src/types.ts 1`] = `
+"import type { JSONAPIServerResource, JSONAPIDataDocument } from "@fresha/api-tools-core";
+
+
+/**
+ * Employee
+ *
+ */
+export type Employee = JSONAPIServerResource<'employees'>;
+
+/**
+ * This is a response resource
+ *
+ * Primary data resources:
+ *  - Employee
+ *
+ */
+export type SimpleResponseDocument = JSONAPIDataDocument<Employee>;
+"
+`;
+
+exports[`primary data skip resources that were generated before: src/types.ts 1`] = `
+"import type { JSONAPIDataDocument } from "@fresha/api-tools-core";
+
+
+/**
+ * This is a response resource
+ *
+ * Primary data resources:
+ *  - Employee
+ *
+ */
+export type SimpleResponseDocument = JSONAPIDataDocument<(Employee)[]>;
+"
+`;

--- a/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/IndexFile.test.ts.snap
+++ b/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/IndexFile.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`simple: src/index.ts 1`] = `
+"export * from './types';
+export * from './actions';
+export * from './fromatters';
+export { init, setAuthCookie, APIClientErrorKind, APIClientError } from './utils';
+"
+`;

--- a/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/RequestFormatterFunc.test.ts.snap
+++ b/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/RequestFormatterFunc.test.ts.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`simple: src/formatters.ts 1`] = `
+"import type { CreateEmployeeRequest } from "./types";
+
+export function formatCreateEmployeeRequest(params: {
+    fullName: string;
+    age: number;
+    gender?: 'male' | 'female';
+    manager: string;
+    subordinates?: string[];
+    mentor?: string | null;
+}): CreateEmployeeRequest {
+    return {
+        jsonapi: { version: '1.0' },
+        data: 
+        {
+            type: 'employees',
+            attributes: 
+            {
+                'full-name': params.fullName,
+                'age': params.age,
+                'gender': params.gender,
+            },
+            relationships: 
+            {
+                'manager': { data: { type: 'employees', id: manager } },
+                'subordinates': subordinates !== undefined ? { data: subordinates.map(id => ({ type: 'employees', id })) } : undefined,
+                'mentor': mentor !== undefined ? { data: mentor == null ? { type: 'employees', id: mentor } : null } : undefined,
+            }
+        }
+    }
+}
+"
+`;

--- a/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/ResourceType.test.ts.snap
+++ b/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/ResourceType.test.ts.snap
@@ -1,0 +1,56 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`attributes 1`] = `
+"import type { JSONAPIServerResource } from "@fresha/api-tools-core";
+
+
+/**
+ * HelloResource
+ *
+ * Attributes:
+ * -  name
+ * -  age
+ * -  gender
+ * -  active
+ *
+ */
+export type HelloResource = JSONAPIServerResource<'hello', {
+        'name': string;
+        'age'?: number | null;
+        'gender': 'male' | 'female' | 'other' | null;
+        'active'?: boolean;
+}>;
+"
+`;
+
+exports[`relationships: src/types.ts 1`] = `
+"import type { JSONAPIServerResource, JSONAPIResourceRelationship1, JSONAPIResourceRelationship0, JSONAPIResourceRelationshipN } from "@fresha/api-tools-core";
+
+
+/**
+ * Employee resource
+ *
+ * This resource contains information about a single employee.
+ * It also links to other related resources.
+ *
+ * Relationships:
+ * -  manager relationship to the 'employees' resource
+ * -  buddy relationship to the 'employees' resource
+ * -  subordinates relationship to the 'employees' resource
+ *
+ */
+export type HelloResource = JSONAPIServerResource<'employees', {}, {
+        'manager': JSONAPIResourceRelationship1<'employees'>;
+        'buddy': JSONAPIResourceRelationship0<'employees'>;
+        'subordinates': JSONAPIResourceRelationshipN<'employees'>;
+}>;
+"
+`;
+
+exports[`simple, client resource: src/types.ts 1`] = `
+"import type { JSONAPIClientResource } from "@fresha/api-tools-core";
+
+
+export type SimpleResource = JSONAPIClientResource;
+"
+`;

--- a/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/UtilsFile.test.ts.snap
+++ b/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/UtilsFile.test.ts.snap
@@ -1,0 +1,169 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`simple: src/utils.ts 1`] = `
+"import type { JSONValue } from '@fresha/api-tools-core';
+
+      export type APIClientErrorKind = 'config' | 'network' | 'logic';
+
+      export class APIClientError extends Error {
+        readonly kind: APIClientErrorKind;
+        readonly original?: unknown;
+
+        constructor(kind: APIClientErrorKind, message: string, original?: unknown) {
+          super(message);
+          this.kind = kind;
+          this.original = original;
+        }
+      }
+
+      export type FetchFunc = (url: string, init: RequestInit) => Promise<Response>;
+
+      export type SuccessCallbackFunc = (actionName: string, params: unknown, response: JSONValue) => void;
+
+      export type TransformResponsePayloadFunc = (actionName: string, payload: JSONValue) => JSONValue;
+
+      let rootUrl = '';
+      let fetcher: FetchFunc = global.fetch;
+      let successCallback: SuccessCallbackFunc | null = null;
+      let transformResponsePayload: TransformResponsePayloadFunc | null = null;
+
+      export type InitParams = {
+        rootUrl: string;
+        fetcher?: FetchFunc;
+        successCallback?: SuccessCallbackFunc;
+        transformResponsePayload?: TransformResponsePayloadFunc;
+      };
+
+      export const init = (params: InitParams): void => {
+        if (!params.rootUrl) {
+          throw new APIClientError('config', 'Expected rootUrl to be a non-empty string');
+        }
+        rootUrl = params.rootUrl;
+        if (params.fetcher) {
+          fetcher = params.fetcher;
+        }
+        if (params.successCallback) {
+          successCallback = params.successCallback;
+        }
+        if (params.transformResponsePayload) {
+          transformResponsePayload = params.transformResponsePayload;
+        }
+      };
+
+      export const makeUrl = (url: string): URL => {
+        if (!rootUrl) {
+          throw new APIClientError('config', 'Root URL is not set');
+        }
+        return new URL(url, rootUrl);
+      };
+
+      let authCookieName = '';
+      let authCookie = '';
+
+      export const setAuthCookie = (name: string, value: string): void => {
+        if (!name || !value) {
+          throw new APIClientError('config', 'Expected cookie name and value to be non-empty');
+        }
+        authCookieName = name;
+        authCookie = value;
+      };
+
+      export type ExtraCallParams = {
+        authCookieName?: string;
+        authCookie?: string;
+        xForwardedFor?: string;
+        xForwardedHost?: string;
+        xForwardedProto?: string;
+      };
+
+      export const authorizeRequest = (request: RequestInit, extraParams?: ExtraCallParams): void => {
+        if (typeof window !== "undefined") {
+          request.credentials = "include";
+        } else {
+          const finalAuthCookieName = extraParams?.authCookieName || authCookieName;
+          const finalAuthCookie = extraParams?.authCookie || authCookie;
+          if (!finalAuthCookieName || !finalAuthCookie) {
+            throw new APIClientError('config', 'Authorization cookie is not set');
+          }
+          request.headers = {
+            ...request.headers,
+            cookie: \`\${finalAuthCookieName}=\${finalAuthCookie};\`,
+          };
+        }
+      };
+
+      export const applyExtraParams = (request: RequestInit, extraParams?: ExtraCallParams): void => {
+        if (extraParams?.xForwardedFor || extraParams?.xForwardedHost || extraParams?.xForwardedProto) {
+          const headers = {
+            ...request.headers
+          } as Record<string, string>;
+          if (extraParams.xForwardedFor) {
+            headers['X-Forwarded-For'] = extraParams.xForwardedFor;
+          }
+          if (extraParams.xForwardedHost) {
+            headers['X-Forwarded-Host'] = extraParams.xForwardedHost;
+          }
+          if (extraParams.xForwardedProto) {
+            headers['X-Forwarded-Proto'] = extraParams.xForwardedProto;
+          }
+          request.headers = headers;
+        }
+      };
+
+      export const addQueryParam = (url: URL, name: string, param: unknown): void => {
+        if (param !== undefined) {
+          url.searchParams.set(name, String(param));
+        }
+      };
+
+      export const COMMON_HEADERS: Record<string, string> = {
+        "X-Requested-With": "XMLHttpRequest",
+        Accept: "application/vnd.api+json",
+        "Content-Type": "application/vnd.api+json",
+      };
+
+      export const callApi = async (url: URL, request: RequestInit): Promise<Response> => {
+        if (!fetcher) {
+          throw new APIClientError('config', 'Fetch function is not set');
+        }
+
+        let result: Response;
+
+        try {
+          result = await fetcher(url.toString(), request);
+        } catch (err) {
+          throw new APIClientError('network', \`Error calling \${url.toString()}\`, err);
+        }
+
+        if (!result.ok) {
+          throw new APIClientError('logic', 'Request failed', result);
+        }
+
+        return result;
+      };
+
+      export const callJsonApi = async (url: URL, request: RequestInit): Promise<JSONValue> => {
+        const result = await callApi(url, request);
+
+        let json: unknown;
+        try {
+          json = await result.json();
+        } catch (err) {
+          throw new APIClientError('logic', \`Cannot parse JSON response for \${url.toString()}\`, err);
+        }
+
+        return json as JSONValue;
+      };
+
+      export const dispatchSuccess = (actionName: string, params: unknown, response: JSONValue): void => {
+        if (successCallback) {
+          successCallback(actionName, params, response);
+        }
+      };
+
+      export const transformResponse = <TResult>(actionName: string, payload: JSONValue): TResult => {
+        const result = transformResponsePayload ? transformResponsePayload(actionName, payload) : payload;
+        return result as unknown as TResult;
+      };
+    "
+`;

--- a/packages/openapi-codegen-client-fetch/src/parts/utils.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/utils.test.ts
@@ -1,11 +1,15 @@
-import { OpenAPIFactory } from '@fresha/openapi-model/build/3.0.3';
+import { OpenAPIFactory, OpenAPIModel } from '@fresha/openapi-model/build/3.0.3';
 
 import { schemaToType } from './utils';
 
 describe('schemaToType', () => {
-  test('simple cases', () => {
-    const openapi = OpenAPIFactory.create();
+  let openapi: OpenAPIModel;
 
+  beforeEach(() => {
+    openapi = OpenAPIFactory.create();
+  });
+
+  test('simple cases', () => {
     expect(schemaToType(openapi.components.setSchema('Null'))).toMatch(/^Unknown\d+/);
     expect(schemaToType(openapi.components.setSchema('Boolean', 'boolean'))).toBe('boolean');
     expect(schemaToType(openapi.components.setSchema('Integer', 'integer'))).toBe('number');
@@ -26,8 +30,6 @@ describe('schemaToType', () => {
   });
 
   test('numeric enum', () => {
-    const openapi = OpenAPIFactory.create();
-
     const enumInteger = openapi.components.setSchema('EnumInt', 'integer');
     enumInteger.addAllowedValues(1, 3, 2, 8);
 
@@ -39,8 +41,6 @@ describe('schemaToType', () => {
   });
 
   test('string enum', () => {
-    const openapi = OpenAPIFactory.create();
-
     const enumString = openapi.components.setSchema('EnumString', 'string');
     enumString.addAllowedValues('val1', 'val2');
 


### PR DESCRIPTION
## Motivation and Context

In short, this PR changes the way we write tests for `@fresha/openapi-codegen-client-fetch`. The biggest change is replacement of `.toHaveFormattedTypeScriptTest` with Jest snapshots. Besides that, I:

- deduplicated test preparation code by moving creation of often used objects to `beforeEach` blocks.
- added a couple of missing tests
- enabled a test coverage threshold for this package (total of 80% of functions/branches/statements).

These changes reduce the amount of code needed to write a codegen test, thus simplifying their creation.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
