### PR TITLE
Correctly check for server count in an OpenAPI schema

### DIFF
--- a/packages/openapi-lint/src/rules/oas3/serverList.ts
+++ b/packages/openapi-lint/src/rules/oas3/serverList.ts
@@ -10,7 +10,7 @@ export const autoFixable = false;
 
 export const run: RuleFunc = (openapi: OpenAPIModel, result: LinterResult): boolean => {
   if (!isDisabled(openapi, id)) {
-    if (!openapi.servers.length) {
+    if (!openapi.serverCount) {
       result.addError(`Server list must not be empty`);
     }
   }


### PR DESCRIPTION
## Motivation and Context

This PR fixes a bug in `fresha-openapi-lint`, which resulted in an error about empty server list even when it was not.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.