### PR TITLE
schemaToType supports object schemas

### DIFF
--- a/packages/openapi-codegen-client-fetch/src/parts/utils.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/utils.test.ts
@@ -2,6 +2,13 @@ import { OpenAPIFactory, OpenAPIModel } from '@fresha/openapi-model/build/3.0.3'
 
 import { schemaToType } from './utils';
 
+const normalize = (raw: string): string => {
+  return raw
+    .split(/\s+/)
+    .map(line => line.trim())
+    .join(' ');
+};
+
 describe('schemaToType', () => {
   let openapi: OpenAPIModel;
 
@@ -49,5 +56,77 @@ describe('schemaToType', () => {
     enumString.nullable = true;
 
     expect(schemaToType(enumString)).toBe("'val1' | 'val2' | null");
+  });
+
+  test('array schema', () => {
+    const arraySchema = openapi.components.setSchema('Array', 'array');
+    arraySchema.setItems('string');
+
+    expect(schemaToType(arraySchema)).toBe('string[]');
+
+    arraySchema.nullable = true;
+
+    expect(schemaToType(arraySchema)).toBe('string[] | null');
+  });
+
+  test('object schema', () => {
+    const objectSchema = openapi.components.setSchema('Object', 'object');
+    objectSchema.setProperties({
+      prop1: 'string',
+      prop2: 'integer',
+      'prop3-x': {
+        type: 'array',
+        items: 'boolean',
+        nullable: true,
+        required: true,
+      },
+    });
+
+    expect(schemaToType(objectSchema)).toBe(
+      "{ prop1?: string; prop2?: number; 'prop3-x': boolean[] | null }",
+    );
+  });
+
+  test('deeply nested schema', () => {
+    const complexSchema = openapi.components.setSchema('ComplexSchema', 'object');
+    complexSchema.setProperties({
+      name: { type: 'string', required: true },
+      age: { type: 'integer', required: true, nullable: true },
+      address: {
+        type: 'object',
+        properties: {
+          street: { type: 'string', required: true },
+          city: { type: 'string', required: true },
+          country: { type: 'string', required: true },
+        },
+        required: true,
+      },
+      phones: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            number: { type: 'string', required: true },
+            type: { type: 'string', required: true, enum: ['home', 'work', 'mobile'] },
+          },
+        },
+      },
+    });
+
+    expect(schemaToType(complexSchema)).toBe(
+      normalize(`{
+      name: string;
+      age: number | null;
+      address: {
+        street: string;
+        city: string;
+        country: string
+      };
+      phones?: {
+        number: string;
+        type: 'home' | 'work' | 'mobile'
+      }[]
+    }`),
+    );
   });
 });


### PR DESCRIPTION
## Motivation and Context

Currently, object types are not supported for parameters and resource attributes. This PR fixes this issue.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

`schemaToType` builds a type definition for `object` schemas.