### PR TITLE
Do not import addQueryParam unnecessarily

### DIFF
--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
@@ -29,6 +29,7 @@ type HeaderName = string;
 export class ActionFunc {
   readonly context: ActionContext;
   readonly name: string;
+  protected hasQueryParams: boolean;
   protected readonly parameterVars: Map<VariableName, ParameterInfo>;
   protected readonly pathParametesVars: Map<string, VariableName>;
   protected readonly headerToSet: Map<HeaderName, VariableName>;
@@ -41,6 +42,7 @@ export class ActionFunc {
   constructor(context: ActionContext) {
     this.context = context;
     this.name = getOperationIdOrThrow(this.context.operation);
+    this.hasQueryParams = false;
     this.parameterVars = new Map<string, ParameterInfo>();
     this.pathParametesVars = new Map<string, string>();
     this.headerToSet = new Map<HeaderName, VariableName>();
@@ -70,6 +72,9 @@ export class ActionFunc {
 
       if (parameter.in === 'path') {
         this.pathParametesVars.set(parameter.name, paramName);
+      }
+      if (parameter.in === 'query') {
+        this.hasQueryParams = true;
       }
       if (parameter.in === 'header') {
         this.headerToSet.set(parameter.name, paramName);
@@ -142,7 +147,7 @@ export class ActionFunc {
       './utils': ['COMMON_HEADERS', 'makeUrl', this.parsesResponse ? 'callJsonApi' : 'callApi'],
     });
 
-    if (this.parameterVars.size) {
+    if (this.hasQueryParams) {
       addImportDeclaration(this.context.sourceFile, './utils', 'addQueryParam');
     }
 

--- a/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/ActionFunc.test.ts.snap
+++ b/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/ActionFunc.test.ts.snap
@@ -217,7 +217,7 @@ export type ReadEmployeeListResponse = JSONAPIDataDocument<(EmployeeResource)[]>
 `;
 
 exports[`test optional header parameters: src/index.ts 1`] = `
-"import { COMMON_HEADERS, makeUrl, callJsonApi, addQueryParam, authorizeRequest, ExtraCallParams, applyExtraParams } from "./utils";
+"import { COMMON_HEADERS, makeUrl, callJsonApi, authorizeRequest, ExtraCallParams, applyExtraParams } from "./utils";
 
 /**
  * operation with an optional header


### PR DESCRIPTION
## Motivation and Context

Currently, `client-fetch` codegen produces code with unused import. `utils/addQueryParam` is imported by `actions.ts` if an action has any parameter. It should be imported only if the action has a query parameter. This PR fixes that bug.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
