### PR TITLE
Improve request formatters

### DIFF
--- a/packages/api-tools-core/src/types.ts
+++ b/packages/api-tools-core/src/types.ts
@@ -386,7 +386,7 @@ export interface JSONAPITopLevelLinks {
  * @see https://jsonapi.org/format/#document-top-level
  */
 interface JSONAPIDocumentBase {
-  jsonapi: JSONAPIImplementationInfo;
+  jsonapi?: JSONAPIImplementationInfo;
   links?: JSONAPITopLevelLinks;
   meta?: JSONAPIMeta;
 }

--- a/packages/api-tools-core/src/utils.test.ts
+++ b/packages/api-tools-core/src/utils.test.ts
@@ -16,6 +16,7 @@ describe('kebabCase', () => {
 describe('camelCase', () => {
   it('should convert strings to camel case', () => {
     expect(camelCase('test-ident')).toBe('testIdent');
+    expect(camelCase('Test-Ident')).toBe('testIdent');
     expect(camelCase('test-123-ident')).toBe('test123Ident');
     expect(camelCase('test_123__iDent')).toBe('test123IDent');
     expect(camelCase('-almostCamel_case')).toBe('almostCamelCase');

--- a/packages/api-tools-core/src/utils.ts
+++ b/packages/api-tools-core/src/utils.ts
@@ -33,7 +33,7 @@ export const camelCase: KeyTransformFunc = str => {
   return str
     .split(RE_WORD_SEPARATOR)
     .filter(Boolean)
-    .map((s, index) => (index > 0 ? s.slice(0, 1).toUpperCase() + s.slice(1) : s))
+    .map((s, index) => s.slice(0, 1)[index > 0 ? 'toUpperCase' : 'toLowerCase']() + s.slice(1))
     .join('');
 };
 

--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
@@ -318,22 +318,7 @@ export class ActionFunc {
       }
 
       writer.newLine();
-      writer.writeLine('@param [extraParams] additional parameters');
-      writer.writeLine(
-        '@param [extraParams.authCookieName] name of the authorization cookie for this request',
-      );
-      writer.writeLine(
-        '@param [extraParams.authCookie] value of the authorization cookie for this request',
-      );
-      writer.writeLine(
-        '@param [extraParams.xForwardedFor] sends X-Forwarded-For header with specified value',
-      );
-      writer.writeLine(
-        '@param [extraParams.xForwardedHost] sends X-Forwarded-Host header with specified value',
-      );
-      writer.write(
-        '@param [extraParams.xForwardedProto] sends X-Forwarded-Proto header with specified value',
-      );
+      writer.writeLine('@see {@link ExtraCallParams}');
     });
   }
 

--- a/packages/openapi-codegen-client-fetch/src/parts/IndexFile.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/IndexFile.ts
@@ -17,7 +17,7 @@ export class IndexFile {
     this.sourceFile.addStatements(`export * from './types';`);
     this.sourceFile.addStatements(`export * from './actions';`);
     if (this.context.withFormatters) {
-      this.sourceFile.addStatements(`export * from './fromatters';`);
+      this.sourceFile.addStatements(`export * from './formatters';`);
     }
     this.sourceFile.addStatements(
       `export { init, setAuthCookie, APIClientErrorKind, APIClientError } from './utils';`,

--- a/packages/openapi-codegen-client-fetch/src/parts/UtilsFile.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/UtilsFile.ts
@@ -77,11 +77,20 @@ export class UtilsFile {
         authCookie = value;
       };
 
+      /**
+       * These parameters allow to change the default behavior of an action for each
+       * individual call.
+       */
       export type ExtraCallParams = {
+        /** name of the authorization cookie for this request */
         authCookieName?: string;
+        /** value of the authorization cookie for this request */
         authCookie?: string;
+        /** sends X-Forwarded-For header with specified value */
         xForwardedFor?: string;
+        /** sends X-Forwarded-Host header with specified value */
         xForwardedHost?: string;
+        /** sends X-Forwarded-Proto header with specified value */
         xForwardedProto?: string;
       };
 

--- a/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/ActionFunc.test.ts.snap
+++ b/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/ActionFunc.test.ts.snap
@@ -225,7 +225,7 @@ exports[`test optional header parameters: src/index.ts 1`] = `
  * This operation has an optional header parameter
  *
  * @param params call parameters
- * @param [params.OptionalHeaderParameter] optional header parameter
+ * @param [params.optionalHeaderParameter] optional header parameter
  *
  * @param [extraParams] additional parameters
  * @param [extraParams.authCookieName] name of the authorization cookie for this request
@@ -235,13 +235,13 @@ exports[`test optional header parameters: src/index.ts 1`] = `
  * @param [extraParams.xForwardedProto] sends X-Forwarded-Proto header with specified value
  */
 export async function test(params: {
-    OptionalHeaderParameter?: string;
+    optionalHeaderParameter?: string;
 }, extraParams?: ExtraCallParams): Promise<void> {
     const url = makeUrl(\`/test-endpoint\`);
 
     const headerParameters: Record<string, string> = {};
 
-    if (params.OptionalHeaderParameter) headerParameters['Optional-Header-Parameter'] = params.OptionalHeaderParameter
+    if (params.optionalHeaderParameter) headerParameters['Optional-Header-Parameter'] = params.optionalHeaderParameter
 
     const request = {
         headers: {...COMMON_HEADERS, ...headerParameters},

--- a/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/ActionFunc.test.ts.snap
+++ b/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/ActionFunc.test.ts.snap
@@ -5,12 +5,8 @@ exports[`action returns raw response: src/index.ts 1`] = `
 import type { ReadEmployeeListResponse } from "./types";
 
 /**
- * @param [extraParams] additional parameters
- * @param [extraParams.authCookieName] name of the authorization cookie for this request
- * @param [extraParams.authCookie] value of the authorization cookie for this request
- * @param [extraParams.xForwardedFor] sends X-Forwarded-For header with specified value
- * @param [extraParams.xForwardedHost] sends X-Forwarded-Host header with specified value
- * @param [extraParams.xForwardedProto] sends X-Forwarded-Proto header with specified value
+ * @see {@link ExtraCallParams}
+ *
  */
 export async function readEmployeeList(extraParams?: ExtraCallParams): Promise<Response> {
     const url = makeUrl(\`/employees\`);
@@ -66,12 +62,8 @@ import type { ReadEmployeeListResponse } from "./types";
  * @param params.offset Index of the first employee to retrieve
  * @param [params.limit] Maximal number of employee resources to retrieve
  *
- * @param [extraParams] additional parameters
- * @param [extraParams.authCookieName] name of the authorization cookie for this request
- * @param [extraParams.authCookie] value of the authorization cookie for this request
- * @param [extraParams.xForwardedFor] sends X-Forwarded-For header with specified value
- * @param [extraParams.xForwardedHost] sends X-Forwarded-Host header with specified value
- * @param [extraParams.xForwardedProto] sends X-Forwarded-Proto header with specified value
+ * @see {@link ExtraCallParams}
+ *
  */
 export async function readEmployeeList(params: {
     offset: number;
@@ -147,12 +139,8 @@ import type { ReadEmployeeListResponse } from "./types";
 import { camelCaseDeep } from "@fresha/api-tools-core";
 
 /**
- * @param [extraParams] additional parameters
- * @param [extraParams.authCookieName] name of the authorization cookie for this request
- * @param [extraParams.authCookie] value of the authorization cookie for this request
- * @param [extraParams.xForwardedFor] sends X-Forwarded-For header with specified value
- * @param [extraParams.xForwardedHost] sends X-Forwarded-Host header with specified value
- * @param [extraParams.xForwardedProto] sends X-Forwarded-Proto header with specified value
+ * @see {@link ExtraCallParams}
+ *
  */
 export async function readEmployeeList(extraParams?: ExtraCallParams): Promise<ReadEmployeeListResponse> {
     const url = makeUrl(\`/employees\`);
@@ -227,12 +215,8 @@ exports[`test optional header parameters: src/index.ts 1`] = `
  * @param params call parameters
  * @param [params.optionalHeaderParameter] optional header parameter
  *
- * @param [extraParams] additional parameters
- * @param [extraParams.authCookieName] name of the authorization cookie for this request
- * @param [extraParams.authCookie] value of the authorization cookie for this request
- * @param [extraParams.xForwardedFor] sends X-Forwarded-For header with specified value
- * @param [extraParams.xForwardedHost] sends X-Forwarded-Host header with specified value
- * @param [extraParams.xForwardedProto] sends X-Forwarded-Proto header with specified value
+ * @see {@link ExtraCallParams}
+ *
  */
 export async function test(params: {
     optionalHeaderParameter?: string;

--- a/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/IndexFile.test.ts.snap
+++ b/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/IndexFile.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`simple: src/index.ts 1`] = `
 "export * from './types';
 export * from './actions';
-export * from './fromatters';
+export * from './formatters';
 export { init, setAuthCookie, APIClientErrorKind, APIClientError } from './utils';
 "
 `;

--- a/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/RequestFormatterFunc.test.ts.snap
+++ b/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/RequestFormatterFunc.test.ts.snap
@@ -1,14 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`simple: src/formatters.ts 1`] = `
+exports[`client naming = camel: src/formatters.ts 1`] = `
 "import type { CreateEmployeeRequest } from "./types";
 
 export function formatCreateEmployeeRequest(params: {
     fullName: string;
     age: number;
     gender?: 'male' | 'female';
-    manager: string;
-    subordinates?: string[];
+    isActive?: boolean;
+    lineManager: string;
+    subordinateList?: string[];
     mentor?: string | null;
 }): CreateEmployeeRequest {
     return {
@@ -18,15 +19,160 @@ export function formatCreateEmployeeRequest(params: {
             type: 'employees',
             attributes: 
             {
-                'full-name': params.fullName,
-                'age': params.age,
-                'gender': params.gender,
+                fullName: params.fullName,
+                age: params.age,
+                gender: params.gender,
+                isActive: params.isActive,
             },
             relationships: 
             {
-                'manager': { data: { type: 'employees', id: manager } },
-                'subordinates': subordinates !== undefined ? { data: subordinates.map(id => ({ type: 'employees', id })) } : undefined,
-                'mentor': mentor !== undefined ? { data: mentor == null ? { type: 'employees', id: mentor } : null } : undefined,
+                lineManager: { data: { type: 'employees', id: params.lineManager } },
+                subordinateList: params.subordinateList !== undefined ? { data: params.subordinateList.map(id => ({ type: 'employees', id })) } : undefined,
+                mentor: params.mentor !== undefined ? { data: params.mentor == null ? { type: 'employees', id: params.mentor } : null } : undefined,
+            }
+        }
+    }
+}
+"
+`;
+
+exports[`client naming = kebab: src/formatters.ts 1`] = `
+"import type { CreateEmployeeRequest } from "./types";
+
+export function formatCreateEmployeeRequest(params: {
+    'full-name': string;
+    age: number;
+    gender?: 'male' | 'female';
+    'is-active'?: boolean;
+    'line-manager': string;
+    'subordinate-list'?: string[];
+    mentor?: string | null;
+}): CreateEmployeeRequest {
+    return {
+        jsonapi: { version: '1.0' },
+        data: 
+        {
+            type: 'employees',
+            attributes: 
+            {
+                'full-name': params['full-name'],
+                age: params.age,
+                gender: params.gender,
+                'is-active': params['is-active'],
+            },
+            relationships: 
+            {
+                'line-manager': { data: { type: 'employees', id: params['line-manager'] } },
+                'subordinate-list': params['subordinate-list'] !== undefined ? { data: params['subordinate-list'].map(id => ({ type: 'employees', id })) } : undefined,
+                mentor: params.mentor !== undefined ? { data: params.mentor == null ? { type: 'employees', id: params.mentor } : null } : undefined,
+            }
+        }
+    }
+}
+"
+`;
+
+exports[`client naming = null: src/formatters.ts 1`] = `
+"import type { CreateEmployeeRequest } from "./types";
+
+export function formatCreateEmployeeRequest(params: {
+    'full-name': string;
+    age: number;
+    gender?: 'male' | 'female';
+    is_active?: boolean;
+    'Line-manager': string;
+    'subordinate-list'?: string[];
+    Mentor?: string | null;
+}): CreateEmployeeRequest {
+    return {
+        jsonapi: { version: '1.0' },
+        data: 
+        {
+            type: 'employees',
+            attributes: 
+            {
+                'full-name': params['full-name'],
+                age: params.age,
+                gender: params.gender,
+                is_active: params.is_active,
+            },
+            relationships: 
+            {
+                'Line-manager': { data: { type: 'employees', id: params['Line-manager'] } },
+                'subordinate-list': params['subordinate-list'] !== undefined ? { data: params['subordinate-list'].map(id => ({ type: 'employees', id })) } : undefined,
+                Mentor: params.Mentor !== undefined ? { data: params.Mentor == null ? { type: 'employees', id: params.Mentor } : null } : undefined,
+            }
+        }
+    }
+}
+"
+`;
+
+exports[`client naming = snake: src/formatters.ts 1`] = `
+"import type { CreateEmployeeRequest } from "./types";
+
+export function formatCreateEmployeeRequest(params: {
+    full_name: string;
+    age: number;
+    gender?: 'male' | 'female';
+    is_active?: boolean;
+    line_manager: string;
+    subordinate_list?: string[];
+    mentor?: string | null;
+}): CreateEmployeeRequest {
+    return {
+        jsonapi: { version: '1.0' },
+        data: 
+        {
+            type: 'employees',
+            attributes: 
+            {
+                full_name: params.full_name,
+                age: params.age,
+                gender: params.gender,
+                is_active: params.is_active,
+            },
+            relationships: 
+            {
+                line_manager: { data: { type: 'employees', id: params.line_manager } },
+                subordinate_list: params.subordinate_list !== undefined ? { data: params.subordinate_list.map(id => ({ type: 'employees', id })) } : undefined,
+                mentor: params.mentor !== undefined ? { data: params.mentor == null ? { type: 'employees', id: params.mentor } : null } : undefined,
+            }
+        }
+    }
+}
+"
+`;
+
+exports[`client naming = title: src/formatters.ts 1`] = `
+"import type { CreateEmployeeRequest } from "./types";
+
+export function formatCreateEmployeeRequest(params: {
+    FullName: string;
+    Age: number;
+    Gender?: 'male' | 'female';
+    IsActive?: boolean;
+    LineManager: string;
+    SubordinateList?: string[];
+    Mentor?: string | null;
+}): CreateEmployeeRequest {
+    return {
+        jsonapi: { version: '1.0' },
+        data: 
+        {
+            type: 'employees',
+            attributes: 
+            {
+                FullName: params.FullName,
+                Age: params.Age,
+                Gender: params.Gender,
+                IsActive: params.IsActive,
+            },
+            relationships: 
+            {
+                LineManager: { data: { type: 'employees', id: params.LineManager } },
+                SubordinateList: params.SubordinateList !== undefined ? { data: params.SubordinateList.map(id => ({ type: 'employees', id })) } : undefined,
+                Mentor: params.Mentor !== undefined ? { data: params.Mentor == null ? { type: 'employees', id: params.Mentor } : null } : undefined,
             }
         }
     }

--- a/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/UtilsFile.test.ts.snap
+++ b/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/UtilsFile.test.ts.snap
@@ -61,11 +61,20 @@ exports[`simple: src/utils.ts 1`] = `
         authCookie = value;
       };
 
+      /**
+       * These parameters allow to change the default behavior of an action for each
+       * individual call.
+       */
       export type ExtraCallParams = {
+        /** name of the authorization cookie for this request */
         authCookieName?: string;
+        /** value of the authorization cookie for this request */
         authCookie?: string;
+        /** sends X-Forwarded-For header with specified value */
         xForwardedFor?: string;
+        /** sends X-Forwarded-Host header with specified value */
         xForwardedHost?: string;
+        /** sends X-Forwarded-Proto header with specified value */
         xForwardedProto?: string;
       };
 

--- a/packages/openapi-codegen-client-fetch/src/parts/utils.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/utils.ts
@@ -32,6 +32,12 @@ export const propertyName = (name: string, convention: Nullable<NamingConvention
   return result.match(/^[_A-Za-z][_0-9A-Za-z]*$/) ? result : `'${result}'`;
 };
 
+export const objectPropertyName = (objectName: string, propName: string): string => {
+  return propName.match(/^[_A-Za-z][_0-9A-Za-z]*$/)
+    ? `${objectName}.${propName}`
+    : `${objectName}[${propName}]`;
+};
+
 let i = 0;
 
 export const schemaToType = (


### PR DESCRIPTION
## Motivation and Context

This PR fixes the following bugs in TS client library generator:

- `camelCase()` now properly makes the first letter of the first word lowercase. I.e., `Team-name` would be transformed to teamName`, not to `TeamName` as currently.
- `jsonapi` field in definitions of JSON:API document types is now optional, as per spec
- fixed a typo in the name of the formatters module in client libraries. `fromatters` -> `formatters`
- request formatters in now abide to naming conventions specified

Also, to reduce the amount of duplicated JS documentation, `ExtraCallParams` is now documented once, in-place, and linked from action functions.

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
