### PR TITLE
Fix parameter interpolations in generated code

### DIFF
--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.test.ts
@@ -16,7 +16,10 @@ import { ActionFunc } from './ActionFunc';
 import type { NamedType } from './NamedType';
 
 const createAction = (operation: OperationModel, filePath = 'src/index.ts'): ActionFunc => {
-  const context = createActionTestContext(operation, filePath);
+  const context: ActionContext = {
+    ...createActionTestContext(operation, filePath),
+    clientNaming: 'camel',
+  };
   return new ActionFunc(context);
 };
 

--- a/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ActionFunc.ts
@@ -1,4 +1,4 @@
-import { camelCase, Nullable, titleCase } from '@fresha/api-tools-core';
+import { Nullable, titleCase } from '@fresha/api-tools-core';
 import { addFunction, addImportDeclaration, addImportDeclarations } from '@fresha/code-morph-ts';
 import {
   assert,
@@ -11,7 +11,7 @@ import {
 import { CodeBlockWriter, SyntaxKind } from 'ts-morph';
 
 import { DocumentType } from './DocumentType';
-import { schemaToType } from './utils';
+import { propertyName, schemaToType } from './utils';
 
 import type { NamedType } from './NamedType';
 import type { ActionContext } from '../context';
@@ -62,7 +62,7 @@ export class ActionFunc {
 
   protected collectParameters(): void {
     for (const parameter of getOperationParameters(this.context.operation)) {
-      const paramName = camelCase(parameter.name);
+      const paramName = propertyName(parameter.name, this.context.clientNaming);
       const typeString = schemaToType(parameter.schema, this.context.clientNaming);
 
       this.parameterVars.set(paramName, {
@@ -357,7 +357,7 @@ export class ActionFunc {
 
   protected generateCallUrl(): string {
     const { pathUrl } = this.context.operation.parent;
-    const str = pathUrl.replace(/\{\w+\}/g, match => {
+    const str = pathUrl.replace(/\{[^}/]+\}/g, match => {
       const argName = this.pathParametesVars.get(match.slice(1, -1));
       assert(
         argName,

--- a/packages/openapi-codegen-client-fetch/src/parts/RequestFormatterFunc.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/RequestFormatterFunc.ts
@@ -96,7 +96,6 @@ export class RequestFormatterFunc {
 
     if (primaryResource.attributesSchema) {
       for (const { name, schema } of primaryResource.attributesSchema.getPropertiesDeep()) {
-        this.context.console.log('param', name);
         paramsType.addProperty({
           name: propertyName(name, this.context.clientNaming),
           type: schemaToType(schema, this.context.clientNaming),
@@ -122,7 +121,6 @@ export class RequestFormatterFunc {
             assert.fail(`Unsupported cardinality ${String(relDef.cardinality)}`);
         }
 
-        this.context.console.log('param', relName);
         paramsType.addProperty({
           name: propertyName(relName, this.context.clientNaming),
           type: paramType,
@@ -141,7 +139,6 @@ export class RequestFormatterFunc {
       // properties in this schema and its allOf subschemas
       if (primaryResource.attributesSchema) {
         for (const { name } of primaryResource.attributesSchema.getPropertiesDeep()) {
-          this.context.console.log('attribute', name);
           const propName = propertyName(name, this.context.clientNaming);
           writer.writeLine(`${propName}: ${objectPropertyName('params', propName)},`);
         }
@@ -157,7 +154,6 @@ export class RequestFormatterFunc {
     writer.inlineBlock(() => {
       if (primaryResource.relationships.size) {
         for (const [relName, relDef] of primaryResource.relationships) {
-          this.context.console.log('relationship', relName);
           const paramName = propertyName(relName, this.context.clientNaming);
           const objPropName = objectPropertyName('params', paramName);
 

--- a/packages/openapi-codegen-client-fetch/src/parts/ResourceType.ts
+++ b/packages/openapi-codegen-client-fetch/src/parts/ResourceType.ts
@@ -66,7 +66,6 @@ export class ResourceType extends NamedType {
       this.context.logger.warn(
         `Cannot find type field in schema ${this.context.operation.parent.pathUrl}`,
       );
-      // this.context.console.log(this.schema);
       return;
     }
 

--- a/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/ActionFunc.test.ts.snap
+++ b/packages/openapi-codegen-client-fetch/src/parts/__snapshots__/ActionFunc.test.ts.snap
@@ -50,6 +50,7 @@ export type ReadEmployeeListResponse = JSONAPIDataDocument<(EmployeeResource)[]>
 exports[`simple test: src/index.ts 1`] = `
 "import { COMMON_HEADERS, makeUrl, callJsonApi, addQueryParam, authorizeRequest, ExtraCallParams, applyExtraParams, dispatchSuccess } from "./utils";
 import type { ReadEmployeeListResponse } from "./types";
+import { camelCaseDeep } from "@fresha/api-tools-core";
 
 /**
  * Reads employee list
@@ -83,7 +84,9 @@ export async function readEmployeeList(params: {
 
     applyExtraParams(request, extraParams)
 
-    const response = await callJsonApi(url, request);
+    let response = await callJsonApi(url, request);
+
+    response = camelCaseDeep(response);
 
     dispatchSuccess('readEmployeeList', params, response)
 


### PR DESCRIPTION
## Motivation and Context

This PR fixes a bug, related to incorrectly interpolating values of path parameters in the code generated by `client-fetch` generator.

Before, if the client naming conventions were different from that of API, parameters did not interpolate.

```ts
const url = makeUrl(`/some/{obj-id}`); // incorrect, action parameter is named objId
```

new behaviour is the following:

```ts
const url = makeUrl(`/some/${params.objId}`); // correct
```

## Type of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

N/A.
